### PR TITLE
Remove redundant data transfer timeout property

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseConnectionSettings.java
@@ -19,14 +19,6 @@ public enum ClickHouseConnectionSettings implements DriverPropertyCreator {
     CHECK_FOR_REDIRECTS("check_for_redirects", false, "whether we should check for 307 redirect using GET before sending POST to given URL"),
     MAX_REDIRECTS("max_redirects", 5, "number of redirect checks before using last URL"),
 
-    /*
-    *
-    * */
-    DATA_TRANSFER_TIMEOUT( "dataTransferTimeout", 10000, "Timeout for data transfer. "
-            + " socketTimeout + dataTransferTimeout is sent to ClickHouse as max_execution_time. "
-            + " ClickHouse rejects request execution if its time exceeds max_execution_time"),
-
-
     /**
      * for ConnectionManager
      */

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/settings/ClickHouseProperties.java
@@ -16,7 +16,6 @@ public class ClickHouseProperties {
     private int apacheBufferSize;
     private int socketTimeout;
     private int connectionTimeout;
-    private int dataTransferTimeout;
     private int timeToLiveMillis;
     private int defaultMaxPerRoute;
     private int maxTotal;
@@ -110,7 +109,6 @@ public class ClickHouseProperties {
         this.apacheBufferSize = (Integer)getSetting(info, ClickHouseConnectionSettings.APACHE_BUFFER_SIZE);
         this.socketTimeout = (Integer)getSetting(info, ClickHouseConnectionSettings.SOCKET_TIMEOUT);
         this.connectionTimeout = (Integer)getSetting(info, ClickHouseConnectionSettings.CONNECTION_TIMEOUT);
-        this.dataTransferTimeout = (Integer)getSetting(info, ClickHouseConnectionSettings.DATA_TRANSFER_TIMEOUT);
         this.timeToLiveMillis = (Integer)getSetting(info, ClickHouseConnectionSettings.TIME_TO_LIVE_MILLIS);
         this.defaultMaxPerRoute = (Integer)getSetting(info, ClickHouseConnectionSettings.DEFAULT_MAX_PER_ROUTE);
         this.maxTotal = (Integer)getSetting(info, ClickHouseConnectionSettings.MAX_TOTAL);
@@ -178,7 +176,6 @@ public class ClickHouseProperties {
         ret.put(ClickHouseConnectionSettings.APACHE_BUFFER_SIZE.getKey(), String.valueOf(apacheBufferSize));
         ret.put(ClickHouseConnectionSettings.SOCKET_TIMEOUT.getKey(), String.valueOf(socketTimeout));
         ret.put(ClickHouseConnectionSettings.CONNECTION_TIMEOUT.getKey(), String.valueOf(connectionTimeout));
-        ret.put(ClickHouseConnectionSettings.DATA_TRANSFER_TIMEOUT.getKey(), String.valueOf(dataTransferTimeout));
         ret.put(ClickHouseConnectionSettings.TIME_TO_LIVE_MILLIS.getKey(), String.valueOf(timeToLiveMillis));
         ret.put(ClickHouseConnectionSettings.DEFAULT_MAX_PER_ROUTE.getKey(), String.valueOf(defaultMaxPerRoute));
         ret.put(ClickHouseConnectionSettings.MAX_TOTAL.getKey(), String.valueOf(maxTotal));
@@ -249,7 +246,6 @@ public class ClickHouseProperties {
         setApacheBufferSize(properties.apacheBufferSize);
         setSocketTimeout(properties.socketTimeout);
         setConnectionTimeout(properties.connectionTimeout);
-        setDataTransferTimeout(properties.dataTransferTimeout);
         setTimeToLiveMillis(properties.timeToLiveMillis);
         setDefaultMaxPerRoute(properties.defaultMaxPerRoute);
         setMaxTotal(properties.maxTotal);
@@ -552,14 +548,6 @@ public class ClickHouseProperties {
 
     public void setConnectionTimeout(int connectionTimeout) {
         this.connectionTimeout = connectionTimeout;
-    }
-
-    public int getDataTransferTimeout() {
-        return dataTransferTimeout;
-    }
-
-    public void setDataTransferTimeout(int dataTransferTimeout) {
-        this.dataTransferTimeout = dataTransferTimeout;
     }
 
     public String getUser() {


### PR DESCRIPTION
`dataTransferTimeout` property was only used to set `max_execution_time` as a sum of `socket_timeout` and `dataTransferTimeout`. From _6851fd74c06174819aca842a1634c2abc33e99b5_ behavior changed: `max_execution_time` is set as `max_execution_time`, has nothing to do with socket or data transfer timeouts.

(and also there are some misleading old docs about it)