### PR TITLE
Write UInt64 Array also as UnsignedLong type

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStream.java
@@ -285,6 +285,15 @@ public class ClickHouseRowBinaryStream {
         }
     }
 
+    public void writeUInt64Array(UnsignedLong[] longs) throws IOException {
+        Preconditions.checkNotNull(longs);
+        writeUnsignedLeb128(longs.length);
+        for (UnsignedLong l : longs) {
+            writeUInt64(l);
+        }
+    }
+
+
     public void writeFloat32Array(float[] floats) throws IOException {
         Preconditions.checkNotNull(floats);
         writeUnsignedLeb128(floats.length);

--- a/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
+++ b/src/test/java/ru/yandex/clickhouse/util/ClickHouseRowBinaryStreamTest.java
@@ -206,6 +206,21 @@ public class ClickHouseRowBinaryStreamTest {
     }
 
     @Test
+    public void testUInt64Array() throws Exception {
+        check(
+            new StreamWriter() {
+              @Override
+              public void write(ClickHouseRowBinaryStream stream) throws Exception {
+                stream.writeUInt64Array(new long[]{0, Long.MAX_VALUE});
+                stream.writeUInt64Array(new UnsignedLong[]{UnsignedLong.valueOf(0), UnsignedLong.valueOf("18446744073709551615")});
+              }
+            },
+            new byte[] { 2, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, 127, // First array
+                2, 0, 0, 0, 0, 0, 0, 0, 0, -1, -1, -1, -1, -1, -1, -1, -1, } // Second array
+        );
+    }
+
+    @Test
     public void testString() throws Exception {
         check(
             new StreamWriter() {


### PR DESCRIPTION
Currently there's a function `writeUInt64Array` with `long[]` parameter. But `writeUInt64` itself supports `UnsignedLong` as well.
Add this overloaded method also for writing UInt64 arrays.