### PR TITLE
Fixed the content type in requests with external data

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -738,7 +738,9 @@ public class ClickHouseStatementImpl extends ConfigurableApi<ClickHouseStatement
             requestEntity = new StringEntity(sql, StandardCharsets.UTF_8);
         } else {
             MultipartEntityBuilder entityBuilder = MultipartEntityBuilder.create();
-            entityBuilder.addTextBody("query", sql);
+
+            ContentType queryContentType = ContentType.create(ContentType.TEXT_PLAIN.getMimeType(), StandardCharsets.UTF_8);
+            entityBuilder.addTextBody("query", sql, queryContentType);
 
             try {
                 for (ClickHouseExternalData externalDataItem : externalData) {


### PR DESCRIPTION
Added an explicit indication of the text/plain content type with UTF-8 encoding for an SQL query in MultipartEntityBuilder, otherwise the text/plain content type with ISO_8859_1 encoding is used and Latin letters turn into'??????'