### PR TITLE
Bugfix for Boolean type formatting

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseValueFormatter.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseValueFormatter.java
@@ -168,6 +168,9 @@ public final class ClickHouseValueFormatter {
         if (o instanceof Number) {
             return false;
         }
+        if (o instanceof Boolean) {
+            return false;
+        }
         if (o.getClass().isArray()) {
             return false;
         }

--- a/src/test/java/ru/yandex/clickhouse/ClickHousePreparedStatementParameterTest.java
+++ b/src/test/java/ru/yandex/clickhouse/ClickHousePreparedStatementParameterTest.java
@@ -33,4 +33,25 @@ public class ClickHousePreparedStatementParameterTest {
         assertEquals(p0.getBatchValue(), p1.getBatchValue());
     }
 
+    @Test
+    public void testBooleanParam() {
+        assertEquals(ClickHousePreparedStatementParameter.fromObject(Boolean.TRUE,
+            TimeZone.getDefault(), TimeZone.getDefault()).getRegularValue(), "1");
+        assertEquals(ClickHousePreparedStatementParameter.fromObject(Boolean.FALSE,
+            TimeZone.getDefault(), TimeZone.getDefault()).getRegularValue(), "0");
+    }
+
+    @Test
+    public void testNumberParam() {
+        assertEquals(ClickHousePreparedStatementParameter.fromObject(10,
+            TimeZone.getDefault(), TimeZone.getDefault()).getRegularValue(), "10");
+        assertEquals(ClickHousePreparedStatementParameter.fromObject(10.5,
+            TimeZone.getDefault(), TimeZone.getDefault()).getRegularValue(), "10.5");
+    }
+
+    @Test
+    public void testStringParam() {
+        assertEquals(ClickHousePreparedStatementParameter.fromObject("someString",
+            TimeZone.getDefault(), TimeZone.getDefault()).getRegularValue(), "'someString'");
+    }
 }


### PR DESCRIPTION
Boolean -> ClickHousePreparedStatementParameter using ClickHousePreparedStatementParameter.fromObject produces value with single quotes (is recognized as String by ClickHouse, not as Uint8, as it should be)