### PR TITLE
Replace rbm dependency to fix package problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
                 <version>${lz4.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.roaringbitmap</groupId>
+                <groupId>com.github.RoaringBitmap.RoaringBitmap</groupId>
                 <artifactId>RoaringBitmap</artifactId>
                 <version>${roaring-bitmap.version}</version>
             </dependency>


### PR DESCRIPTION
`com.github.RoaringBitmap:RoaringBitmap` and `com.github.RoaringBitmap.RoaringBitmap:RoaringBitmap` will generate the same jar file name "RoaringBitmap-0.9.9.jar" as below, and the latter is an empty jar.
![image](https://user-images.githubusercontent.com/26023240/125557276-6006d049-ed20-4d78-a39a-aa28d9f8ec1a.png)

Only one jar will remain in `target/lib` after `mvn compile` since their name are identical, sadly the empty jar replaced the other, so I got a `java.lang.NoClassDefFoundError: org/roaringbitmap/RoaringBitmap`.
![image](https://user-images.githubusercontent.com/26023240/125557950-d2faf416-8597-4501-97d4-c00c9b453653.png)

I think we should use `com.github.RoaringBitmap.RoaringBitmap:RoaringBitmap` rather than `com.github.RoaringBitmap:RoaringBitmap` to avoid this problem.

