### PR TITLE
Enhance Bool support

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
@@ -31,6 +31,7 @@ import com.clickhouse.client.data.ClickHouseArrayValue;
 import com.clickhouse.client.data.ClickHouseBigDecimalValue;
 import com.clickhouse.client.data.ClickHouseBigIntegerValue;
 import com.clickhouse.client.data.ClickHouseBitmapValue;
+import com.clickhouse.client.data.ClickHouseBoolValue;
 import com.clickhouse.client.data.ClickHouseByteValue;
 import com.clickhouse.client.data.ClickHouseDateTimeValue;
 import com.clickhouse.client.data.ClickHouseDateValue;
@@ -185,6 +186,40 @@ public final class ClickHouseValues {
         }
 
         return low.add(high.multiply(BIGINT_HL_BOUNDARY));
+    }
+
+    /**
+     * Converts given character to boolean value.
+     *
+     * @param value character represents a boolean value
+     * @return boolean value
+     */
+    public static boolean convertToBoolean(char value) {
+        // not going to support X/V, ✓/✗ and 是/否 as they're less common
+        if (value == '1' || value == 'T' || value == 't' || value == 'Y' || value == 'y') {
+            return true;
+        } else if (value == '0' || value == 'F' || value == 'f' || value == 'N' || value == 'n') {
+            return false;
+        } else {
+            throw new IllegalArgumentException("Invalid boolean value, please use 1/0, T/F, Y/N");
+        }
+    }
+
+    /**
+     * Converts given string to boolean value.
+     *
+     * @param value string represents a boolean value
+     * @return boolean value
+     */
+    public static boolean convertToBoolean(String value) {
+        if (value == null || value.isEmpty() || "0".equals(value) || "false".equalsIgnoreCase(value)
+                || "no".equalsIgnoreCase(value)) {
+            return false;
+        } else if ("1".equals(value) || "true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value)) {
+            return true;
+        } else {
+            throw new IllegalArgumentException("Invalid boolean value, please use 1/0, true/false, yes/no");
+        }
     }
 
     /**
@@ -950,6 +985,9 @@ public final class ClickHouseValues {
     private static ClickHouseValue newValue(ClickHouseConfig config, ClickHouseDataType type, ClickHouseColumn column) {
         ClickHouseValue value = null;
         switch (type) { // still faster than EnumMap and with less overhead
+            case Bool:
+                value = ClickHouseBoolValue.ofNull();
+                break;
             case Enum:
             case Enum8:
             case Int8:

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStringValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStringValue.java
@@ -133,8 +133,7 @@ public class ClickHouseStringValue implements ClickHouseValue {
 
     @Override
     public boolean asBoolean() {
-        // what about Y/N, Yes/No, enabled/disabled?
-        return !isNullOrEmpty() && Boolean.parseBoolean(asString());
+        return ClickHouseValues.convertToBoolean(asString());
     }
 
     @Override

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseValuesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseValuesTest.java
@@ -81,6 +81,33 @@ public class ClickHouseValuesTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
+    public void testNewBasicValues() {
+        ClickHouseConfig config = new ClickHouseConfig();
+        for (ClickHouseDataType type : ClickHouseDataType.values()) {
+            // skip advanced types
+            if (type.isNested() || type == ClickHouseDataType.AggregateFunction
+                    || type == ClickHouseDataType.SimpleAggregateFunction) {
+                continue;
+            }
+
+            ClickHouseValue value = ClickHouseValues.newValue(config, type);
+            Assert.assertNotNull(value);
+
+            if (type == ClickHouseDataType.Point) {
+                Assert.assertEquals(value.asObject(), new double[] { 0D, 0D });
+            } else if (type == ClickHouseDataType.Ring) {
+                Assert.assertEquals(value.asObject(), new double[0][]);
+            } else if (type == ClickHouseDataType.Polygon) {
+                Assert.assertEquals(value.asObject(), new double[0][][]);
+            } else if (type == ClickHouseDataType.MultiPolygon) {
+                Assert.assertEquals(value.asObject(), new double[0][][][]);
+            } else {
+                Assert.assertNull(value.asObject());
+            }
+        }
+    }
+
+    @Test(groups = { "unit" })
     public void testConvertToDateTime() {
         Assert.assertEquals(ClickHouseValues.convertToDateTime(null), null);
         Assert.assertEquals(ClickHouseValues.convertToDateTime(BigDecimal.valueOf(0L)),

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseBoolValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseBoolValueTest.java
@@ -1,0 +1,233 @@
+package com.clickhouse.client.data;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.UUID;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import com.clickhouse.client.BaseClickHouseValueTest;
+import com.clickhouse.client.ClickHouseDataType;
+
+public class ClickHouseBoolValueTest extends BaseClickHouseValueTest {
+    @Test(groups = { "unit" })
+    public void testUpdate() throws Exception {
+        ClickHouseBoolValue v = ClickHouseBoolValue.of(0);
+        Assert.assertEquals(v.getValue(), false);
+        Assert.assertEquals(v.update(true).asByte(), (byte) 1);
+        Assert.assertEquals(v.update(Boolean.TRUE).getValue(), true);
+        Assert.assertEquals(v.update(false).asByte(), (byte) 0);
+        Assert.assertEquals(v.update(Boolean.FALSE).getValue(), false);
+        Assert.assertEquals(v.update('T').getValue(), true);
+        Assert.assertEquals(v.update('F').getValue(), false);
+        Assert.assertEquals(v.update('t').getValue(), true);
+        Assert.assertEquals(v.update('f').getValue(), false);
+        Assert.assertEquals(v.update('1').getValue(), true);
+        Assert.assertEquals(v.update('0').getValue(), false);
+        Assert.assertEquals(v.update('Y').getValue(), true);
+        Assert.assertEquals(v.update('N').getValue(), false);
+        Assert.assertEquals(v.update('y').getValue(), true);
+        Assert.assertEquals(v.update('n').getValue(), false);
+        Assert.assertEquals(v.update("tRue").getValue(), true);
+        Assert.assertEquals(v.update("False").getValue(), false);
+        Assert.assertEquals(v.update("yeS").getValue(), true);
+        Assert.assertEquals(v.update("NO").getValue(), false);
+        Assert.assertEquals(v.update("1").getValue(), true);
+        Assert.assertEquals(v.update("0").getValue(), false);
+
+        Assert.assertEquals(v.update((byte) 1).getValue(), true);
+        Assert.assertEquals(v.update((byte) 0).getValue(), false);
+        Assert.assertEquals(v.update(Byte.valueOf("1")).getValue(), true);
+        Assert.assertEquals(v.update(Byte.valueOf("0")).getValue(), false);
+        Assert.assertEquals(v.update((short) 1).getValue(), true);
+        Assert.assertEquals(v.update((short) 0).getValue(), false);
+        Assert.assertEquals(v.update(Short.valueOf("1")).getValue(), true);
+        Assert.assertEquals(v.update(Short.valueOf("0")).getValue(), false);
+        Assert.assertEquals(v.update(1).getValue(), true);
+        Assert.assertEquals(v.update(0).getValue(), false);
+        Assert.assertEquals(v.update(Integer.valueOf("1")).getValue(), true);
+        Assert.assertEquals(v.update(Integer.valueOf("0")).getValue(), false);
+        Assert.assertEquals(v.update(1L).getValue(), true);
+        Assert.assertEquals(v.update(0L).getValue(), false);
+        Assert.assertEquals(v.update(Long.valueOf("1")).getValue(), true);
+        Assert.assertEquals(v.update(Long.valueOf("0")).getValue(), false);
+        Assert.assertEquals(v.update(1F).getValue(), true);
+        Assert.assertEquals(v.update(0F).getValue(), false);
+        Assert.assertEquals(v.update(Float.valueOf("1")).getValue(), true);
+        Assert.assertEquals(v.update(Float.valueOf("0")).getValue(), false);
+        Assert.assertEquals(v.update(1D).getValue(), true);
+        Assert.assertEquals(v.update(0D).getValue(), false);
+        Assert.assertEquals(v.update(Double.valueOf("1")).getValue(), true);
+        Assert.assertEquals(v.update(Double.valueOf("0")).getValue(), false);
+        Assert.assertEquals(v.update(BigInteger.ONE).getValue(), true);
+        Assert.assertEquals(v.update(BigInteger.ZERO).getValue(), false);
+        Assert.assertEquals(v.update(BigDecimal.ONE).getValue(), true);
+        Assert.assertEquals(v.update(BigDecimal.ZERO).getValue(), false);
+        Assert.assertEquals(v.update(BigDecimal.valueOf(1L, 4)).getValue(), true);
+        Assert.assertEquals(v.update(BigDecimal.valueOf(0L, 5)).getValue(), false);
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update('x'));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update('v'));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update("enabled"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update("disabled"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update((byte) 2));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update((short) -1));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(3));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(4L));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(5F));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(6D));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(BigInteger.TWO));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(BigDecimal.TEN));
+    }
+
+    @Test(groups = { "unit" })
+    public void testValue() throws Exception {
+        // null value
+        checkNull(ClickHouseBoolValue.ofNull());
+        checkNull(ClickHouseBoolValue.of(1).resetToNullOrEmpty());
+        checkNull(ClickHouseBoolValue.of(0).resetToNullOrEmpty());
+        checkNull(ClickHouseBoolValue.of(true).resetToNullOrEmpty());
+        checkNull(ClickHouseBoolValue.of(false).resetToNullOrEmpty());
+
+        // invalid values
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseBoolValue.of(2));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseBoolValue.of(-1));
+
+        // non-null
+        checkValue(ClickHouseBoolValue.of(0), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                false, // boolean
+                (byte) 0, // byte
+                (short) 0, // short
+                0, // int
+                0L, // long
+                0F, // float
+                0D, // double
+                BigDecimal.valueOf(0L), // BigDecimal
+                new BigDecimal(BigInteger.ZERO, 3), // BigDecimal
+                BigInteger.ZERO, // BigInteger
+                ClickHouseDataType.values()[0].name(), // Enum<ClickHouseDataType>
+                false, // Object
+                LocalDate.ofEpochDay(0L), // Date
+                LocalDateTime.of(LocalDate.ofEpochDay(0L), LocalTime.ofSecondOfDay(0)), // DateTime
+                LocalDateTime.of(LocalDate.ofEpochDay(0L), LocalTime.ofSecondOfDay(0)), // DateTime(9)
+                Inet4Address.getAllByName("0.0.0.0")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:0")[0], // Inet6Address
+                "false", // String
+                "0", // SQL Expression
+                LocalTime.ofSecondOfDay(0), // Time
+                UUID.fromString("00000000-0000-0000-0000-000000000000"), // UUID
+                Integer.class, // Key class
+                Boolean.class, // Value class
+                new Object[] { Boolean.FALSE }, // Array
+                new Boolean[] { Boolean.FALSE }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { Boolean.FALSE }), // Map
+                buildMap(new Object[] { 1 }, new Boolean[] { Boolean.FALSE }), // typed Map
+                Arrays.asList(Boolean.FALSE) // Tuple
+        );
+        checkValue(ClickHouseBoolValue.of(1), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                true, // boolean
+                (byte) 1, // byte
+                (short) 1, // short
+                1, // int
+                1L, // long
+                1F, // float
+                1D, // double
+                BigDecimal.valueOf(1L), // BigDecimal
+                new BigDecimal(BigInteger.ONE, 3), // BigDecimal
+                BigInteger.ONE, // BigInteger
+                ClickHouseDataType.values()[1].name(), // Enum<ClickHouseDataType>
+                true, // Object
+                LocalDate.ofEpochDay(1L), // Date
+                LocalDateTime.ofEpochSecond(1L, 0, ZoneOffset.UTC), // DateTime
+                LocalDateTime.ofEpochSecond(0L, 1, ZoneOffset.UTC), // DateTime(9)
+                Inet4Address.getAllByName("0.0.0.1")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:1")[0], // Inet6Address
+                "true", // String
+                "1", // SQL Expression
+                LocalTime.ofSecondOfDay(1), // Time
+                UUID.fromString("00000000-0000-0000-0000-000000000001"), // UUID
+                Integer.class, // Key class
+                Boolean.class, // Value class
+                new Object[] { Boolean.TRUE }, // Array
+                new Boolean[] { Boolean.TRUE }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { Boolean.TRUE }), // Map
+                buildMap(new Object[] { 1 }, new Boolean[] { Boolean.TRUE }), // typed Map
+                Arrays.asList(Boolean.TRUE) // Tuple
+        );
+
+        checkValue(ClickHouseBoolValue.of(false), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                false, // boolean
+                (byte) 0, // byte
+                (short) 0, // short
+                0, // int
+                0L, // long
+                0F, // float
+                0D, // double
+                BigDecimal.valueOf(0L), // BigDecimal
+                new BigDecimal(BigInteger.ZERO, 3), // BigDecimal
+                BigInteger.ZERO, // BigInteger
+                ClickHouseDataType.values()[0].name(), // Enum<ClickHouseDataType>
+                false, // Object
+                LocalDate.ofEpochDay(0L), // Date
+                LocalDateTime.of(LocalDate.ofEpochDay(0L), LocalTime.ofSecondOfDay(0)), // DateTime
+                LocalDateTime.of(LocalDate.ofEpochDay(0L), LocalTime.ofSecondOfDay(0)), // DateTime(9)
+                Inet4Address.getAllByName("0.0.0.0")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:0")[0], // Inet6Address
+                "false", // String
+                "0", // SQL Expression
+                LocalTime.ofSecondOfDay(0), // Time
+                UUID.fromString("00000000-0000-0000-0000-000000000000"), // UUID
+                Integer.class, // Key class
+                Boolean.class, // Value class
+                new Object[] { Boolean.FALSE }, // Array
+                new Boolean[] { Boolean.FALSE }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { Boolean.FALSE }), // Map
+                buildMap(new Object[] { 1 }, new Boolean[] { Boolean.FALSE }), // typed Map
+                Arrays.asList(Boolean.FALSE) // Tuple
+        );
+        checkValue(ClickHouseBoolValue.of(true), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                true, // boolean
+                (byte) 1, // byte
+                (short) 1, // short
+                1, // int
+                1L, // long
+                1F, // float
+                1D, // double
+                BigDecimal.valueOf(1L), // BigDecimal
+                new BigDecimal(BigInteger.ONE, 3), // BigDecimal
+                BigInteger.ONE, // BigInteger
+                ClickHouseDataType.values()[1].name(), // Enum<ClickHouseDataType>
+                true, // Object
+                LocalDate.ofEpochDay(1L), // Date
+                LocalDateTime.ofEpochSecond(1L, 0, ZoneOffset.UTC), // DateTime
+                LocalDateTime.ofEpochSecond(0L, 1, ZoneOffset.UTC), // DateTime(9)
+                Inet4Address.getAllByName("0.0.0.1")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:1")[0], // Inet6Address
+                "true", // String
+                "1", // SQL Expression
+                LocalTime.ofSecondOfDay(1), // Time
+                UUID.fromString("00000000-0000-0000-0000-000000000001"), // UUID
+                Integer.class, // Key class
+                Boolean.class, // Value class
+                new Object[] { Boolean.TRUE }, // Array
+                new Boolean[] { Boolean.TRUE }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { Boolean.TRUE }), // Map
+                buildMap(new Object[] { 1 }, new Boolean[] { Boolean.TRUE }), // typed Map
+                Arrays.asList(Boolean.TRUE) // Tuple
+        );
+    }
+}

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseBoolValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseBoolValueTest.java
@@ -82,7 +82,7 @@ public class ClickHouseBoolValueTest extends BaseClickHouseValueTest {
         Assert.assertThrows(IllegalArgumentException.class, () -> v.update(4L));
         Assert.assertThrows(IllegalArgumentException.class, () -> v.update(5F));
         Assert.assertThrows(IllegalArgumentException.class, () -> v.update(6D));
-        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(BigInteger.TWO));
+        Assert.assertThrows(IllegalArgumentException.class, () -> v.update(BigInteger.TEN));
         Assert.assertThrows(IllegalArgumentException.class, () -> v.update(BigDecimal.TEN));
     }
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseStringValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseStringValueTest.java
@@ -152,7 +152,7 @@ public class ClickHouseStringValueTest extends BaseClickHouseValueTest {
         checkValue(ClickHouseStringValue.of("1"), false, // isInfinity
                 false, // isNan
                 false, // isNull
-                false, // boolean
+                true, // boolean
                 (byte) 1, // byte
                 (short) 1, // short
                 1, // int
@@ -184,7 +184,7 @@ public class ClickHouseStringValueTest extends BaseClickHouseValueTest {
         checkValue(ClickHouseStringValue.of("2"), false, // isInfinity
                 false, // isNan
                 false, // isNull
-                false, // boolean
+                IllegalArgumentException.class, // boolean
                 (byte) 2, // byte
                 (short) 2, // short
                 2, // int
@@ -216,7 +216,7 @@ public class ClickHouseStringValueTest extends BaseClickHouseValueTest {
         checkValue(ClickHouseStringValue.of("-1"), false, // isInfinity
                 false, // isNan
                 false, // isNull
-                false, // boolean
+                IllegalArgumentException.class, // boolean
                 (byte) -1, // byte
                 (short) -1, // short
                 -1, // int

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -88,13 +88,11 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     public void testReadWriteBool() throws SQLException {
         try (ClickHouseConnection conn = newConnection(new Properties());
                 Statement s = conn.createStatement();
-                PreparedStatement stmt = conn.prepareStatement("insert into test_read_write_bool values(?,?)")) {
-            s.execute("drop table if exists test_read_write_bool");
-            try {
-                s.execute("create table test_read_write_bool(id Int32, b Bool)engine=Memory");
-            } catch (SQLException e) {
-                s.execute("create table test_read_write_bool(id Int32, b UInt8)engine=Memory");
-            }
+                PreparedStatement stmt = conn.prepareStatement(
+                        "insert into test_read_write_bool select c1, c2 from input('c1 Int32, c2 Bool')")) {
+            s.execute("drop table if exists test_read_write_bool; "
+                    + "create table test_read_write_bool(id Int32, b Bool)engine=Memory");
+
             stmt.setInt(1, 1);
             stmt.setBoolean(2, true);
             stmt.addBatch();


### PR DESCRIPTION
* Fix #848 
* Throw `IllegalArgumentException` for invalid boolean value
* Improve type conversion and add more tests

| Type | Value | Boolean Value | Remark |
| ---- | ------ | -------------- | -------- |
|  Number | `1` | true | same for 1.000 |
|   | `0` | false | same for 0.000 |
|  Character | `T`, `Y`, `1` | true | case-insensitive |
|   | `F`, `N`, `0` | false | case-insensitive |
|  String | `true`, `yes`, `1` | true | case-insensitive |
|   | `false`, `no`, `0` | false | case-insensitive, null and empty string are treated as false |
