### PR TITLE
Log connect failures in BalancedClickhouseDataSource

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
+++ b/src/main/java/ru/yandex/clickhouse/BalancedClickhouseDataSource.java
@@ -144,6 +144,7 @@ public class BalancedClickhouseDataSource implements DataSource {
             driver.connect(url, properties).createStatement().execute("SELECT 1");
             return true;
         } catch (Exception e) {
+            log.debug("Unable to connect using {}", url, e);
             return false;
         }
     }


### PR DESCRIPTION
It is very difficult to debug connect failures while using BalancedClickhouseDataSource as the code swallows all connect exceptions.

This adds a log so that it's actually possible to figure out why connect is failing for one or more JDBC URLs. I wasn't totally sure what the ethos is in this project WRT how much to log, so I started at debug, but would be happy to increase the log level.