### PR TITLE
Static null parameters for non-batch PreparedStatement

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
+++ b/src/main/java/ru/yandex/clickhouse/ClickHousePreparedStatementImpl.java
@@ -25,6 +25,7 @@ import java.util.regex.Pattern;
 public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl implements ClickHousePreparedStatement {
 
     static final String PARAM_MARKER = "?";
+    static final String NULL_MARKER = "\\N";
 
     private static final Pattern VALUES = Pattern.compile("(?i)VALUES[\\s]*\\(");
 
@@ -82,6 +83,8 @@ public class ClickHousePreparedStatementImpl extends ClickHouseStatementImpl imp
             String pValue = getParameter(i - 1);
             if (PARAM_MARKER.equals(pValue)) {
                 sb.append(binds[p++].getRegularValue());
+            } else if (NULL_MARKER.equals(pValue)) {
+                sb.append("NULL");
             } else {
                 sb.append(pValue);
             }

--- a/src/main/java/ru/yandex/clickhouse/PreparedStatementParser.java
+++ b/src/main/java/ru/yandex/clickhouse/PreparedStatementParser.java
@@ -173,7 +173,7 @@ final class PreparedStatementParser  {
             return "0";
         }
         if ("NULL".equalsIgnoreCase(paramValue)) {
-            return "\\N";
+            return ClickHousePreparedStatementImpl.NULL_MARKER;
         }
         return paramValue;
     }

--- a/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
+++ b/src/test/java/ru/yandex/clickhouse/integration/ClickHousePreparedStatementTest.java
@@ -640,6 +640,25 @@ public class ClickHousePreparedStatementTest {
         Assert.assertEquals(result[1].getTime(), 1560698526598L);
     }
 
+    @Test
+    public void testStaticNullValue() throws Exception {
+        connection.createStatement().execute(
+            "DROP TABLE IF EXISTS test.static_null_value");
+        connection.createStatement().execute(
+            "CREATE TABLE IF NOT EXISTS test.static_null_value"
+          + "(foo Nullable(String), bar Nullable(String)) "
+          + "ENGINE = TinyLog"
+        );
+        PreparedStatement ps0 = connection.prepareStatement(
+            "INSERT INTO test.static_null_value(foo) VALUES (null)");
+        ps0.executeUpdate();
+
+        ps0 = connection.prepareStatement(
+            "INSERT INTO test.static_null_value(foo, bar) VALUES (null, ?)");
+        ps0.setNull(1, Types.VARCHAR);
+        ps0.executeUpdate();
+    }
+
     private static byte[] randomEncodedUUID() {
         UUID uuid = UUID.randomUUID();
         return ByteBuffer.allocate(16)


### PR DESCRIPTION
Fix for #495 It's not beautiful, but should fix the bug (at least the tests are green). I expect some major clean-up / refactoring in `ClickHousePreparedStatementImpl` and friends after 0.2.5 (e.g. via #418 and perhaps #535)