### PR TITLE
Optimize conversion of primitive arrays to string

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,21 @@
             <artifactId>jaxb-api</artifactId>
             <version>2.3.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.21</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.21</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <distributionManagement>

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseArrayUtil.java
@@ -2,6 +2,7 @@ package ru.yandex.clickhouse.util;
 
 import ru.yandex.clickhouse.ClickHouseUtil;
 
+import java.util.Arrays;
 import java.util.Collection;
 
 /**
@@ -34,54 +35,22 @@ public class ClickHouseArrayUtil {
 
     private static String primitiveArrayToString(Object array) {
         if (array instanceof int[]) {
-            return toString((int[]) array);
+            return Arrays.toString((int[])array);
         } else if (array instanceof long[]) {
-            return toString((long[]) array);
+            return Arrays.toString((long[]) array);
         } else if (array instanceof float[]) {
-            return toString((float[]) array);
+            return Arrays.toString((float[])array);
         } else if (array instanceof double[]) {
-            return toString((double[]) array);
+            return Arrays.toString((double[]) array);
         } else if (array instanceof char[]) {
             return toString((char[]) array);
         } else if (array instanceof byte[]) {
             return toString((byte[]) array);
         } else if (array instanceof short[]) {
-            return toString((short[]) array);
+            return Arrays.toString((short[]) array);
         } else {
             throw new IllegalArgumentException("Wrong primitive type: " + array.getClass().getComponentType());
         }
-    }
-
-    public static String toString(int[] values) {
-        ArrayBuilder builder = new ArrayBuilder(false, true);
-        for (int value : values) {
-            builder.append(value);
-        }
-        return builder.build();
-    }
-
-    public static String toString(long[] values) {
-        ArrayBuilder builder = new ArrayBuilder(false, true);
-        for (long value : values) {
-            builder.append(value);
-        }
-        return builder.build();
-    }
-
-    public static String toString(float[] values) {
-        ArrayBuilder builder = new ArrayBuilder(false, true);
-        for (float value : values) {
-            builder.append(value);
-        }
-        return builder.build();
-    }
-
-    public static String toString(double[] values) {
-        ArrayBuilder builder = new ArrayBuilder(false, true);
-        for (double value : values) {
-            builder.append(value);
-        }
-        return builder.build();
     }
 
     public static String toString(byte[] values) {
@@ -91,15 +60,6 @@ public class ClickHouseArrayUtil {
         }
         return builder.build();
     }
-
-    public static String toString(short[] values) {
-        ArrayBuilder builder = new ArrayBuilder(false, true);
-        for (short value : values) {
-            builder.append(value);
-        }
-        return builder.build();
-    }
-
 
     public static String toString(char[] values) {
         ArrayBuilder builder = new ArrayBuilder(true, true);

--- a/src/test/java/ru/yandex/clickhouse/benchmark/BindTest.java
+++ b/src/test/java/ru/yandex/clickhouse/benchmark/BindTest.java
@@ -1,0 +1,86 @@
+package ru.yandex.clickhouse.benchmark;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import ru.yandex.clickhouse.ClickHouseArray;
+import ru.yandex.clickhouse.ClickHouseDataSource;
+
+import java.sql.PreparedStatement;
+import java.sql.Timestamp;
+import java.sql.Types;
+
+/**
+ * Created by krash on 21.08.19.
+ */
+@Warmup(iterations = 3, time = 3)
+@Fork(value = 3, jvmArgsAppend = "-XX:+UseG1GC")
+@Measurement(time = 3, iterations = 5)
+public class BindTest {
+
+    public static void main(String[] args) throws RunnerException {
+
+        Options opt = new OptionsBuilder()
+                .include(BindTest.class.getSimpleName())
+                .build();
+
+        new Runner(opt).run();
+    }
+
+    @Benchmark
+    public void benchBindIntArray(StatementState statementState) throws Exception {
+        PreparedStatement stmt = statementState.statement;
+        stmt.setArray(1, statementState.intArray);
+    }
+
+    @Benchmark
+    public void benchBindLongArray(StatementState statementState) throws Exception {
+        PreparedStatement stmt = statementState.statement;
+        stmt.setArray(1, statementState.longArray);
+    }
+
+    @Benchmark
+    public void benchBindShortArray(StatementState statementState) throws Exception {
+        PreparedStatement stmt = statementState.statement;
+        stmt.setArray(1, statementState.shortArray);
+    }
+
+    @Benchmark
+    public void benchBindFloatArray(StatementState statementState) throws Exception {
+        PreparedStatement stmt = statementState.statement;
+        stmt.setArray(1, statementState.floatArray);
+    }
+
+    @Benchmark
+    public void benchBindDoubleArray(StatementState statementState) throws Exception {
+        PreparedStatement stmt = statementState.statement;
+        stmt.setArray(1, statementState.doubleArray);
+    }
+
+    @State(Scope.Thread)
+    public static class StatementState {
+        public final ClickHouseArray intArray = new ClickHouseArray(Types.INTEGER, new int[]{10, 20, 30, 40});
+        public final ClickHouseArray floatArray = new ClickHouseArray(Types.FLOAT, new float[]{10, 20, 30, 40});
+        public final ClickHouseArray doubleArray = new ClickHouseArray(Types.DOUBLE, new double[]{10, 20, 30, 40});
+        public final ClickHouseArray longArray = new ClickHouseArray(Types.INTEGER, new long[]{10, 20, 30, 40});
+        public final ClickHouseArray shortArray = new ClickHouseArray(Types.INTEGER, new short[]{10, 20, 30, 40});
+        public volatile PreparedStatement statement;
+
+        public StatementState() {
+            try {
+                ClickHouseDataSource source = new ClickHouseDataSource("jdbc:clickhouse://localhost:8123");
+                statement = source.getConnection().prepareStatement("INSERT INTO default.smth (bla) VALUES (?)");
+            } catch (Exception err) {
+                throw new RuntimeException(err);
+            }
+        }
+    }
+
+}

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseArrayUtilTest.java
@@ -10,6 +10,12 @@ import org.testng.annotations.Test;
  * @author Dmitry Andreev <a href="mailto:AndreevDm@yandex-team.ru"></a>
  */
 public class ClickHouseArrayUtilTest {
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testNotAnArray() throws Exception {
+        ClickHouseArrayUtil.arrayToString("Hello");
+    }
+
     @Test
     public void testArrayToString() throws Exception {
         Assert.assertEquals(
@@ -39,12 +45,12 @@ public class ClickHouseArrayUtilTest {
 
         Assert.assertEquals(
             ClickHouseArrayUtil.arrayToString(new int[]{21, 42}),
-            "[21,42]"
+            "[21, 42]"
         );
 
         Assert.assertEquals(
                 ClickHouseArrayUtil.arrayToString(new double[]{0.1, 1.2}),
-                "[0.1,1.2]"
+                "[0.1, 1.2]"
         );
 
         Assert.assertEquals(
@@ -69,18 +75,21 @@ public class ClickHouseArrayUtilTest {
 
         Assert.assertEquals(
             ClickHouseArrayUtil.arrayToString(new double[][]{{0.1, 1.2}, {0.2, 2.2}}),
-            "[[0.1,1.2],[0.2,2.2]]"
+            "[[0.1, 1.2],[0.2, 2.2]]"
         );
 
         Assert.assertEquals(
             ClickHouseArrayUtil.arrayToString(new int[][]{{1, 2}, {3, 4}}),
-            "[[1,2],[3,4]]"
+            "[[1, 2],[3, 4]]"
         );
 
         Assert.assertEquals(
             ClickHouseArrayUtil.arrayToString(new char[][]{{'a', 'b'}, {'c', 'd'}}),
             "[['a','b'],['c','d']]"
         );
+
+        Assert.assertEquals(ClickHouseArrayUtil.arrayToString(new short[]{ 1,2,3 }), "[1, 2, 3]");
+        Assert.assertEquals(ClickHouseArrayUtil.arrayToString(new float[]{ 1.2f, 2.3f, 3.4f }), "[1.2, 2.3, 3.4]");
 
     }
 


### PR DESCRIPTION
This PR improves speed of binding arrays in prepared statements
JMH Results:
```
BindTest.benchBindDoubleArray  thrpt   15  3745576.179 ± 389141.253  ops/s
BindTest.benchBindDoubleArray  thrpt   15  5544670.142 ± 138029.538  ops/s
+48%
```
```
BindTest.benchBindFloatArray   thrpt   15  4127465.414 ±  67650.486  ops/s
BindTest.benchBindFloatArray   thrpt   15  5684227.118 ±  77065.492  ops/s
+37%
```
```
BindTest.benchBindIntArray     thrpt   15  7047571.132 ± 143269.075  ops/s
BindTest.benchBindIntArray     thrpt   15  15777212.957 ± 944574.097  ops/s
+120%
```
```
BindTest.benchBindLongArray    thrpt   15  7000060.972 ±  78086.627  ops/s
BindTest.benchBindLongArray    thrpt   15  13688058.489 ± 507957.236  ops/s
+95%
```
```
BindTest.benchBindShortArray   thrpt   15  7293179.203 ±  80167.534  ops/s
BindTest.benchBindShortArray   thrpt   15  15914677.941 ± 237247.522  ops/s
+118%
```