### PR TITLE
ConfigurableApi.addExternalData and withExternalData

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnection.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnection.java
@@ -1,5 +1,7 @@
 package ru.yandex.clickhouse;
 
+import ru.yandex.clickhouse.settings.ClickHouseProperties;
+
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.TimeZone;
@@ -9,6 +11,8 @@ public interface ClickHouseConnection extends Connection {
     TimeZone getServerTimeZone();
     
     TimeZone getTimeZone();
+
+    ClickHouseProperties getProperties();
 
     @Override
     ClickHouseStatement createStatement() throws SQLException;

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseConnectionImpl.java
@@ -514,6 +514,11 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
         return 0;
     }
 
+    @Override
+    public ClickHouseProperties getProperties() {
+        return new ClickHouseProperties(properties);
+    }
+
     void cleanConnections() {
         httpclient.getConnectionManager().closeExpiredConnections();
         httpclient.getConnectionManager().closeIdleConnections(2 * properties.getSocketTimeout(), TimeUnit.MILLISECONDS);
@@ -521,9 +526,5 @@ public class ClickHouseConnectionImpl implements ClickHouseConnection {
 
     String getUrl() {
         return url;
-    }
-
-    ClickHouseProperties getProperties() {
-        return properties;
     }
 }

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ClickHouseStatementImpl.java
@@ -723,6 +723,9 @@ public class ClickHouseStatementImpl extends ConfigurableApi<ClickHouseStatement
                         ? new EnumMap<ClickHouseQueryParam, String>(ClickHouseQueryParam.class)
                         : additionalClickHouseDBParams);
 
+        // merge request externalData with those set in ConfigurableApi
+        externalData = getAllExternalData(externalData);
+
         URI uri = buildRequestUri(
             null,
             externalData,
@@ -801,6 +804,14 @@ public class ClickHouseStatementImpl extends ConfigurableApi<ClickHouseStatement
             log.info("Error sql: {}", sql);
             throw ClickHouseExceptionSpecifier.specify(e, properties.getHost(), properties.getPort());
         }
+    }
+
+    private List<ClickHouseExternalData> getAllExternalData(List<ClickHouseExternalData> requestExternalData) {
+        List<ClickHouseExternalData> res = new ArrayList<>(getAdditionalExternalData());
+        if (requestExternalData != null) {
+            res.addAll(requestExternalData);
+        }
+        return res;
     }
 
     URI buildRequestUri(

--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ConfigurableApi.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/ConfigurableApi.java
@@ -10,6 +10,7 @@ class ConfigurableApi<T> {
     protected final ClickHouseStatementImpl statement;
     private Map<ClickHouseQueryParam, String> additionalDBParams = new HashMap<ClickHouseQueryParam, String>();
     private Map<String, String> additionalRequestParams = new HashMap<String, String>();
+    private List<ClickHouseExternalData> additionalExternalData = new ArrayList<>();
 
     ConfigurableApi(ClickHouseStatementImpl statement) {
         this.statement = statement;
@@ -21,6 +22,10 @@ class ConfigurableApi<T> {
 
     Map<ClickHouseQueryParam, String> getAdditionalDBParams() {
         return additionalDBParams;
+    }
+
+    List<ClickHouseExternalData> getAdditionalExternalData() {
+        return additionalExternalData;
     }
 
     public T addDbParam(ClickHouseQueryParam param, String value) {
@@ -59,4 +64,16 @@ class ConfigurableApi<T> {
         return (T) this;
     }
 
+    public T addExternalData(ClickHouseExternalData data) {
+        additionalExternalData.add(data);
+        return (T) this;
+    }
+
+    public T withExternalData(List<ClickHouseExternalData> data) {
+        additionalExternalData = new ArrayList<>();
+        if (data != null) {
+            additionalExternalData.addAll(data);
+        }
+        return (T) this;
+    }
 }

--- a/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
+++ b/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/integration/ClickHouseStatementImplTest.java
@@ -28,11 +28,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-import ru.yandex.clickhouse.ClickHouseConnection;
-import ru.yandex.clickhouse.ClickHouseContainerForTest;
-import ru.yandex.clickhouse.ClickHouseDataSource;
-import ru.yandex.clickhouse.ClickHouseExternalData;
-import ru.yandex.clickhouse.ClickHouseStatement;
+import ru.yandex.clickhouse.*;
 import ru.yandex.clickhouse.settings.ClickHouseProperties;
 import ru.yandex.clickhouse.settings.ClickHouseQueryParam;
 import ru.yandex.clickhouse.util.ClickHouseVersionNumberUtil;
@@ -250,6 +246,20 @@ public class ClickHouseStatementImplTest {
         Assert.assertEquals(cnt, 99500);
     }
 
+    @Test
+    public void testAdditionalExternalData() throws SQLException {
+        try (ClickHouseStatementImpl stmt = connection.createStatement().unwrap(ClickHouseStatementImpl.class)) {
+            stmt.addExternalData(new ClickHouseExternalData(
+                    "data",
+                    new ByteArrayInputStream("1\n2\n3\n".getBytes())
+            ).withStructure("val UInt64"));
+
+            ResultSet rs = stmt.executeQuery("select count() from data");
+            rs.next();
+
+            Assert.assertEquals(rs.getInt(1), 3);
+        }
+    }
 
     @Test
     public void testResultSetWithExtremes() throws SQLException {


### PR DESCRIPTION
I added `addExternal/withExternalData` methods in `ConfigurableApi`, similar to `addDbParam `and `options`. I also made `ClickHouseConnection.getProperties()` public.

These two changes simplify the way I'm using Clickhouse JDBC driver in my project.
