### PR TITLE
Change log level for driver registration

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseDriver.java
@@ -46,7 +46,7 @@ public class ClickHouseDriver implements Driver {
         } catch (SQLException e) {
             throw new RuntimeException(e);
         }
-        logger.info("Driver registered");
+        logger.debug("Driver registered");
     }
 
     @Override


### PR DESCRIPTION
It looks like the log level is `INFO` for the driver registration. If you look at most JDBC implementations, they use DEBUG in this exact case since the registration is expected when we load ClickhouseDriver in the runtime. 