### PR TITLE
Update build config for repackaging 3rd party libs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           find . -type f -name "pom.xml" -exec sed -i -e 's|${revision}|${{ steps.version.outputs.value }}|g' \
             -e 's|^\(    <version>\).*\(</version>\)$|\1${{ steps.version.outputs.value }}\2|' \
-            -e 's|${parent.groupId}|tech.clickhouse|g' -e 's|.*argLine.*timezone=.*||g' '{}' \;
+            -e 's|${parent.groupId}|com.clickhouse|g' '{}' \;
           find . -type f -name "log4j.*" -exec rm -fv '{}' \;
       - name: Build project
         run: |
@@ -99,7 +99,7 @@ jobs:
         run: |
           find . -type f -name "pom.xml" -exec sed -i -e 's|${revision}|${{ github.event.inputs.version }}|g' \
             -e 's|^\(    <version>\).*\(</version>\)$|\1${{ github.event.inputs.driver }}\2|' \
-            -e 's|${parent.groupId}|tech.clickhouse|g' -e 's|.*argLine.*timezone=.*||g' '{}' \;
+            -e 's|${parent.groupId}|com.clickhouse|g' '{}' \;
           find . -type f -name "log4j.*" -exec rm -fv '{}' \;
         continue-on-error: true
       - name: Install driver as needed

--- a/.github/workflows/release_3rd_party_libs.yml
+++ b/.github/workflows/release_3rd_party_libs.yml
@@ -6,11 +6,11 @@ on:
       version:
         description: "Release version"
         required: true
-        default: "0.3.2-SNAPSHOT"
+        default: "1.0.0"
 
 jobs:
   release:
-    name: "Build and Publish Artifact"
+    name: "Build and Publish Repackaged 3rd Party Libraries"
     runs-on: "ubuntu-latest"
 
     steps:
@@ -19,7 +19,7 @@ jobs:
       - name: Install Java and Maven
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 9
       - name: Update pom files and reduce logs
         run: |
           find . -type f -name "pom.xml" -exec sed -i -e 's|${revision}|${{ github.event.inputs.version }}|g' \
@@ -29,19 +29,10 @@ jobs:
       - name: Release Maven package
         uses: samuelmeuli/action-maven-publish@v1
         with:
+          directory: third-party-libraries
           maven_profiles: release
           maven_args: -q --batch-mode
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_USER }}
           nexus_password: ${{ secrets.SONATYPE_PASSWD }}
-      - name: Create Pre-release on Github
-        uses: "zhicwu/action-automatic-releases@latest"
-        with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "v${{ github.event.inputs.version }}"
-          prerelease: true
-          title: "Release v${{ github.event.inputs.version }}"
-          files: |
-            LICENSE
-            **/target/clickhouse*.jar

--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -56,7 +56,6 @@ jobs:
             ${{ runner.os }}-build-
       - name: Test using Maven
         run: |
-          find . -type f -name "pom.xml" -exec sed -i -e 's|.*argLine.*timezone=.*||g' '{}' \;
           mvn --batch-mode --update-snapshots \
             -DclickhouseTimezone=${{ matrix.serverTz }} \
             -DclickhouseVersion=21.8 \

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -85,7 +85,6 @@ jobs:
       - name: Verify with Maven
         if: steps.check.outputs.triggered == 'true'
         run: |
-          find . -type f -name "pom.xml" -exec sed -i -e 's|.*argLine.*timezone=.*||g' '{}' \;
           mvn --batch-mode --update-snapshots \
             -DclickhouseVersion=${{ fromJSON(steps.commented.outputs.result).clickhouse }} \
             -DclickhouseTimezone=Asia/Chongqing \
@@ -129,7 +128,6 @@ jobs:
         continue-on-error: true
       - name: Verify with Maven
         run: |
-          find . -type f -name "pom.xml" -exec sed -i -e 's|.*argLine.*timezone=.*||g' '{}' \;
           mvn --batch-mode --update-snapshots \
             -DclickhouseVersion=${{ github.event.inputs.clickhouse }} \
             -DclickhouseTimezone=${{ github.event.inputs.chTz }} \

--- a/third-party-libraries/io.grpc/pom.xml
+++ b/third-party-libraries/io.grpc/pom.xml
@@ -5,21 +5,18 @@
     <parent>
         <groupId>com.clickhouse</groupId>
         <artifactId>third-party-libraries</artifactId>
-        <version>1.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>io.grpc</artifactId>
-    <version>${grpc.version}</version>
-    <name>Repackaged grpc-java for JPMS support</name>
-    <description>A Java modules compatible re-packaging of grpc-java</description>
+    <version>${revision}</version>
+    <packaging>jar</packaging>
+
+    <name>${project.artifactId}</name>
+    <description>Repackaged grpc-java for JPMS support</description>
+    <url>https://github.com/ClickHouse/clickhouse-jdbc/tree/master/third-party-libraries/io.grpc</url>
 
     <dependencies>
-        <!--
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-        </dependency>
-        -->
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
@@ -72,7 +69,6 @@
 
     <build>
         <plugins>
-            <!-- create the base JAR removing all of the dummy classes -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -82,8 +78,6 @@
                     </excludes>
                 </configuration>
             </plugin>
-
-            <!-- create the shaded JAR -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
@@ -114,14 +108,6 @@
                                     </excludes>
                                 </filter>
                             </filters>
-                            <!-- artifactSet>
-                                <includes>
-                                    <include>io.grpc:*</include>
-                                    <include>com.google.instrumentation:instrumentation-api</include>
-                                    <include>io.opencensus:opencensus-api</include>
-                                    <include>io.opencensus:opencensus-contrib-grpc-metrics</include>
-                                </includes>
-                            </artifactSet -->
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer" />
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />

--- a/third-party-libraries/org.roaringbitmap/pom.xml
+++ b/third-party-libraries/org.roaringbitmap/pom.xml
@@ -4,15 +4,15 @@
     <parent>
         <groupId>com.clickhouse</groupId>
         <artifactId>third-party-libraries</artifactId>
-        <version>1.0.0</version>
+        <version>${revision}</version>
     </parent>
 
     <artifactId>org.roaringbitmap</artifactId>
-    <version>${roaring-bitmap.version}</version>
+    <version>${revision}</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
-    <description>Repackaged RoaringBitmap for JPMS compatibility</description>
+    <description>Repackaged RoaringBitmap for JPMS support</description>
     <url>https://github.com/ClickHouse/clickhouse-jdbc/tree/master/third-party-libraries/org.roaringbitmap</url>
 
     <dependencies>

--- a/third-party-libraries/pom.xml
+++ b/third-party-libraries/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.clickhouse</groupId>
     <artifactId>third-party-libraries</artifactId>
-    <version>1.0.0</version>
+    <version>${revision}</version>
     <packaging>pom</packaging>
 
     <name>${project.artifactId}</name>
@@ -68,6 +68,7 @@
     </distributionManagement>
 
     <properties>
+        <revision>1.0.0</revision>
         <project.current.year>2021</project.current.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -85,6 +86,7 @@
         <shade-plugin.version>3.2.4</shade-plugin.version>
         <source-plugin.version>3.2.1</source-plugin.version>
         <jar-plugin.version>3.2.0</jar-plugin.version>
+        <javadoc-plugin.version>3.2.0</javadoc-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -190,6 +192,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${javadoc-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>${shade-plugin.version}</version>
                 </plugin>
@@ -256,6 +263,18 @@
                                 <id>attach-sources</id>
                                 <goals>
                                     <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
* use consistent version for all repackaged 3rd party libs
* update group id to `com.clickhouse` instead of `tech.clickhouse`
* remove useless build steps
* add new job to release 3rd party libs