### PR TITLE
Issue with driver not honoring the server keep-alive timeout settings

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -17,6 +17,7 @@ public class ClickHouseProperties {
     private int socketTimeout;
     private int connectionTimeout;
     private int dataTransferTimeout;
+    @Deprecated
     private int keepAliveTimeout;
     private int timeToLiveMillis;
     private int defaultMaxPerRoute;

--- a/src/main/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilder.java
+++ b/src/main/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilder.java
@@ -1,10 +1,6 @@
 package ru.yandex.clickhouse.util;
 
-import org.apache.http.Header;
-import org.apache.http.HeaderElement;
-import org.apache.http.HeaderElementIterator;
-import org.apache.http.HttpHeaders;
-import org.apache.http.HttpResponse;
+import org.apache.http.*;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.ConnectionConfig;
 import org.apache.http.config.RegistryBuilder;
@@ -13,6 +9,7 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
@@ -21,7 +18,6 @@ import org.apache.http.message.BasicHeaderElementIterator;
 import org.apache.http.protocol.HTTP;
 import org.apache.http.protocol.HttpContext;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
-import ru.yandex.clickhouse.util.guava.StreamUtils;
 import ru.yandex.clickhouse.util.ssl.NonValidatingTrustManager;
 
 import javax.net.ssl.HostnameVerifier;
@@ -59,13 +55,25 @@ public class ClickHouseHttpClientBuilder {
     public CloseableHttpClient buildClient() throws Exception {
         return HttpClientBuilder.create()
                 .setConnectionManager(getConnectionManager())
-                .setKeepAliveStrategy(createKeepAliveStrategy())
+                .setConnectionReuseStrategy(getConnectionReuseStrategy())
                 .setDefaultConnectionConfig(getConnectionConfig())
                 .setDefaultRequestConfig(getRequestConfig())
                 .setDefaultHeaders(getDefaultHeaders())
                 .disableContentCompression() // gzip здесь ни к чему. Используется lz4 при compress=1
                 .disableRedirectHandling()
                 .build();
+    }
+
+    private ConnectionReuseStrategy getConnectionReuseStrategy() {
+        return new DefaultConnectionReuseStrategy() {
+            @Override
+            public boolean keepAlive(HttpResponse httpResponse, HttpContext httpContext) {
+                if (httpResponse.getStatusLine().getStatusCode() != HttpURLConnection.HTTP_OK) {
+                    return false;
+                }
+                return super.keepAlive(httpResponse, httpContext);
+            }
+        };
     }
 
     private PoolingHttpClientConnectionManager getConnectionManager()


### PR DESCRIPTION
We faced an issue where the client was getting broken pipe error while sending a request to insert data into clickhouse. We figured that the server had <keep_alive_timeout>3</keep_alive_timeout> and client (driver) was trying to keep the connection alive for 30 seconds (default). 
Ideally, client shouldn't try to use it's own settings for keep-alive when server responds with a different value. If server doesn't respond with a value of timeout, TCP defaults should be used. 

The chances of getting this issue are more when data is written as an InputStream as HttpClient can't retry that request due to stream processing.

After we fixed and deployed this change locally, we haven't received any broke pipe issues. 
