### PR TITLE
Doesn't quote generated arrays if a collection was given.

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseValueFormatter.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseValueFormatter.java
@@ -174,6 +174,9 @@ public final class ClickHouseValueFormatter {
         if (o instanceof ClickHouseArray) {
             return false;
         }
+        if (o instanceof Collection) {
+            return false;
+        }
         return true;
     }
 

--- a/src/test/java/ru/yandex/clickhouse/ClickHousePreparedStatementParameterTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHousePreparedStatementParameterTest.java
@@ -20,4 +20,14 @@ public class ClickHousePreparedStatementParameterTest {
         assertSame(p1, p0);
     }
 
+    @Test
+    public void testArrayAndCollectionParam() {
+        ClickHousePreparedStatementParameter p0 =
+                ClickHousePreparedStatementParameter.fromObject(Arrays.asList("A", "B", "C"), TimeZone.getDefault(), TimeZone.getDefault());
+        ClickHousePreparedStatementParameter p1 =
+                ClickHousePreparedStatementParameter.fromObject(new String[]{"A", "B", "C"}, TimeZone.getDefault(), TimeZone.getDefault());
+        assertEquals(p0.getRegularValue(), p1.getRegularValue());
+        assertEquals(p0.getBatchValue(), p1.getBatchValue());
+    }
+
 }


### PR DESCRIPTION
If a collection is passed in it will automatically be converted
into an array literal. However, like for normal arrays, this
generated string must not be quoted again when being
inserted into a prepared statement.

ClickHouseValueFormatter#formatObject (L155)
will happy convert Collections into appropriate array
literals but these will be quoted again and then rejected
by the Clickhosue server as a true array instead of a
string literal is expected.