### PR TITLE
Remove e notion from float and double values

### DIFF
--- a/clickhouse-benchmark/src/main/java/com/clickhouse/benchmark/misc/FloatBenchmark.java
+++ b/clickhouse-benchmark/src/main/java/com/clickhouse/benchmark/misc/FloatBenchmark.java
@@ -1,0 +1,69 @@
+package com.clickhouse.benchmark.misc;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import com.clickhouse.client.data.ClickHouseFloatValue;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Measurement(iterations = 10, timeUnit = TimeUnit.SECONDS, time = 1)
+@Fork(value = 2)
+@Threads(value = -1)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.SECONDS)
+public class FloatBenchmark {
+    @State(Scope.Thread)
+    public static class ValueState {
+        private final Random random = new Random();
+
+        public int samples;
+        public float num;
+
+        @Setup(Level.Trial)
+        public void setupSamples() {
+            samples = 10000000;
+        }
+
+        @Setup(Level.Iteration)
+        public void setupValue() {
+            num = random.nextFloat() * 10F;
+        }
+    }
+
+    @Benchmark
+    public long removeE(ValueState state, Blackhole consumer) {
+        for (int i = 0; i < state.samples; i++) {
+            float v = 10000000F + state.num;
+            consumer.consume(ClickHouseFloatValue.of(v).toSqlExpression());
+            // consumer.consume(v);
+        }
+
+        return 1L;
+    }
+
+    @Benchmark
+    public long normal(ValueState state, Blackhole consumer) {
+        for (int i = 0; i < state.samples; i++) {
+            float v = state.num;
+            consumer.consume(ClickHouseFloatValue.of(v).toSqlExpression());
+            // consumer.consume(v);
+        }
+
+        return 1L;
+    }
+}

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
@@ -8,6 +8,8 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -19,8 +21,10 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
@@ -79,6 +83,13 @@ public final class ClickHouseValues {
     public static final String EMPTY_ARRAY_EXPR = "[]";
 
     public static final BigDecimal NANOS = new BigDecimal(BigInteger.TEN.pow(9));
+
+    /**
+     * Whether E notion should be removed from float / double expression.
+     */
+    public static final boolean REMOVE_E_NOTION = true;
+    public static final ThreadLocal<DecimalFormat> DECIMAL_FORMATTER = REMOVE_E_NOTION ? ThreadLocal
+            .withInitial(() -> new DecimalFormat("#0.0#########", new DecimalFormatSymbols(Locale.ROOT))) : null;
 
     public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public static final DateTimeFormatter TIME_FORMATTER = new DateTimeFormatterBuilder().appendPattern("HH:mm:ss")
@@ -501,6 +512,10 @@ public final class ClickHouseValues {
             s = String.valueOf((boolean) value ? 1 : 0);
         } else if (value instanceof Character) {
             s = String.valueOf((int) ((char) value));
+        } else if (value instanceof Float) {
+            s = ClickHouseFloatValue.convertToSqlExpression((Float) value);
+        } else if (value instanceof Double) {
+            s = ClickHouseDoubleValue.convertToSqlExpression((Double) value);
         } else if (value instanceof boolean[]) {
             s = convertToString((boolean[]) value);
         } else if (value instanceof char[]) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
@@ -13,6 +13,33 @@ import com.clickhouse.client.ClickHouseValues;
  */
 public class ClickHouseDoubleValue implements ClickHouseValue {
     /**
+     * Converts double object to SQL expression.
+     *
+     * @param v double object, could be null
+     * @return SQL expression representing the double value
+     */
+    public static String convertToSqlExpression(Double v) {
+        if (v == null) {
+            return ClickHouseValues.NULL_EXPR;
+        }
+
+        double value = v.doubleValue();
+        if (v.isNaN()) {
+            return ClickHouseValues.NAN_EXPR;
+        } else if (value == Double.POSITIVE_INFINITY) {
+            return ClickHouseValues.INF_EXPR;
+        } else if (value == Double.NEGATIVE_INFINITY) {
+            return ClickHouseValues.NINF_EXPR;
+        } else if (ClickHouseValues.REMOVE_E_NOTION
+                && ((value < 0D && value > -0.001D) || (value > 0D && value < 0.001D)
+                        || value <= -10000000D || value >= 10000000D)) {
+            return ClickHouseValues.DECIMAL_FORMATTER.get().format(value);
+        }
+
+        return Double.toString(value);
+    }
+
+    /**
      * Create a new instance representing null value.
      *
      * @return new instance representing null value
@@ -174,13 +201,17 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
             return ClickHouseValues.NULL_EXPR;
         } else if (isNaN()) {
             return ClickHouseValues.NAN_EXPR;
-        } else if (value == Float.POSITIVE_INFINITY) {
+        } else if (value == Double.POSITIVE_INFINITY) {
             return ClickHouseValues.INF_EXPR;
-        } else if (value == Float.NEGATIVE_INFINITY) {
+        } else if (value == Double.NEGATIVE_INFINITY) {
             return ClickHouseValues.NINF_EXPR;
+        } else if (ClickHouseValues.REMOVE_E_NOTION
+                && ((value < 0D && value > -0.001D) || (value > 0D && value < 0.001D)
+                        || value <= -10000000D || value >= 10000000D)) {
+            return ClickHouseValues.DECIMAL_FORMATTER.get().format(value);
         }
 
-        return String.valueOf(value);
+        return Double.toString(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
@@ -13,6 +13,33 @@ import com.clickhouse.client.ClickHouseValues;
  */
 public class ClickHouseFloatValue implements ClickHouseValue {
     /**
+     * Converts float object to SQL expression.
+     *
+     * @param v float object, could be null
+     * @return SQL expression representing the float value
+     */
+    public static String convertToSqlExpression(Float v) {
+        if (v == null) {
+            return ClickHouseValues.NULL_EXPR;
+        }
+
+        float value = v.floatValue();
+        if (v.isNaN()) {
+            return ClickHouseValues.NAN_EXPR;
+        } else if (value == Float.POSITIVE_INFINITY) {
+            return ClickHouseValues.INF_EXPR;
+        } else if (value == Float.NEGATIVE_INFINITY) {
+            return ClickHouseValues.NINF_EXPR;
+        } else if (ClickHouseValues.REMOVE_E_NOTION
+                && ((value < 0F && value > -0.001F) || (value > 0F && value < 0.001F)
+                        || value <= -10000000F || value >= 10000000F)) {
+            return ClickHouseValues.DECIMAL_FORMATTER.get().format(value);
+        }
+
+        return Float.toString(value);
+    }
+
+    /**
      * Create a new instance representing null value.
      *
      * @return new instance representing null value
@@ -198,9 +225,13 @@ public class ClickHouseFloatValue implements ClickHouseValue {
             return ClickHouseValues.INF_EXPR;
         } else if (value == Float.NEGATIVE_INFINITY) {
             return ClickHouseValues.NINF_EXPR;
+        } else if (ClickHouseValues.REMOVE_E_NOTION
+                && ((value < 0F && value > -0.001F) || (value > 0F && value < 0.001F)
+                        || value <= -10000000F || value >= 10000000F)) {
+            return ClickHouseValues.DECIMAL_FORMATTER.get().format(value);
         }
 
-        return String.valueOf(value);
+        return Float.toString(value);
     }
 
     @Override

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseValuesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseValuesTest.java
@@ -135,13 +135,11 @@ public class ClickHouseValuesTest extends BaseClickHouseValueTest {
         Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Long.MIN_VALUE),
                 String.valueOf(Long.MIN_VALUE));
         Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Float.MAX_VALUE),
-                String.valueOf(Float.MAX_VALUE));
-        Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Float.MIN_VALUE),
-                String.valueOf(Float.MIN_VALUE));
+                "340282346638528860000000000000000000000.0");
+        Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Float.MIN_VALUE), "0.0");
         Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Double.MAX_VALUE),
-                String.valueOf(Double.MAX_VALUE));
-        Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Double.MIN_VALUE),
-                String.valueOf(Double.MIN_VALUE));
+                "179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0");
+        Assert.assertEquals(ClickHouseValues.convertToSqlExpression(Double.MIN_VALUE), "0.0");
 
         // stringlike types
         Assert.assertEquals(ClickHouseValues.convertToSqlExpression(""), String.valueOf("''"));

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
@@ -11,9 +11,12 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.UUID;
+
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.clickhouse.client.BaseClickHouseValueTest;
 import com.clickhouse.client.ClickHouseDataType;
+import com.clickhouse.client.ClickHouseValues;
 
 public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
@@ -250,5 +253,37 @@ public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
                 buildMap(new Object[] { 1 }, new Double[] { -1D }), // typed Map
                 Arrays.asList(Double.valueOf(-1D)) // Tuple
         );
+    }
+
+    @Test(groups = { "unit" })
+    public void testToSqlExpression() throws Exception {
+        if (!ClickHouseValues.REMOVE_E_NOTION) {
+            return;
+        }
+
+        Assert.assertEquals(ClickHouseDoubleValue.of(-0.001D).toSqlExpression(), "-0.001");
+        Assert.assertEquals(ClickHouseDoubleValue.of(-0.001D - 0.0001D).toSqlExpression(), "-0.0011");
+        Assert.assertEquals(ClickHouseDoubleValue.of(-0.001D + 0.0001D).toSqlExpression(), "-0.0009");
+        Assert.assertEquals(ClickHouseDoubleValue.of(-0.001D + 0.001D).toSqlExpression(), "0.0");
+
+        Assert.assertEquals(ClickHouseDoubleValue.of(-10000000D).toSqlExpression(), "-10000000.0");
+        Assert.assertEquals(ClickHouseDoubleValue.of(-10000000D - 1D).toSqlExpression(), "-10000001.0");
+        Assert.assertEquals(ClickHouseDoubleValue.of(-10000000D + 0.1D).toSqlExpression(), "-9999999.9");
+        Assert.assertEquals(ClickHouseDoubleValue.of(-10000000D + 1D).toSqlExpression(), "-9999999.0");
+
+        Assert.assertEquals(ClickHouseDoubleValue.of(0.001D).toSqlExpression(), "0.001");
+        Assert.assertEquals(ClickHouseDoubleValue.of(0.001D - 0.0001D).toSqlExpression(), "0.0009");
+        Assert.assertEquals(ClickHouseDoubleValue.of(0.001D + 0.0001D).toSqlExpression(), "0.0011");
+        Assert.assertEquals(ClickHouseDoubleValue.of(0.001D + 0.001D).toSqlExpression(), "0.002");
+
+        Assert.assertEquals(ClickHouseDoubleValue.of(10000000D).toSqlExpression(), "10000000.0");
+        Assert.assertEquals(ClickHouseDoubleValue.of(10000000D - 1D).toSqlExpression(), "9999999.0");
+        Assert.assertEquals(ClickHouseDoubleValue.of(10000000D + 0.1D).toSqlExpression(), "10000000.1");
+        Assert.assertEquals(ClickHouseDoubleValue.of(10000000D + 1D).toSqlExpression(), "10000001.0");
+
+        Assert.assertEquals(ClickHouseDoubleValue.of(Double.MIN_VALUE).toSqlExpression(),
+                "0.0");
+        Assert.assertEquals(ClickHouseDoubleValue.of(Double.MAX_VALUE).toSqlExpression(),
+                "179769313486231570000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.0");
     }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseFloatValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseFloatValueTest.java
@@ -11,9 +11,12 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.UUID;
+
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import com.clickhouse.client.BaseClickHouseValueTest;
 import com.clickhouse.client.ClickHouseDataType;
+import com.clickhouse.client.ClickHouseValues;
 
 public class ClickHouseFloatValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
@@ -250,5 +253,37 @@ public class ClickHouseFloatValueTest extends BaseClickHouseValueTest {
                 buildMap(new Object[] { 1 }, new Float[] { -1F }), // typed Map
                 Arrays.asList(Float.valueOf(-1F)) // Tuple
         );
+    }
+
+    @Test(groups = { "unit" })
+    public void testToSqlExpression() throws Exception {
+        if (!ClickHouseValues.REMOVE_E_NOTION) {
+            return;
+        }
+
+        Assert.assertEquals(ClickHouseFloatValue.of(-0.001F).toSqlExpression(), "-0.001");
+        Assert.assertEquals(ClickHouseFloatValue.of(-0.001F - 0.0001F).toSqlExpression(), "-0.0011");
+        Assert.assertEquals(ClickHouseFloatValue.of(-0.001F + 0.0001F).toSqlExpression(), "-0.0009");
+        Assert.assertEquals(ClickHouseFloatValue.of(-0.001F + 0.001F).toSqlExpression(), "0.0");
+
+        Assert.assertEquals(ClickHouseFloatValue.of(-10000000F).toSqlExpression(), "-10000000.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(-10000000F - 1F).toSqlExpression(), "-10000001.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(-10000000F + 0.1F).toSqlExpression(), "-10000000.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(-10000000F + 1F).toSqlExpression(), "-9999999.0");
+
+        Assert.assertEquals(ClickHouseFloatValue.of(0.001F).toSqlExpression(), "0.001");
+        Assert.assertEquals(ClickHouseFloatValue.of(0.001F - 0.0001F).toSqlExpression(), "0.0009");
+        Assert.assertEquals(ClickHouseFloatValue.of(0.001F + 0.0001F).toSqlExpression(), "0.0011");
+        Assert.assertEquals(ClickHouseFloatValue.of(0.001F + 0.001F).toSqlExpression(), "0.002");
+
+        Assert.assertEquals(ClickHouseFloatValue.of(10000000F).toSqlExpression(), "10000000.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(10000000F - 1F).toSqlExpression(), "9999999.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(10000000F + 0.1F).toSqlExpression(), "10000000.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(10000000F + 1F).toSqlExpression(), "10000001.0");
+
+        Assert.assertEquals(ClickHouseFloatValue.of(Float.MIN_VALUE).toSqlExpression(),
+                "0.0");
+        Assert.assertEquals(ClickHouseFloatValue.of(Float.MAX_VALUE).toSqlExpression(),
+                "340282346638528860000000000000000000000.0");
     }
 }


### PR DESCRIPTION
Only applied to Float32 and Float64 two data types. Hold the change for nested type due to the poor performance(-50%).