### PR TITLE
Shared cookie store

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -42,6 +42,7 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
      * additional
      */
     USE_OBJECTS_IN_ARRAYS("use_objects_in_arrays", false, "Whether Object[] should be used instead primitive arrays."),
+    USE_SHARED_COOKIE_STORE("use_shared_cookie_store", false, "Whether to use shared cookie to store among all http clients are not"),
     MAX_COMPRESS_BUFFER_SIZE("maxCompressBufferSize", 1024*1024, ""),
 
     USE_SERVER_TIME_ZONE("use_server_time_zone", true, "Whether to use timezone from server. On connection init select timezone() will be executed"),

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -42,7 +42,7 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
      * additional
      */
     USE_OBJECTS_IN_ARRAYS("use_objects_in_arrays", false, "Whether Object[] should be used instead primitive arrays."),
-    USE_SHARED_COOKIE_STORE("use_shared_cookie_store", false, "Whether to use shared cookie to store among all http clients are not"),
+    USE_SHARED_COOKIE_STORE("useSharedCookieStore", false, "Whether to use shared cookie to store among all http clients of db are not"),
     MAX_COMPRESS_BUFFER_SIZE("maxCompressBufferSize", 1024*1024, ""),
 
     USE_SERVER_TIME_ZONE("use_server_time_zone", true, "Whether to use timezone from server. On connection init select timezone() will be executed"),

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -56,6 +56,7 @@ public class ClickHouseProperties {
     private String useTimeZone;
     private boolean useServerTimeZoneForDates;
     private boolean useObjectsInArrays;
+    // the shared cookie store is scoped to a database
     private boolean useSharedCookieStore;
 
     // queries settings

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -56,6 +56,7 @@ public class ClickHouseProperties {
     private String useTimeZone;
     private boolean useServerTimeZoneForDates;
     private boolean useObjectsInArrays;
+    private boolean useSharedCookieStore;
 
     // queries settings
     private Integer maxParallelReplicas;
@@ -130,6 +131,7 @@ public class ClickHouseProperties {
         this.useTimeZone = (String)getSetting(info, ClickHouseConnectionSettings.USE_TIME_ZONE);
         this.useServerTimeZoneForDates = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE_FOR_DATES);
         this.useObjectsInArrays = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_OBJECTS_IN_ARRAYS);
+        this.useSharedCookieStore = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_SHARED_COOKIE_STORE);
         this.clientName = (String)getSetting(info, ClickHouseConnectionSettings.CLIENT_NAME);
         this.useNewParser = (Boolean)getSetting(info, ClickHouseConnectionSettings.USE_NEW_PARSER);
 
@@ -199,6 +201,7 @@ public class ClickHouseProperties {
         ret.put(ClickHouseConnectionSettings.USE_TIME_ZONE.getKey(), String.valueOf(useTimeZone));
         ret.put(ClickHouseConnectionSettings.USE_SERVER_TIME_ZONE_FOR_DATES.getKey(), String.valueOf(useServerTimeZoneForDates));
         ret.put(ClickHouseConnectionSettings.USE_OBJECTS_IN_ARRAYS.getKey(), String.valueOf(useObjectsInArrays));
+        ret.put(ClickHouseConnectionSettings.USE_SHARED_COOKIE_STORE.getKey(), String.valueOf(useSharedCookieStore));
         ret.put(ClickHouseConnectionSettings.CLIENT_NAME.getKey(), String.valueOf(clientName));
         ret.put(ClickHouseConnectionSettings.USE_NEW_PARSER.getKey(), String.valueOf(useNewParser));
 
@@ -271,6 +274,7 @@ public class ClickHouseProperties {
         setUseTimeZone(properties.useTimeZone);
         setUseServerTimeZoneForDates(properties.useServerTimeZoneForDates);
         setUseObjectsInArrays(properties.useObjectsInArrays);
+        setUseSharedCookieStore(properties.useSharedCookieStore);
         setClientName(properties.clientName);
         setUseNewParser(properties.useNewParser);
         setMaxParallelReplicas(properties.maxParallelReplicas);
@@ -686,6 +690,14 @@ public class ClickHouseProperties {
 
     public void setUseObjectsInArrays(boolean useObjectsInArrays) {
         this.useObjectsInArrays = useObjectsInArrays;
+    }
+
+    public boolean isUseSharedCookieStore() {
+        return useSharedCookieStore;
+    }
+
+    public void setUseSharedCookieStore(boolean useSharedCookieStore) {
+        this.useSharedCookieStore = useSharedCookieStore;
     }
 
     public String getClientName() {

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/util/ClickHouseCookieStoreProvider.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/util/ClickHouseCookieStoreProvider.java
@@ -1,0 +1,29 @@
+package ru.yandex.clickhouse.util;
+
+import org.apache.http.client.CookieStore;
+import org.apache.http.impl.client.BasicCookieStore;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class ClickHouseCookieStoreProvider {
+    private static final Map<String, CookieStore> cookieStoreMap = new ConcurrentHashMap<>();
+
+    public CookieStore getCookieStore(ClickHouseProperties properties) {
+        return hasValidProperties(properties) && properties.isUseSharedCookieStore() ?
+                cookieStoreMap.computeIfAbsent(getCookieStoreKey(properties), k -> new BasicCookieStore()) :
+                null;
+    }
+
+    private boolean hasValidProperties(ClickHouseProperties properties) {
+        return properties != null
+                && !Utils.isNullOrEmptyString(properties.getHost())
+                && properties.getPort() > 0
+                && !Utils.isNullOrEmptyString(properties.getDatabase());
+    }
+
+    private String getCookieStoreKey(ClickHouseProperties properties) {
+        return String.format("%s:%s/%s", properties.getHost(), properties.getPort(), properties.getDatabase());
+    }
+}

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilder.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilder.java
@@ -34,6 +34,7 @@ import org.apache.http.NoHttpResponseException;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.AuthCache;
+import org.apache.http.client.CookieStore;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.RequestConfig;
@@ -47,6 +48,7 @@ import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
 import org.apache.http.impl.DefaultConnectionReuseStrategy;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
+import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
@@ -60,6 +62,7 @@ import ru.yandex.clickhouse.util.ssl.NonValidatingTrustManager;
 
 public class ClickHouseHttpClientBuilder {
 
+    private static final CookieStore SHARED_COOKIE_STORE = new BasicCookieStore();
     private final ClickHouseProperties properties;
 
     public ClickHouseHttpClientBuilder(ClickHouseProperties properties) {
@@ -76,6 +79,7 @@ public class ClickHouseHttpClientBuilder {
                 .setDefaultHeaders(getDefaultHeaders())
                 .setDefaultCredentialsProvider(getDefaultCredentialsProvider())
                 .disableContentCompression() // gzip is not needed. Use lz4 when compress=1
+                .setDefaultCookieStore(getCookieStore())
                 .disableRedirectHandling();
 
         String clientName = properties != null ? properties.getClientName() : null;
@@ -251,6 +255,10 @@ public class ClickHouseHttpClientBuilder {
                 properties.getUser() != null  ? properties.getUser() : "default",
                 properties.getPassword() != null ? properties.getPassword() : ""));
         return credsProvider;
+    }
+
+    private CookieStore getCookieStore() {
+        return properties.isUseSharedCookieStore() ? SHARED_COOKIE_STORE : new BasicCookieStore();
     }
 
     private static HttpHost getTargetHost(ClickHouseProperties props) {

--- a/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/util/ClickHouseCookieStoreProviderTest.java
+++ b/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/util/ClickHouseCookieStoreProviderTest.java
@@ -1,0 +1,71 @@
+package ru.yandex.clickhouse.util;
+
+import org.testng.annotations.Test;
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class ClickHouseCookieStoreProviderTest {
+    ClickHouseCookieStoreProvider cookieStoreProvider = new ClickHouseCookieStoreProvider();
+
+    @Test
+    public void testCookieStoreProviderWithNullHost() {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setUseSharedCookieStore(true);
+        props.setPort(8080);
+        props.setDatabase("default");
+        assertNull(cookieStoreProvider.getCookieStore(props));
+    }
+
+    @Test
+    public void testCookieStoreProviderWithInvalidPort() {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setUseSharedCookieStore(true);
+        props.setHost("127.0.0.1");
+        props.setPort(0);
+        props.setDatabase("default");
+        assertNull(cookieStoreProvider.getCookieStore(props));
+    }
+
+    @Test
+    public void testCookieStoreProviderWithNullDBName() {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setUseSharedCookieStore(true);
+        props.setHost("127.0.0.1");
+        props.setPort(0);
+        assertNull(cookieStoreProvider.getCookieStore(props));
+    }
+
+    @Test
+    public void testCookieStoreProviderWithSameDBAndSharedCookieStore() {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setUseSharedCookieStore(true);
+        props.setHost("127.0.0.1");
+        props.setPort(0);
+        props.setDatabase("default");
+        assertEquals(cookieStoreProvider.getCookieStore(props), cookieStoreProvider.getCookieStore(props));
+    }
+
+    @Test
+    public void testCookieStoreProviderWithSameDBAndPrivateCookieStore() {
+        ClickHouseProperties props = new ClickHouseProperties();
+        props.setUseSharedCookieStore(true);
+        props.setHost("127.0.0.1");
+        props.setPort(0);
+        props.setDatabase("default");
+        assertEquals(cookieStoreProvider.getCookieStore(props), cookieStoreProvider.getCookieStore(props));
+    }
+
+    @Test
+    public void testCookieStoreProviderWithDiffDB() {
+        ClickHouseProperties props1 = new ClickHouseProperties();
+        props1.setUseSharedCookieStore(true);
+        props1.setHost("127.0.0.1");
+        props1.setPort(0);
+        props1.setDatabase("default1");
+        ClickHouseProperties props2 = new ClickHouseProperties(props1);
+        props2.setDatabase("default2");
+        assertEquals(cookieStoreProvider.getCookieStore(props1), cookieStoreProvider.getCookieStore(props2));
+    }
+}

--- a/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/util/ClickHouseCookieStoreProviderTest.java
+++ b/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/util/ClickHouseCookieStoreProviderTest.java
@@ -4,6 +4,8 @@ import org.testng.annotations.Test;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 public class ClickHouseCookieStoreProviderTest {
@@ -42,19 +44,20 @@ public class ClickHouseCookieStoreProviderTest {
         ClickHouseProperties props = new ClickHouseProperties();
         props.setUseSharedCookieStore(true);
         props.setHost("127.0.0.1");
-        props.setPort(0);
+        props.setPort(8080);
         props.setDatabase("default");
+        assertNotNull(cookieStoreProvider.getCookieStore(props));
         assertEquals(cookieStoreProvider.getCookieStore(props), cookieStoreProvider.getCookieStore(props));
     }
 
     @Test
-    public void testCookieStoreProviderWithSameDBAndPrivateCookieStore() {
+    public void testCookieStoreProviderWithPrivateCookieStore() {
         ClickHouseProperties props = new ClickHouseProperties();
-        props.setUseSharedCookieStore(true);
+        props.setUseSharedCookieStore(false);
         props.setHost("127.0.0.1");
-        props.setPort(0);
+        props.setPort(8080);
         props.setDatabase("default");
-        assertEquals(cookieStoreProvider.getCookieStore(props), cookieStoreProvider.getCookieStore(props));
+        assertNull(cookieStoreProvider.getCookieStore(props));
     }
 
     @Test
@@ -62,10 +65,10 @@ public class ClickHouseCookieStoreProviderTest {
         ClickHouseProperties props1 = new ClickHouseProperties();
         props1.setUseSharedCookieStore(true);
         props1.setHost("127.0.0.1");
-        props1.setPort(0);
+        props1.setPort(8080);
         props1.setDatabase("default1");
         ClickHouseProperties props2 = new ClickHouseProperties(props1);
         props2.setDatabase("default2");
-        assertEquals(cookieStoreProvider.getCookieStore(props1), cookieStoreProvider.getCookieStore(props2));
+        assertNotEquals(cookieStoreProvider.getCookieStore(props1), cookieStoreProvider.getCookieStore(props2));
     }
 }

--- a/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilderTest.java
+++ b/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/util/ClickHouseHttpClientBuilderTest.java
@@ -110,6 +110,7 @@ public class ClickHouseHttpClientBuilderTest {
         ClickHouseProperties props = new ClickHouseProperties();
         props.setHost("localhost");
         props.setPort(mockServer.port());
+        props.setDatabase("default");
         props.setUseSharedCookieStore(true);
         CloseableHttpClient client = new ClickHouseHttpClientBuilder(props).buildClient();
         String cookie = "AWS-ALB=random-value-" + Instant.now().toEpochMilli();


### PR DESCRIPTION
Allows to share same cookie store among http clients of same database. This feature allows users to use [AWS ALB ](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/sticky-sessions.html) sticky sessions.

With the help of sticky sessions, we can direct all the queries from a given client to same CH node. We can achieve `read your writes` consistency at each client level (Client will always see the writes it made as we are hitting the same CH node - assuming other CH properties are appropriately configured). 