### PR TITLE
fix bug when select with FORMAT JSONEachRow

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -76,6 +76,9 @@ public class ClickHouseStatementImpl implements ClickHouseStatement {
     private static final String[] selectKeywords = new String[]{"SELECT", "WITH", "SHOW", "DESC", "EXISTS"};
     private static final String databaseKeyword = "CREATE DATABASE";
 
+    /**
+     * is a sql with "FORMAT JSONEachRow"
+     */
     private boolean isSelectWithFormatJSONEachRow = false;
 
     public ClickHouseStatementImpl(CloseableHttpClient client, ClickHouseConnection connection,

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultBuilder.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultBuilder.java
@@ -23,6 +23,7 @@ public class ClickHouseResultBuilder {
     private TimeZone timezone = TimeZone.getTimeZone("UTC");
     private boolean usesWithTotals;
     private ClickHouseProperties properties = new ClickHouseProperties();
+    private boolean isSelectWithFormatJSONEachRow = false;
 
     public static ClickHouseResultBuilder builder(int columnsNum) {
         return new ClickHouseResultBuilder(columnsNum);
@@ -46,6 +47,11 @@ public class ClickHouseResultBuilder {
 
     public ClickHouseResultBuilder withTotals(boolean usesWithTotals) {
         this.usesWithTotals = usesWithTotals;
+        return this;
+    }
+
+    public ClickHouseResultBuilder withSelectWithFormatJSONEachRow(boolean selectWithFormatJSONEachRow) {
+        isSelectWithFormatJSONEachRow = selectWithFormatJSONEachRow;
         return this;
     }
 
@@ -91,7 +97,7 @@ public class ClickHouseResultBuilder {
             byte[] bytes = baos.toByteArray();
             ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
 
-            return new ClickHouseResultSet(inputStream, 1024, "system", "unknown", usesWithTotals, null, timezone, properties);
+            return new ClickHouseResultSet(inputStream, 1024, "system", "unknown", usesWithTotals, null, timezone,isSelectWithFormatJSONEachRow, properties);
         } catch (IOException e) {
             throw new RuntimeException("Never happens", e);
         }

--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseScrollableResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseScrollableResultSet.java
@@ -13,8 +13,10 @@ public class ClickHouseScrollableResultSet extends ClickHouseResultSet {
     
     private List<ByteFragment[]> lines;
 
-    public ClickHouseScrollableResultSet(InputStream is, int bufferSize, String db, String table, boolean usesWithTotals, ClickHouseStatement statement, TimeZone timezone, ClickHouseProperties properties) throws IOException {
-        super(is, bufferSize, db, table, usesWithTotals, statement, timezone, properties);
+    public ClickHouseScrollableResultSet(InputStream is, int bufferSize, String db, String table,
+										 boolean usesWithTotals, ClickHouseStatement statement,
+										 TimeZone timezone,boolean isSelectWithFormatJSONEachRow, ClickHouseProperties properties) throws IOException {
+        super(is, bufferSize, db, table, usesWithTotals, statement, timezone,isSelectWithFormatJSONEachRow, properties);
         lines = new ArrayList<ByteFragment[]>();
     }
 


### PR DESCRIPTION
if sql is a select with FORMAT JSONEachRow, result has no headerFragment and typesFragment from clickhouse server. but first and second json data will be used for headerFragment and typesFragment in ru.yandex.clickhouse.response.ClickHouseResultSet,this will result in the loss of two records.