### PR TITLE
Fix http connection reuse

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -28,6 +28,7 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
 
 
     KEEP_ALIVE_TIMEOUT("keepAliveTimeout", 30 * 1000, ""),
+    REUSE_CONNECTIONS("reuseConnections", false, ""),
 
     /**
      * for ConnectionManager

--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -93,7 +93,7 @@ public class ClickHouseProperties {
     private Boolean insertDeduplicate;
     private Boolean insertDistributedSync;
     private Boolean anyJoinDistinctRightTableKeys;
-
+    private boolean reuseConnections;
 
     public ClickHouseProperties() {
         this(new Properties());
@@ -108,6 +108,7 @@ public class ClickHouseProperties {
         this.connectionTimeout = (Integer)getSetting(info, ClickHouseConnectionSettings.CONNECTION_TIMEOUT);
         this.dataTransferTimeout = (Integer)getSetting(info, ClickHouseConnectionSettings.DATA_TRANSFER_TIMEOUT);
         this.keepAliveTimeout = (Integer)getSetting(info, ClickHouseConnectionSettings.KEEP_ALIVE_TIMEOUT);
+        this.reuseConnections = (Boolean)getSetting(info, ClickHouseConnectionSettings.REUSE_CONNECTIONS);
         this.timeToLiveMillis = (Integer)getSetting(info, ClickHouseConnectionSettings.TIME_TO_LIVE_MILLIS);
         this.defaultMaxPerRoute = (Integer)getSetting(info, ClickHouseConnectionSettings.DEFAULT_MAX_PER_ROUTE);
         this.maxTotal = (Integer)getSetting(info, ClickHouseConnectionSettings.MAX_TOTAL);
@@ -172,6 +173,7 @@ public class ClickHouseProperties {
         ret.put(ClickHouseConnectionSettings.CONNECTION_TIMEOUT.getKey(), String.valueOf(connectionTimeout));
         ret.put(ClickHouseConnectionSettings.DATA_TRANSFER_TIMEOUT.getKey(), String.valueOf(dataTransferTimeout));
         ret.put(ClickHouseConnectionSettings.KEEP_ALIVE_TIMEOUT.getKey(), String.valueOf(keepAliveTimeout));
+        ret.put(ClickHouseConnectionSettings.REUSE_CONNECTIONS.getKey(), String.valueOf(reuseConnections));
         ret.put(ClickHouseConnectionSettings.TIME_TO_LIVE_MILLIS.getKey(), String.valueOf(timeToLiveMillis));
         ret.put(ClickHouseConnectionSettings.DEFAULT_MAX_PER_ROUTE.getKey(), String.valueOf(defaultMaxPerRoute));
         ret.put(ClickHouseConnectionSettings.MAX_TOTAL.getKey(), String.valueOf(maxTotal));
@@ -239,6 +241,7 @@ public class ClickHouseProperties {
         setConnectionTimeout(properties.connectionTimeout);
         setDataTransferTimeout(properties.dataTransferTimeout);
         setKeepAliveTimeout(properties.keepAliveTimeout);
+        setReuseConnections(properties.reuseConnections);
         setTimeToLiveMillis(properties.timeToLiveMillis);
         setDefaultMaxPerRoute(properties.defaultMaxPerRoute);
         setMaxTotal(properties.maxTotal);
@@ -525,6 +528,14 @@ public class ClickHouseProperties {
 
     public void setKeepAliveTimeout(int keepAliveTimeout) {
         this.keepAliveTimeout = keepAliveTimeout;
+    }
+
+    public boolean getReuseConnections() {
+        return reuseConnections;
+    }
+
+    public void setReuseConnections(boolean reuseConnections) {
+        this.reuseConnections = reuseConnections;
     }
 
     public String getUser() {


### PR DESCRIPTION
At Datameer, we have had failing communication between client and server when the client reused HTTP connections. When I looked at the code, I noticed that the author(s) of the `ConnectionKeepAliveStrategy` seemed to think that it does what is actually the purpose of a `ConnectionReuseStrategy`. The comments within `getKeepAliveDuration(..)` suggest that they thought that by returning `-1` they disable connection reuse (it actually means "keep the connection alive indefinitely").
However, I'm not sure if that is the real root cause of our issues regarding failing communication between client and server when connections are reused, so I designed the new code so that connections are never reused unless told to via property.