### PR TITLE
do not put database in url if it is default database

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -830,7 +830,7 @@ public class ClickHouseStatementImpl extends ConfigurableApi<ClickHouseStatement
         }
 
         Map<ClickHouseQueryParam, String> params = properties.buildQueryParams(true);
-        if (!ignoreDatabase) {
+        if (!ignoreDatabase && !ClickhouseJdbcUrlParser.DEFAULT_DATABASE.equals(initialDatabase)) {
             params.put(ClickHouseQueryParam.DATABASE, initialDatabase);
         }
 


### PR DESCRIPTION
for a user in users.xml like:
```xml
    <test>
      <password>test</password>
      <networks incl="networks" replace="replace">
        <ip>::/0</ip>
      </networks>
      <profile>default</profile>
      <quota>default</quota>
      <allow_databases>
        <database>test</database>
      </allow_databases>
    </test>
```

`echo 'SELECT 1' | curl 'http://test:test@localhost:8123/?database=default' -d @-` 
Code: 291, e.displayText() = DB::Exception: Access denied to database default for user test (version 19.17.4.11 (official build))

  `echo 'SELECT 1' | curl 'http://test:test@localhost:8123/' -d @-` 
1

Similarly, the following code fails to create connection due to the construct backend query URL have `?database=default` while the user `test` doesn't have the privilege of database `default`
```java
    Class.forName("ru.yandex.clickhouse.ClickHouseDriver");
    Connection conn = DriverManager.getConnection(
        "jdbc:clickhouse://localhost:8123",
        "test", 
        "test"
    );
    Statement st = conn.createStatement();
    ResultSet rs = st.executeQuery("select 1");
    while (rs.next()) {
      System.out.println(rs.getString(1));
    }
    rs.close();
    st.close();
    conn.close();
```