### PR TITLE
Prepare patch6

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Note: in general, the new driver(v0.3.2) is a few times faster with less memory 
     <groupId>com.clickhouse</groupId>
     <!-- or clickhouse-grpc-client if you prefer gRPC -->
     <artifactId>clickhouse-http-client</artifactId>
-    <version>0.3.2-patch5</version>
+    <version>0.3.2-patch6</version>
 </dependency>
 ```
 
@@ -148,7 +148,7 @@ try (ClickHouseClient client = ClickHouseClient.newInstance(preferredProtocol);
     <!-- will stop using ru.yandex.clickhouse starting from 0.4.0  -->
     <groupId>com.clickhouse</groupId>
     <artifactId>clickhouse-jdbc</artifactId>
-    <version>0.3.2-patch5</version>
+    <version>0.3.2-patch6</version>
     <!-- below is only needed when all you want is a shaded jar -->
     <classifier>http</classifier>
     <exclusions>

--- a/clickhouse-client/README.md
+++ b/clickhouse-client/README.md
@@ -9,7 +9,7 @@ Async Java client for ClickHouse. `clickhouse-client` is an abstract module, so 
 <dependency>
     <groupId>com.clickhouse</groupId>
     <artifactId>clickhouse-http-client</artifactId>
-    <version>0.3.2-patch5</version>
+    <version>0.3.2-patch6</version>
 </dependency>
 ```
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
@@ -356,7 +356,8 @@ public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetD
         if (value == null) {
             resetToNullOrEmpty();
         } else {
-            set(OffsetDateTime.parse(value, ClickHouseValues.DATETIME_FORMATTER));
+            set(LocalDateTime.parse(value, ClickHouseValues.DATETIME_FORMATTER).atZone(tz.toZoneId())
+                    .toOffsetDateTime());
         }
         return this;
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessor.java
@@ -286,7 +286,7 @@ public class ClickHouseRowBinaryProcessor extends ClickHouseDataProcessor {
             buildMappings(deserializers, serializers,
                     (r, f, c, i) -> ClickHouseDateValue.of(r,
                             BinaryStreamUtils.readDate32(i, f.getTimeZoneForDate())),
-                    (v, f, c, o) -> BinaryStreamUtils.writeDate(o, v.asDate(), f.getTimeZoneForDate()),
+                    (v, f, c, o) -> BinaryStreamUtils.writeDate32(o, v.asDate(), f.getTimeZoneForDate()),
                     ClickHouseDataType.Date32);
             buildMappings(deserializers, serializers, (r, f, c, i) -> c.getTimeZone() == null
                     ? ClickHouseDateTimeValue.of(r,

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
@@ -414,7 +414,7 @@ public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> {
                 byte[] arr = new byte[list.size()];
                 int index = 0;
                 for (String v : list) {
-                    arr[index++] = Byte.parseByte(v);
+                    arr[index++] = v == null ? (byte) 0 : Byte.parseByte(v);
                 }
                 set(arr);
             }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
@@ -410,7 +410,7 @@ public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> 
                 double[] arr = new double[list.size()];
                 int index = 0;
                 for (String v : list) {
-                    arr[index++] = Double.parseDouble(v);
+                    arr[index++] = v == null ? 0D : Double.parseDouble(v);
                 }
                 set(arr);
             }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
@@ -410,7 +410,7 @@ public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> {
                 float[] arr = new float[list.size()];
                 int index = 0;
                 for (String v : list) {
-                    arr[index++] = Float.parseFloat(v);
+                    arr[index++] = v == null ? 0F : Float.parseFloat(v);
                 }
                 set(arr);
             }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
@@ -410,7 +410,7 @@ public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> {
                 int[] arr = new int[list.size()];
                 int index = 0;
                 for (String v : list) {
-                    arr[index++] = Integer.parseInt(v);
+                    arr[index++] = v == null ? 0 : Integer.parseInt(v);
                 }
                 set(arr);
             }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
@@ -410,7 +410,7 @@ public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> {
                 long[] arr = new long[list.size()];
                 int index = 0;
                 for (String v : list) {
-                    arr[index++] = Long.parseLong(v);
+                    arr[index++] = v == null ? 0L : Long.parseLong(v);
                 }
                 set(arr);
             }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
@@ -410,7 +410,7 @@ public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> {
                 short[] arr = new short[list.size()];
                 int index = 0;
                 for (String v : list) {
-                    arr[index++] = Short.parseShort(v);
+                    arr[index++] = v == null ? (short) 0 : Short.parseShort(v);
                 }
                 set(arr);
             }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseUtilsTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseUtilsTest.java
@@ -375,6 +375,11 @@ public class ClickHouseUtilsTest {
                 args.lastIndexOf(']') + 1);
         Assert.assertEquals(list, Arrays.asList("1", "2", "3"));
 
+        args = "[1, null , 3,, Null]";
+        list.clear();
+        Assert.assertEquals(ClickHouseUtils.readValueArray(args, 0, args.length(), list::add), args.length());
+        Assert.assertEquals(list, Arrays.asList("1", null, "3", null, null));
+
         args = "['1\\'2', '2,3' , '3\n4\r5']";
         list.clear();
         Assert.assertEquals(ClickHouseUtils.readValueArray(args, 0, args.length(), list::add), args.length());

--- a/clickhouse-jdbc/README.md
+++ b/clickhouse-jdbc/README.md
@@ -99,7 +99,8 @@ try (PreparedStatement ps = conn.prepareStatement("insert into mytable(* except 
 }
 
 // 3. not recommended as it's based on a large SQL
-try (PreparedStatement ps = conn.prepareStatement("insert into mytable values(?,?,?)")) {
+// Note: "insert into mytable values(?,?,?)" is treated as "insert into mytable"
+try (PreparedStatement ps = conn.prepareStatement("insert into mytable values(trim(?),?,?)")) {
     ps.setString(1, "test"); // id
     ps.setObject(2, LocalDateTime.now()); // timestamp
     ps.setString(3, null); // description

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
@@ -137,13 +137,9 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
         return results;
     }
 
-    protected int toArrayIndex(int parameterIndex) throws SQLException {
-        if (parameterIndex < 1 || parameterIndex > values.length) {
-            throw SqlExceptionUtils.clientError(ClickHouseUtils
-                    .format("Parameter index must between 1 and %d but we got %d", values.length, parameterIndex));
-        }
-
-        return parameterIndex - 1;
+    @Override
+    protected int getMaxParameterIndex() {
+        return values.length;
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
@@ -209,13 +209,9 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
         return results;
     }
 
-    protected int toArrayIndex(int parameterIndex) throws SQLException {
-        if (parameterIndex < 1 || parameterIndex > templates.length) {
-            throw SqlExceptionUtils.clientError(ClickHouseUtils
-                    .format("Parameter index must between 1 and %d but we got %d", templates.length, parameterIndex));
-        }
-
-        return parameterIndex - 1;
+    @Override
+    protected int getMaxParameterIndex() {
+        return templates.length;
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
@@ -113,19 +113,15 @@ public class TableBasedPreparedStatement extends AbstractPreparedStatement imple
         return results;
     }
 
+    @Override
+    protected int getMaxParameterIndex() {
+        return values.length;
+    }
+
     protected String getSql() {
         // why? because request can be modified so it might not always same as
         // parsedStmt.getSQL()
         return getRequest().getStatements(false).get(0);
-    }
-
-    protected int toArrayIndex(int parameterIndex) throws SQLException {
-        if (parameterIndex < 1 || parameterIndex > values.length) {
-            throw SqlExceptionUtils.clientError(ClickHouseUtils
-                    .format("Parameter index must between 1 and %d but we got %d", values.length, parameterIndex));
-        }
-
-        return parameterIndex - 1;
     }
 
     @Override

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -18,12 +18,17 @@ import java.time.ZoneOffset;
 import java.util.Properties;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
+import com.clickhouse.client.ClickHouseConfig;
 import com.clickhouse.client.ClickHouseFormat;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.config.ClickHouseClientOption;
+import com.clickhouse.client.data.BinaryStreamUtils;
 import com.clickhouse.client.data.ClickHouseBitmap;
 import com.clickhouse.client.data.ClickHouseExternalTable;
+import com.clickhouse.client.data.ClickHousePipedStream;
 import com.clickhouse.jdbc.internal.InputBasedPreparedStatement;
 import com.clickhouse.jdbc.internal.SqlBasedPreparedStatement;
 
@@ -55,11 +60,12 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                         false },
                 new Object[] { "insert_table", "insert into $table", InputBasedPreparedStatement.class, false,
                         new String[] { "2" }, true },
-                new Object[] { "insert_param", "insert into $table values(?)", SqlBasedPreparedStatement.class,
-                        false,
-                        new String[] { "3" }, true },
+                new Object[] { "insert_param", "insert into $table values(?)", InputBasedPreparedStatement.class,
+                        false, new String[] { "3" }, true },
+                new Object[] { "insert_param", "insert into $table values(trim(?))",
+                        SqlBasedPreparedStatement.class, false, new String[] { "4" }, true },
                 new Object[] { "insert_input", "insert into $table select s from input('s String')",
-                        InputBasedPreparedStatement.class, false, new String[] { "4" }, true },
+                        InputBasedPreparedStatement.class, false, new String[] { "5" }, true },
         };
     }
 
@@ -81,6 +87,31 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                 Assert.assertEquals(rs.getString(1), results[i]);
             }
             Assert.assertFalse(rs.next(), "Should not have next row");
+        }
+    }
+
+    @Test(groups = "integration")
+    public void testQueryWithoutParameter() throws SQLException {
+        Properties props = new Properties();
+        try (ClickHouseConnection conn = newConnection(props);
+                PreparedStatement stmt = conn.prepareStatement("select 1")) {
+            ResultSet rs = stmt.executeQuery();
+            Assert.assertTrue(rs.next(), "Should have one row");
+            Assert.assertEquals(rs.getInt(1), 1);
+            Assert.assertFalse(rs.next(), "Should have only one row");
+
+            Assert.assertThrows(SQLException.class, () -> stmt.setInt(1, 2));
+        }
+
+        props.setProperty(JdbcConfig.PROP_NAMED_PARAM, "true");
+        try (ClickHouseConnection conn = newConnection(props);
+                PreparedStatement stmt = conn.prepareStatement("select 1")) {
+            ResultSet rs = stmt.executeQuery();
+            Assert.assertTrue(rs.next(), "Should have one row");
+            Assert.assertEquals(rs.getInt(1), 1);
+            Assert.assertFalse(rs.next(), "Should have only one row");
+
+            Assert.assertThrows(SQLException.class, () -> stmt.setInt(1, 2));
         }
     }
 
@@ -206,18 +237,18 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
         Date x = Date.valueOf(d);
         try (ClickHouseConnection conn = newConnection(new Properties());
                 Statement s = conn.createStatement();
-                PreparedStatement stmt = conn.prepareStatement("insert into test_read_write_date values(?,?,?)")) {
+                PreparedStatement stmt = conn.prepareStatement("insert into test_read_write_date values(? + 1,?,?)")) {
             s.execute("drop table if exists test_read_write_date");
             try {
                 s.execute("create table test_read_write_date(id Int32, d1 Date, d2 Date32)engine=Memory");
             } catch (SQLException e) {
                 s.execute("create table test_read_write_date(id Int32, d1 Date, d2 Nullable(Date))engine=Memory");
             }
-            stmt.setInt(1, 1);
+            stmt.setInt(1, 0);
             stmt.setObject(2, d);
             stmt.setObject(3, d);
             stmt.addBatch();
-            stmt.setInt(1, 2);
+            stmt.setInt(1, 1);
             stmt.setDate(2, x);
             stmt.setDate(3, x);
             stmt.addBatch();
@@ -246,9 +277,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
         Properties props = new Properties();
         props.setProperty(ClickHouseClientOption.USE_SERVER_TIME_ZONE_FOR_DATES.getKey(), "false");
         try (ClickHouseConnection conn = newConnection(props);
-                Statement s = conn.createStatement();
-                PreparedStatement stmt = conn
-                        .prepareStatement("insert into test_read_write_date_cz values (?, ?, ?)")) {
+                Statement s = conn.createStatement()) {
             TimeZone tz = conn.getServerTimeZone();
             // 2021-03-25
             LocalDate d = LocalDateTime.ofInstant(Instant.ofEpochSecond(1616630400L), tz.toZoneId()).toLocalDate();
@@ -259,16 +288,19 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             } catch (SQLException e) {
                 s.execute("create table test_read_write_date_cz(id Int32, d1 Date, d2 Nullable(Date))engine=Memory");
             }
-            stmt.setInt(1, 1);
-            stmt.setObject(2, d);
-            stmt.setObject(3, d);
-            stmt.addBatch();
-            stmt.setInt(1, 2);
-            stmt.setDate(2, x);
-            stmt.setDate(3, x);
-            stmt.addBatch();
-            int[] results = stmt.executeBatch();
-            Assert.assertEquals(results, new int[] { 1, 1 });
+            try (PreparedStatement stmt = conn
+                    .prepareStatement("insert into test_read_write_date_cz values (?, ?, ?)")) {
+                stmt.setInt(1, 1);
+                stmt.setObject(2, d);
+                stmt.setObject(3, d);
+                stmt.addBatch();
+                stmt.setInt(1, 2);
+                stmt.setDate(2, x);
+                stmt.setDate(3, x);
+                stmt.addBatch();
+                int[] results = stmt.executeBatch();
+                Assert.assertEquals(results, new int[] { 1, 1 });
+            }
 
             ResultSet rs = conn.createStatement().executeQuery("select * from test_read_write_date_cz order by id");
             Assert.assertTrue(rs.next());
@@ -293,14 +325,15 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
         LocalDateTime dt = LocalDateTime.of(2021, 3, 25, 8, 50, 56);
         Timestamp x = Timestamp.valueOf(dt);
         try (ClickHouseConnection conn = newConnection(new Properties());
-                PreparedStatement stmt = conn.prepareStatement("insert into test_read_write_datetime values(?,?,?)")) {
+                PreparedStatement stmt = conn
+                        .prepareStatement("insert into test_read_write_datetime values(?+1,?,?)")) {
             conn.createStatement().execute("drop table if exists test_read_write_datetime;"
                     + "create table test_read_write_datetime(id Int32, d1 DateTime32, d2 DateTime64(3))engine=Memory");
-            stmt.setInt(1, 1);
+            stmt.setInt(1, 0);
             stmt.setObject(2, dt);
             stmt.setObject(3, dt);
             stmt.addBatch();
-            stmt.setInt(1, 2);
+            stmt.setInt(1, 1);
             stmt.setTimestamp(2, x);
             stmt.setTimestamp(3, x);
             stmt.addBatch();
@@ -406,7 +439,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             long value = 1617359745321000L;
             Instant i = Instant.ofEpochMilli(value / 1000L);
             LocalDateTime dt = LocalDateTime.ofInstant(i, conn.getServerTimeZone().toZoneId());
-            try (PreparedStatement ps = conn.prepareStatement("insert into test_issue_612 values(?,?)")) {
+            try (PreparedStatement ps = conn.prepareStatement("insert into test_issue_612 values(trim(?),?)")) {
                 ps.setLong(2, value);
                 ps.setObject(1, id);
                 ps.execute();
@@ -439,16 +472,16 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     public void testBatchInsert() throws SQLException {
         try (ClickHouseConnection conn = newConnection(new Properties());
                 ClickHouseStatement s = conn.createStatement();
-                PreparedStatement stmt = conn.prepareStatement("insert into test_batch_insert values(?,?)")) {
+                PreparedStatement stmt = conn.prepareStatement("insert into test_batch_insert values(? + 1,?)")) {
             s.execute("drop table if exists test_batch_insert;"
                     + "create table test_batch_insert(id Int32, name Nullable(String))engine=Memory");
-            stmt.setInt(1, 1);
+            stmt.setInt(1, 0);
             stmt.setString(2, "a");
             stmt.addBatch();
-            stmt.setInt(1, 2);
+            stmt.setInt(1, 1);
             stmt.setString(2, "b");
             stmt.addBatch();
-            stmt.setInt(1, 3);
+            stmt.setInt(1, 2);
             stmt.setString(2, null);
             stmt.addBatch();
             int[] results = stmt.executeBatch();
@@ -754,6 +787,40 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     }
 
     @Test(groups = "integration")
+    public void testLoadRawData() throws Exception {
+        try (ClickHouseConnection conn = newConnection(new Properties());
+                ClickHouseStatement stmt = conn.createStatement();
+                PreparedStatement ps = conn.prepareStatement(
+                        "insert into test_jdbc_load_raw_data select * from {tt 'raw_data'}")) {
+            Assert.assertFalse(stmt.execute("drop table if exists test_jdbc_load_raw_data; "
+                    + "create table test_jdbc_load_raw_data(s String)engine=Memory"), "Should not have result set");
+            ClickHouseConfig config = stmt.getConfig();
+            CompletableFuture<Integer> future;
+            try (ClickHousePipedStream stream = new ClickHousePipedStream(config.getMaxBufferSize(),
+                    config.getMaxQueuedRequests(), config.getSocketTimeout())) {
+                ps.setObject(1, ClickHouseExternalTable.builder().name("raw_data")
+                        .columns("s String").format(ClickHouseFormat.RowBinary)
+                        .content(stream.getInput())
+                        .build());
+                future = CompletableFuture.supplyAsync(() -> {
+                    try {
+                        return ps.executeUpdate();
+                    } catch (SQLException e) {
+                        throw new CompletionException(e);
+                    }
+                });
+
+                // write bytes into the piped stream
+                for (int i = 0; i < 101; i++) {
+                    BinaryStreamUtils.writeString(stream, Integer.toString(i));
+                }
+            }
+
+            Assert.assertTrue(future.get() >= 0);
+        }
+    }
+
+    @Test(groups = "integration")
     public void testQueryWithExternalTable() throws SQLException {
         // FIXME grpc seems has problem dealing with session
         if (DEFAULT_PROTOCOL == ClickHouseProtocol.GRPC) {
@@ -799,7 +866,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
         try (ClickHouseConnection conn = newConnection(new Properties());
                 Statement s = conn.createStatement();
                 PreparedStatement stmt = conn.prepareStatement(
-                        "insert into test_array_insert(id, a, b) values (?,?,?)")) {
+                        "insert into test_array_insert(id, a, b) values (toUInt32(?),?,?)")) {
             s.execute("drop table if exists test_array_insert;"
                     + "create table test_array_insert(id UInt32, a Array(Int16), b Array(Nullable(UInt32)))engine=Memory");
 

--- a/examples/grpc/pom.xml
+++ b/examples/grpc/pom.xml
@@ -56,7 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <clickhouse-grpc.version>0.3.2-patch5</clickhouse-grpc.version>
+        <clickhouse-grpc.version>0.3.2-patch6</clickhouse-grpc.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 

--- a/examples/jdbc/pom.xml
+++ b/examples/jdbc/pom.xml
@@ -56,7 +56,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <clickhouse-jdbc.version>0.3.2-patch5</clickhouse-jdbc.version>
+        <clickhouse-jdbc.version>0.3.2-patch6</clickhouse-jdbc.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,25 +81,25 @@
         <asm.version>9.2</asm.version>
         <caffeine.version>3.0.5</caffeine.version>
         <disruptor.version>3.4.4</disruptor.version>
-        <dnsjava.version>3.4.3</dnsjava.version>
-        <fastutil.version>8.5.6</fastutil.version>
+        <dnsjava.version>3.5.0</dnsjava.version>
+        <fastutil.version>8.5.8</fastutil.version>
         <grpc.version>1.40.2</grpc.version>
-        <gson.version>2.8.9</gson.version>
+        <gson.version>2.9.0</gson.version>
         <httpclient.version>4.5.13</httpclient.version>
         <protobuf.version>3.17.3</protobuf.version>
         <lz4.version>1.8.0</lz4.version>
-        <roaring-bitmap.version>0.9.23</roaring-bitmap.version>
+        <roaring-bitmap.version>0.9.25</roaring-bitmap.version>
         <slf4j.version>2.0.0-alpha5</slf4j.version>
         <mockito.version>3.12.4</mockito.version>
         <wiremock.version>2.32.0</wiremock.version>
         <testcontainers.version>1.16.3</testcontainers.version>
-        <testng.version>7.4.0</testng.version>
+        <testng.version>7.5</testng.version>
 
         <mariadb-driver.version>3.0.3</mariadb-driver.version>
         <mysql-driver.version>8.0.28</mysql-driver.version>
         <postgresql-driver.version>42.3.3</postgresql-driver.version>
 
-        <repackaged.version>1.1.1</repackaged.version>
+        <repackaged.version>1.1.2</repackaged.version>
 
         <assembly-plugin.version>3.3.0</assembly-plugin.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>


### PR DESCRIPTION
* Bump version
* Fix issue of writing Date32 value in RowBinary format
* Fix OffsetDateTime parsing error
* Fix NumberFormatException when parsing primitive array with null value
* Optimize PreparedStatement by treating `insert into table values(?,?)` as `insert into table` for better performance and less memory consumption on client side