### PR TITLE
Expose the pointer for the LZ4 Compression buffer

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseLZ4OutputStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseLZ4OutputStream.java
@@ -12,16 +12,24 @@ public class ClickHouseLZ4OutputStream extends OutputStream {
     private static final LZ4Factory factory = LZ4Factory.safeInstance();
     private final LittleEndianDataOutputStream dataWrapper;
 
-    private byte[] currentBlock;
-    private int pointer;
-    private byte[] compressedBlock;
     private final LZ4Compressor compressor;
+    private final byte[] currentBlock;
+    private final byte[] compressedBlock;
+
+    private int pointer;
 
     public ClickHouseLZ4OutputStream(OutputStream stream, int maxCompressBlockSize) {
         dataWrapper = new LittleEndianDataOutputStream(stream);
         compressor = factory.fastCompressor();
         currentBlock = new byte[maxCompressBlockSize];
         compressedBlock = new byte[compressor.maxCompressedLength(maxCompressBlockSize)];
+    }
+
+    /**
+    * @return Location of pointer in the byte buffer (bytes not yet flushed)
+    */
+    public int position() {
+        return pointer;
     }
 
     @Override


### PR DESCRIPTION
Not sure if this is wanted / useful for others.

But in our case, we aren't using the full JDBC library, just this class to compress the `INSERT` queries (because we're doing some batching of records, then push as one batch to a HTTP output stream).

Because of also other buffers, it is useful to know how much data is buffered into the LZ4 compression buffers, preventing having to call `flush()` regularly.