### PR TITLE
fix NegativeArraySizeException error

### DIFF
--- a/src/main/java/ru/yandex/clickhouse/response/StreamSplitter.java
+++ b/src/main/java/ru/yandex/clickhouse/response/StreamSplitter.java
@@ -108,7 +108,11 @@ public class StreamSplitter {
             posNext = 0;
         } else {
             byte[] oldBuf = buf;
-            buf = new byte[buf.length*2];
+            if (buf.length > (Integer.MAX_VALUE - 2) / 2) {
+                buf = new byte[Integer.MAX_VALUE - 2];// Some platforms will throw 'Requested array size exceeds VM limit' when maximum length of array is Integer.MAX_VALUE - 1
+            } else {
+                buf = new byte[buf.length * 2];
+            }
             System.arraycopy(oldBuf, 0, buf, 0, oldBuf.length);
         }
     }


### PR DESCRIPTION
It will throw NegativeArraySizeException when result is very large by execute sql with `connection.prepareStatement(sql).executeQuery()` 

The error stack：
[error stack](https://github.com/zzsmdfj/picture/blob/master/clickhouse/1616382893968-00c4c88f-991f-43b9-91c4-622c8c5d6652.png)


