### PR TITLE
Fixes a type parsing error when the type ends with multiple closing parentheses

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/response/ClickHouseColumnInfo.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/response/ClickHouseColumnInfo.java
@@ -152,7 +152,7 @@ public final class ClickHouseColumnInfo {
         return args
             .substring(
                 args.indexOf("(", currIdx) + 1,
-                args.indexOf(")", currIdx))
+                args.lastIndexOf(")"))
             .split("\\s*,\\s*");
     }
 


### PR DESCRIPTION
When I query data from a table that has a column type of `Map(String, FixedString(N)),` the following exception occurs:

```java

org.springframework.jdbc.UncategorizedSQLException: StatementCallback; uncategorized SQLException for SQL [select * from tutorial.t_test]; SQL state [null]; error code [1002]; ClickHouse exception, code: 1002, host: 0.0.0.0, port: 8123; String index out of range: -13; nested exception is ru.yandex.clickhouse.except.ClickHouseUnknownException: ClickHouse exception, code: 1002, host: 0.0.0.0, port: 8123; String index out of range: -13
	at org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1542) ~[spring-jdbc-5.3.9.jar:5.3.9]
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:393) ~[spring-jdbc-5.3.9.jar:5.3.9]
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:465) ~[spring-jdbc-5.3.9.jar:5.3.9]
	at org.springframework.jdbc.core.JdbcTemplate.query(JdbcTemplate.java:475) ~[spring-jdbc-5.3.9.jar:5.3.9]
	at org.springframework.jdbc.core.JdbcTemplate.queryForList(JdbcTemplate.java:525) ~[spring-jdbc-5.3.9.jar:5.3.9]
Caused by: ru.yandex.clickhouse.except.ClickHouseUnknownException: ClickHouse exception, code: 1002, host: 0.0.0.0, port: 8123; String index out of range: -13
	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.getException(ClickHouseExceptionSpecifier.java:92) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:56) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.except.ClickHouseExceptionSpecifier.specify(ClickHouseExceptionSpecifier.java:25) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:351) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:324) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:319) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:314) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at com.alibaba.druid.filter.FilterChainImpl.statement_executeQuery(FilterChainImpl.java:2883) ~[druid-1.2.5.jar:1.2.5]
	at com.alibaba.druid.filter.FilterAdapter.statement_executeQuery(FilterAdapter.java:2514) ~[druid-1.2.5.jar:1.2.5]
	at com.alibaba.druid.filter.FilterEventAdapter.statement_executeQuery(FilterEventAdapter.java:302) ~[druid-1.2.5.jar:1.2.5]
	at com.alibaba.druid.filter.FilterChainImpl.statement_executeQuery(FilterChainImpl.java:2880) ~[druid-1.2.5.jar:1.2.5]
	at com.alibaba.druid.proxy.jdbc.StatementProxyImpl.executeQuery(StatementProxyImpl.java:221) ~[druid-1.2.5.jar:1.2.5]
	at com.alibaba.druid.pool.DruidPooledStatement.executeQuery(DruidPooledStatement.java:296) ~[druid-1.2.5.jar:1.2.5]
	at org.springframework.jdbc.core.JdbcTemplate$1QueryStatementCallback.doInStatement(JdbcTemplate.java:452) ~[spring-jdbc-5.3.9.jar:5.3.9]
	at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:381) ~[spring-jdbc-5.3.9.jar:5.3.9]
	... 71 common frames omitted
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: -13
	at java.lang.String.substring(String.java:1967) ~[na:1.8.0_275]
	at ru.yandex.clickhouse.response.ClickHouseColumnInfo.splitArgs(ClickHouseColumnInfo.java:153) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.response.ClickHouseColumnInfo.parse(ClickHouseColumnInfo.java:131) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.response.ClickHouseColumnInfo.parse(ClickHouseColumnInfo.java:138) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.response.ClickHouseResultSet.<init>(ClickHouseResultSet.java:125) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.createResultSet(ClickHouseStatementImpl.java:1121) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.updateResult(ClickHouseStatementImpl.java:224) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	at ru.yandex.clickhouse.ClickHouseStatementImpl.executeQuery(ClickHouseStatementImpl.java:344) ~[clickhouse-jdbc-0.3.1.jar:0.3.1]
	... 82 common frames omitted

```

There seems a bug in the following code snippet of `ClickHouseColumnInfo.java`: 

```java
private static String[] splitArgs(String args, int currIdx) {
        return args
            .substring(
                args.indexOf("(", currIdx) + 1,
                args.indexOf(")", currIdx))     // error code
            .split("\\s*,\\s*");
    } 
```
If a type ends with multiple closing parentheses, we should delete the last closing parentheses rather than the first one.

