### PR TITLE
Make column comments available via DatabaseMetaData REMARKS

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -803,10 +803,10 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
         StringBuilder query;
         if (connection.getServerVersion().compareTo("1.1.54237") > 0) {
             query = new StringBuilder(
-                "SELECT database, table, name, type, default_kind as default_type, default_expression ");
+                "SELECT database, table, name, type, default_kind as default_type, default_expression, comment ");
         } else {
             query = new StringBuilder(
-                "SELECT database, table, name, type, default_type, default_expression ");
+                "SELECT database, table, name, type, default_type, default_expression, NULL AS comment ");
         }
         query.append("FROM system.columns ");
         List<String> predicates = new ArrayList<String>();
@@ -856,7 +856,9 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
                 ? String.valueOf(columnNullable)
                 : String.valueOf(columnNoNulls));
             //remarks
-            row.add(null);
+            row.add("".equals(descTable.getString("comment"))
+                ? null
+                : descTable.getString("comment"));
 
             // COLUMN_DEF
             if ("DEFAULT".equals(descTable.getString("default_type"))) {

--- a/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHouseDatabaseMetadata.java
@@ -717,7 +717,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
 
         List typeList = types != null ? Arrays.asList(types) : null;
         while (result.next()) {
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             row.add(DEFAULT_CAT);
             row.add(result.getString(1));
             row.add(result.getString(2));
@@ -809,7 +809,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
                 "SELECT database, table, name, type, default_type, default_expression, NULL AS comment ");
         }
         query.append("FROM system.columns ");
-        List<String> predicates = new ArrayList<String>();
+        List<String> predicates = new ArrayList<>();
         if (schemaPattern != null) {
             predicates.add("database LIKE '" + schemaPattern + "' ");
         }
@@ -827,7 +827,7 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
         ResultSet descTable = request(query.toString());
         int colNum = 1;
         while (descTable.next()) {
-            List<String> row = new ArrayList<String>();
+            List<String> row = new ArrayList<>();
             //catalog name
             row.add(DEFAULT_CAT);
             //database name
@@ -856,9 +856,10 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
                 ? String.valueOf(columnNullable)
                 : String.valueOf(columnNoNulls));
             //remarks
-            row.add("".equals(descTable.getString("comment"))
+            String remarks = descTable.getString("comment");
+            row.add("".equals(remarks)
                 ? null
-                : descTable.getString("comment"));
+                : remarks);
 
             // COLUMN_DEF
             if ("DEFAULT".equals(descTable.getString("default_type"))) {
@@ -1324,10 +1325,12 @@ public class ClickHouseDatabaseMetadata implements DatabaseMetaData {
         return iface.isAssignableFrom(getClass());
     }
 
+    @Override
     public ResultSet getPseudoColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern) throws SQLException {
         return null;
     }
 
+    @Override
     public boolean generatedKeyAlwaysReturned() throws SQLException {
         return false;
     }

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHouseDatabaseMetadataTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHouseDatabaseMetadataTest.java
@@ -68,7 +68,7 @@ public class ClickHouseDatabaseMetadataTest {
             "DROP TABLE IF EXISTS test.testMetadata");
         connection.createStatement().executeQuery(
             "CREATE TABLE test.testMetadata("
-          + "foo Float32) ENGINE = TinyLog");
+          + "foo Float32, bar String COMMENT 'baz') ENGINE = TinyLog");
         ResultSet columns = connection.getMetaData().getColumns(
             null, "test", "testMetadata", null);
         columns.next();
@@ -96,6 +96,8 @@ public class ClickHouseDatabaseMetadataTest {
         Assert.assertNull(columns.getObject("SOURCE_DATA_TYPE"));
         Assert.assertEquals(columns.getString("IS_AUTOINCREMENT"), "NO");
         Assert.assertEquals(columns.getString("IS_GENERATEDCOLUMN"), "NO");
+        columns.next();
+        Assert.assertEquals(columns.getObject("REMARKS"), "baz");
     }
 
     @Test

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHouseDatabaseMetadataTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHouseDatabaseMetadataTest.java
@@ -68,7 +68,7 @@ public class ClickHouseDatabaseMetadataTest {
             "DROP TABLE IF EXISTS test.testMetadata");
         connection.createStatement().executeQuery(
             "CREATE TABLE test.testMetadata("
-          + "foo Float32, bar String COMMENT 'baz') ENGINE = TinyLog");
+          + "foo Float32, bar UInt8 DEFAULT 42 COMMENT 'baz') ENGINE = TinyLog");
         ResultSet columns = connection.getMetaData().getColumns(
             null, "test", "testMetadata", null);
         columns.next();
@@ -97,6 +97,7 @@ public class ClickHouseDatabaseMetadataTest {
         Assert.assertEquals(columns.getString("IS_AUTOINCREMENT"), "NO");
         Assert.assertEquals(columns.getString("IS_GENERATEDCOLUMN"), "NO");
         columns.next();
+        Assert.assertEquals(columns.getInt("COLUMN_DEF"), 42);
         Assert.assertEquals(columns.getObject("REMARKS"), "baz");
     }
 


### PR DESCRIPTION
Fix for #480

Column comments have been available for some years in ClickHouse server, so I assume it is safe to refer to the column. If we want to support older server versions, please give me a hint for which minimum version to check.