### PR TITLE
when parsedStmt isDDL,Database is should not ignore

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -709,7 +709,8 @@ public class ClickHouseStatementImpl extends ConfigurableApi<ClickHouseStatement
         Map<String, String> additionalRequestParams
     ) throws ClickHouseException {
         String sql = parsedStmt.getSQL();
-        boolean ignoreDatabase = parsedStmt.isRecognized() && !parsedStmt.isDML();
+        //when parsedStmt isDDL,Database is should not ignore
+        boolean ignoreDatabase = parsedStmt.isRecognized() && !parsedStmt.isDML()&& !parsedStmt.isDDL();
         
         log.debug("Executing SQL: {}", sql);
 


### PR DESCRIPTION
if we ignore the Database,Explicit assignment database name in sql is in need,That  maybe unreasonable.
DDL语句需要注入数据库名
sql example:
String sql="ALTER TABLE HITS02 ADD COLUMN Added1 UInt32 FIRST";