### PR TITLE
read FixedString from BinaryInputStream

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStream.java
@@ -84,6 +84,13 @@ public class ClickHouseRowBinaryInputStream implements Closeable {
 		return new String(bytes, StreamUtils.UTF_8);
 	}
 
+	public String readFixedString(int length) throws IOException {
+		byte[] bytes = new byte[length];
+		readBytes(bytes);
+
+		return new String(bytes, StreamUtils.UTF_8);
+	}
+
 	private void validateInt(int value, int minValue, int maxValue, String dataType) {
 		if (value < minValue || value > maxValue) {
 			throw new IllegalStateException("Not a " + dataType + " value: " + value);

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStreamTest.java
@@ -5,6 +5,8 @@ import org.testng.annotations.Test;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.Date;
 import java.util.TimeZone;
 
@@ -78,6 +80,12 @@ public class ClickHouseRowBinaryInputStreamTest {
 		assertEquals(input.readUInt64AsLong(), UnsignedLong.valueOf("18446744073709551615").longValue());
 	}
 
+	@Test
+	public void testFixedString() throws Exception {
+		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{48, 49, 48, 49, 55, 49, 50, 50, 48, 48});
+
+		assertEquals(input.readFixedString(10), "0101712200");
+	}
 
 	@Test
 	public void testOne() throws Exception {

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryInputStreamTest.java
@@ -85,6 +85,10 @@ public class ClickHouseRowBinaryInputStreamTest {
 		ClickHouseRowBinaryInputStream input = prepareStream(new byte[]{48, 49, 48, 49, 55, 49, 50, 50, 48, 48});
 
 		assertEquals(input.readFixedString(10), "0101712200");
+
+		ClickHouseRowBinaryInputStream inputZeroPaddedString = prepareStream(new byte[]{104, 101, 108, 108, 111, 0, 0, 0, 0, 0});
+
+		assertEquals(inputZeroPaddedString.readFixedString(10), "hello\0\0\0\0\0");
 	}
 
 	@Test


### PR DESCRIPTION
`ClickHouseRowBinaryInputStream` can't read FixedString(n) and throw exception in this case, therefore the functionality for reading FixedString(n) has been added.

this [issue](https://github.com/ClickHouse/clickhouse-jdbc/issues/394) 