### PR TITLE
implement ResultSet findColumn() method issue#525

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
+++ b/src/main/java/ru/yandex/clickhouse/response/ClickHouseResultSet.java
@@ -607,6 +607,11 @@ public class ClickHouseResultSet extends AbstractResultSet {
         }
     }
 
+    @Override
+    public int findColumn(String columnLabel) throws SQLException {
+        return asColNum(columnLabel);
+    }
+
     //////
 
     @Override

--- a/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultBuilderTest.java
+++ b/src/test/java/ru/yandex/clickhouse/response/ClickHouseResultBuilderTest.java
@@ -19,6 +19,9 @@ public class ClickHouseResultBuilderTest {
             .build();
         List<ClickHouseColumnInfo> columns = resultSet.getColumns();
 
+        Assert.assertEquals(1, resultSet.findColumn("string"));
+        Assert.assertEquals(2, resultSet.findColumn("int"));
+
         Assert.assertEquals("string", columns.get(0).getColumnName());
         Assert.assertEquals("int", columns.get(1).getColumnName());
 


### PR DESCRIPTION
```
    /**
     * Maps the given <code>ResultSet</code> column label to its
     * <code>ResultSet</code> column index.
     *
     * @param columnLabel the label for the column specified with the SQL AS clause.  If the SQL AS clause was not specified, then the label is the name of the column
     * @return the column index of the given column name
     * @exception SQLException if the <code>ResultSet</code> object
     * does not contain a column labeled <code>columnLabel</code>, a database access error occurs
     *  or this method is called on a closed result set
     */
    int findColumn(String columnLabel) throws SQLException;
```