### PR TITLE
Fix default column expression

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -860,7 +860,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
 
             // COLUMN_DEF
             if ("DEFAULT".equals(descTable.getString("default_type"))) {
-                row.add(descTable.getString("default_expresseion"));
+                row.add(descTable.getString("default_expression"));
             } else {
                 row.add(null);
             }

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHouseDatabaseMetadataTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHouseDatabaseMetadataTest.java
@@ -68,7 +68,7 @@ public class ClickHouseDatabaseMetadataTest {
             "DROP TABLE IF EXISTS test.testMetadata");
         connection.createStatement().executeQuery(
             "CREATE TABLE test.testMetadata("
-          + "foo Float32) ENGINE = TinyLog");
+          + "foo Float32, bar UInt8 DEFAULT 42) ENGINE = TinyLog");
         ResultSet columns = connection.getMetaData().getColumns(
             null, "test", "testMetadata", null);
         columns.next();
@@ -96,6 +96,10 @@ public class ClickHouseDatabaseMetadataTest {
         Assert.assertNull(columns.getObject("SOURCE_DATA_TYPE"));
         Assert.assertEquals(columns.getString("IS_AUTOINCREMENT"), "NO");
         Assert.assertEquals(columns.getString("IS_GENERATEDCOLUMN"), "NO");
+
+        columns.next();
+        Assert.assertEquals(columns.getInt("COLUMN_DEF"), 42);
+
     }
 
     @Test


### PR DESCRIPTION
Retrieving DB MetaData for table which contains columns with defaults values, results in Exception `no column default_expresseion in columns list database table name type default_type default_expression`