### PR TITLE
Fix version check for system.tables.comment column in DatabaseMetaData.getTables

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
@@ -752,7 +752,7 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
         List<ResultSet> results = new ArrayList<>(databases.size());
         for (String database : databases) {
             Map<String, String> params = new HashMap<>();
-            params.put("comment", connection.getServerVersion().check("[20.8,)") ? "t.comment" : "''");
+            params.put("comment", connection.getServerVersion().check("[21.6,)") ? "t.comment" : "''");
             params.put("database", ClickHouseValues.convertToQuotedString(database));
             params.put("table", ClickHouseChecker.isNullOrEmpty(tableNamePattern) ? "'%'"
                     : ClickHouseValues.convertToQuotedString(tableNamePattern));

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaDataTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaDataTest.java
@@ -2,6 +2,8 @@ package com.clickhouse.jdbc;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Locale;
 import java.util.Properties;
 
 import org.testng.Assert;
@@ -15,6 +17,28 @@ public class ClickHouseDatabaseMetaDataTest extends JdbcIntegrationTest {
         try (ClickHouseConnection conn = newConnection(props); ResultSet rs = conn.getMetaData().getTypeInfo()) {
             while (rs.next()) {
                 Assert.assertNotNull(rs.getString(1));
+            }
+        }
+    }
+
+    @Test(groups = "integration")
+    public void testTableComment() throws SQLException {
+        String tableName = "test_table_comment";
+        String tableComment = "table comments";
+        try (ClickHouseConnection conn = newConnection(new Properties());
+                Statement s = conn.createStatement()) {
+            // https://github.com/ClickHouse/ClickHouse/pull/30852
+            if (!conn.getServerVersion().check("[21.6,)")) {
+                return;
+            }
+
+            s.execute(String.format(Locale.ROOT,
+                    "drop table if exists %1$s; create table %1$s(s String) engine=Memory comment '%2$s'",
+                    tableName, tableComment));
+            try (ResultSet rs = conn.getMetaData().getTables(null, "%", tableName, null)) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getString("remarks"), tableComment);
+                Assert.assertFalse(rs.next());
             }
         }
     }


### PR DESCRIPTION
`comment` column doesn't exist in `system.tables` when version < 21.6 as far as I confirmed. 