### PR TITLE
Add the query_id in the ClickHouseProperties

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -93,6 +93,7 @@ public class ClickHouseProperties {
     private Boolean insertDeduplicate;
     private Boolean insertDistributedSync;
     private Boolean anyJoinDistinctRightTableKeys;
+    private String queryId;
 
 
     public ClickHouseProperties() {
@@ -161,6 +162,7 @@ public class ClickHouseProperties {
         this.insertDeduplicate = getSetting(info, ClickHouseQueryParam.INSERT_DEDUPLICATE);
         this.insertDistributedSync = getSetting(info, ClickHouseQueryParam.INSERT_DISTRIBUTED_SYNC);
         this.anyJoinDistinctRightTableKeys = getSetting(info, ClickHouseQueryParam.ANY_JOIN_DISTINCT_RIGHT_TABLE_KEYS);
+        this.queryId = getSetting(info, ClickHouseQueryParam.QUERY_ID);
     }
 
     public Properties asProperties() {
@@ -225,7 +227,7 @@ public class ClickHouseProperties {
         ret.put(ClickHouseQueryParam.INSERT_DEDUPLICATE.getKey(), insertDeduplicate);
         ret.put(ClickHouseQueryParam.INSERT_DISTRIBUTED_SYNC.getKey(), insertDistributedSync);
         ret.put(ClickHouseQueryParam.ANY_JOIN_DISTINCT_RIGHT_TABLE_KEYS.getKey(), anyJoinDistinctRightTableKeys);
-
+        ret.put(ClickHouseQueryParam.QUERY_ID.getKey(), queryId);
         return ret.getProperties();
     }
 
@@ -291,6 +293,7 @@ public class ClickHouseProperties {
         setInsertDeduplicate(properties.insertDeduplicate);
         setInsertDistributedSync(properties.insertDistributedSync);
         setAnyJoinDistinctRightTableKeys(properties.anyJoinDistinctRightTableKeys);
+        setQueryId(properties.queryId);
     }
 
     public Map<ClickHouseQueryParam, String> buildQueryParams(boolean ignoreDatabase){
@@ -373,6 +376,7 @@ public class ClickHouseProperties {
         addQueryParam(insertDeduplicate, ClickHouseQueryParam.INSERT_DEDUPLICATE, params);
         addQueryParam(insertDistributedSync, ClickHouseQueryParam.INSERT_DISTRIBUTED_SYNC, params);
         addQueryParam(anyJoinDistinctRightTableKeys, ClickHouseQueryParam.ANY_JOIN_DISTINCT_RIGHT_TABLE_KEYS, params);
+        addQueryParam(queryId, ClickHouseQueryParam.QUERY_ID, params);
 
         if (enableOptimizePredicateExpression != null) {
             params.put(ClickHouseQueryParam.ENABLE_OPTIMIZE_PREDICATE_EXPRESSION, enableOptimizePredicateExpression ? "1" : "0");
@@ -900,6 +904,14 @@ public class ClickHouseProperties {
 
     public void setAnyJoinDistinctRightTableKeys(Boolean anyJoinDistinctRightTableKeys) {
         this.anyJoinDistinctRightTableKeys = anyJoinDistinctRightTableKeys;
+    }
+
+    public String getQueryId() {
+        return this.queryId;
+    }
+
+    public void setQueryId(String queryId) {
+        this.queryId = queryId;
     }
 
     public Boolean getAnyJoinDistinctRightTableKeys() {

--- a/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
+++ b/src/test/java/ru/yandex/clickhouse/settings/ClickHousePropertiesTest.java
@@ -8,6 +8,7 @@ import ru.yandex.clickhouse.ClickHouseDataSource;
 import java.net.URI;
 import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 
 import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
@@ -136,6 +137,7 @@ public class ClickHousePropertiesTest {
 
     @Test
     public void buildQueryParamsTest() {
+        String queryId = UUID.randomUUID().toString();
         ClickHouseProperties clickHouseProperties = new ClickHouseProperties();
         clickHouseProperties.setInsertQuorumTimeout(1000L);
         clickHouseProperties.setInsertQuorum(3L);
@@ -143,6 +145,7 @@ public class ClickHousePropertiesTest {
         clickHouseProperties.setMaxInsertBlockSize(42L);
         clickHouseProperties.setInsertDeduplicate(true);
         clickHouseProperties.setInsertDistributedSync(true);
+        clickHouseProperties.setQueryId(queryId);
 
         Map<ClickHouseQueryParam, String> clickHouseQueryParams = clickHouseProperties.buildQueryParams(true);
         Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.INSERT_QUORUM), "3");
@@ -151,6 +154,7 @@ public class ClickHousePropertiesTest {
         Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.MAX_INSERT_BLOCK_SIZE), "42");
         Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.INSERT_DEDUPLICATE), "1");
         Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.INSERT_DISTRIBUTED_SYNC), "1");
+        Assert.assertEquals(clickHouseQueryParams.get(ClickHouseQueryParam.QUERY_ID), queryId);
     }
 
     @Test


### PR DESCRIPTION
# Description 

I had an use case in which I need to set the ClickHouse query ID when executing the query. In the release that I was using, when setting the ClickHouse query_id, this ones was override in ClickHouse by an another UUID.  

The goal of this PR is to add the `query_id` in the ClickHouseProperties and to be able to find into ClickHouse when requesting the `query_log` table. 