### PR TITLE
Return proper error when user tries to enable transactions

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -209,7 +209,10 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
-
+        if (autoCommit) {
+            return;
+        }
+        throw new SQLFeatureNotSupportedException("Transactions are not supported");
     }
 
     @Override
@@ -219,12 +222,12 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     @Override
     public void commit() throws SQLException {
-
+        throw new SQLException("Cannot commit when auto-commit is enabled");
     }
 
     @Override
     public void rollback() throws SQLException {
-
+        throw new SQLException("Cannot commit when auto-commit is enabled");
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -214,7 +214,7 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     @Override
     public boolean getAutoCommit() throws SQLException {
-        return false;
+        return true;
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -227,7 +227,7 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     @Override
     public void rollback() throws SQLException {
-        throw new SQLException("Cannot commit when auto-commit is enabled");
+        throw new SQLException("Cannot rollback when auto-commit is enabled");
     }
 
     @Override


### PR DESCRIPTION
Transactions are not supported, so `setAutoCommit(false)` should fail,
as it does not provide the isolation or rollback-ability requested by
the caller.

`commit()` and `rollback()` should fail in auto-commit mode (this is
what PostgreSQL JDBC driver does).