### PR TITLE
Rounding

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
@@ -133,16 +133,16 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
         if (isNull) {
             return null;
         }
-        final RoundingMode roundingMode = RoundingMode.HALF_UP;
+
         BigDecimal dec = BigDecimal.valueOf(value);
-        if (value == 0D || isInfinity() || isNaN()) {
-            dec = dec.setScale(scale, roundingMode);
+        if (value == 0D) {
+            dec = dec.setScale(scale);
         } else {
             int diff = scale - dec.scale();
             if (diff > 0) {
                 dec = dec.divide(BigDecimal.TEN.pow(diff + 1));
             } else if (diff < 0) {
-                dec = dec.setScale(scale, roundingMode);
+                dec = dec.setScale(scale, RoundingMode.DOWN);
             }
         }
         return dec;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
@@ -48,8 +48,7 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
 
     /**
      * Update value of the given object or create a new instance if {@code
-     * ref} is
-     * null.
+     * ref} is null.
      *
      * @param ref   object to update, could be null
      * @param value value
@@ -159,14 +158,10 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
         if (isNull) {
             return null;
         }
-
         String str = String.valueOf(value);
         if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(
-                            charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
+            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset), length);
         }
-
         return str;
     }
 
@@ -186,7 +181,6 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
         } else if (value == Float.NEGATIVE_INFINITY) {
             return ClickHouseValues.NINF_EXPR;
         }
-
         return String.valueOf(value);
     }
 
@@ -232,33 +226,27 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
 
     @Override
     public ClickHouseDoubleValue update(BigInteger value) {
-        return value
-               == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
+        return value == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
     }
 
     @Override
     public ClickHouseDoubleValue update(BigDecimal value) {
-        return value
-               == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
+        return value == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
     }
 
     @Override
     public ClickHouseDoubleValue update(Enum<?> value) {
-        return value
-               == null ? resetToNullOrEmpty() : set(false, value.ordinal());
+        return value == null ? resetToNullOrEmpty() : set(false, value.ordinal());
     }
 
     @Override
     public ClickHouseDoubleValue update(String value) {
-        return value
-               == null ? resetToNullOrEmpty() : set(false,
-                Double.parseDouble(value));
+        return value == null ? resetToNullOrEmpty() : set(false, Double.parseDouble(value));
     }
 
     @Override
     public ClickHouseDoubleValue update(ClickHouseValue value) {
-        return value
-               == null ? resetToNullOrEmpty() : set(false, value.asDouble());
+        return value == null ? resetToNullOrEmpty() : set(false, value.asDouble());
     }
 
     @Override
@@ -268,7 +256,6 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
         } else if (value instanceof ClickHouseValue) {
             return set(false, ((ClickHouseValue) value).asDouble());
         }
-
         ClickHouseValue.super.update(value);
         return this;
     }
@@ -280,7 +267,6 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
         } else if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
-
         ClickHouseDoubleValue v = (ClickHouseDoubleValue) obj;
         return isNull == v.isNull && value == v.value;
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
@@ -2,8 +2,10 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
@@ -22,13 +24,15 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
     }
 
     /**
-     * Update given value to null or create a new instance if {@code ref} is null.
-     * 
+     * Update given value to null or create a new instance if {@code ref} is
+     * null.
+     *
      * @param ref object to update, could be null
      * @return same object as {@code ref} or a new instance if it's null
      */
     public static ClickHouseDoubleValue ofNull(ClickHouseValue ref) {
-        return ref instanceof ClickHouseDoubleValue ? ((ClickHouseDoubleValue) ref).set(true, 0D)
+        return ref instanceof ClickHouseDoubleValue ?
+                ((ClickHouseDoubleValue) ref).set(true, 0D)
                 : new ClickHouseDoubleValue(true, 0D);
     }
 
@@ -43,7 +47,8 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
     }
 
     /**
-     * Update value of the given object or create a new instance if {@code ref} is
+     * Update value of the given object or create a new instance if {@code
+     * ref} is
      * null.
      *
      * @param ref   object to update, could be null
@@ -51,7 +56,8 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
      * @return same object as {@code ref} or a new instance if it's null
      */
     public static ClickHouseDoubleValue of(ClickHouseValue ref, double value) {
-        return ref instanceof ClickHouseDoubleValue ? ((ClickHouseDoubleValue) ref).set(false, value)
+        return ref instanceof ClickHouseDoubleValue ?
+                ((ClickHouseDoubleValue) ref).set(false, value)
                 : new ClickHouseDoubleValue(false, value);
     }
 
@@ -128,16 +134,16 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
         if (isNull) {
             return null;
         }
-
+        final RoundingMode roundingMode = RoundingMode.HALF_UP;
         BigDecimal dec = BigDecimal.valueOf(value);
         if (value == 0D || isInfinity() || isNaN()) {
-            dec = dec.setScale(scale);
+            dec = dec.setScale(scale, roundingMode);
         } else {
             int diff = scale - dec.scale();
             if (diff > 0) {
                 dec = dec.divide(BigDecimal.TEN.pow(diff + 1));
             } else if (diff < 0) {
-                dec = dec.setScale(scale);
+                dec = dec.setScale(scale, roundingMode);
             }
         }
         return dec;
@@ -156,7 +162,8 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
 
         String str = String.valueOf(value);
         if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
+            ClickHouseChecker.notWithDifferentLength(str.getBytes(
+                            charset == null ? StandardCharsets.UTF_8 : charset),
                     length);
         }
 
@@ -225,27 +232,33 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
 
     @Override
     public ClickHouseDoubleValue update(BigInteger value) {
-        return value == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
+        return value
+               == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
     }
 
     @Override
     public ClickHouseDoubleValue update(BigDecimal value) {
-        return value == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
+        return value
+               == null ? resetToNullOrEmpty() : set(false, value.doubleValue());
     }
 
     @Override
     public ClickHouseDoubleValue update(Enum<?> value) {
-        return value == null ? resetToNullOrEmpty() : set(false, value.ordinal());
+        return value
+               == null ? resetToNullOrEmpty() : set(false, value.ordinal());
     }
 
     @Override
     public ClickHouseDoubleValue update(String value) {
-        return value == null ? resetToNullOrEmpty() : set(false, Double.parseDouble(value));
+        return value
+               == null ? resetToNullOrEmpty() : set(false,
+                Double.parseDouble(value));
     }
 
     @Override
     public ClickHouseDoubleValue update(ClickHouseValue value) {
-        return value == null ? resetToNullOrEmpty() : set(false, value.asDouble());
+        return value
+               == null ? resetToNullOrEmpty() : set(false, value.asDouble());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.math.RoundingMode;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import com.clickhouse.client.ClickHouseChecker;
@@ -149,7 +150,7 @@ public class ClickHouseFloatValue implements ClickHouseValue {
             return null;
         }
 
-        BigDecimal dec = BigDecimal.valueOf(value);
+        BigDecimal dec = new BigDecimal(Float.toString(value));
         if (value == 0F) {
             dec = dec.setScale(scale);
         } else {
@@ -157,7 +158,7 @@ public class ClickHouseFloatValue implements ClickHouseValue {
             if (diff > 0) {
                 dec = dec.divide(BigDecimal.TEN.pow(diff + 1));
             } else if (diff < 0) {
-                dec = dec.setScale(scale);
+                dec = dec.setScale(scale, RoundingMode.DOWN);
             }
         }
         return dec;

--- a/clickhouse-client/src/test/java/com/clickhouse/client/BaseClickHouseValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/BaseClickHouseValueTest.java
@@ -30,18 +30,19 @@ public abstract class BaseClickHouseValueTest {
         } else if (expected instanceof Class && Throwable.class.isAssignableFrom((Class<?>) expected)) {
             Assert.assertThrows((Class<Throwable>) expected, () -> actual.get());
         } else if (expected instanceof String) {
-            Assert.assertEquals(String.valueOf(actual.get()), (String) expected);
+            Assert.assertEquals(String.valueOf(actual.get()), (String) expected, String.class.getName());
         } else if (expected instanceof List) {
             List<?> l1 = (List<?>) actual.get();
             List<?> l2 = (List<?>) expected;
             // unfortunately TestNG 6.x didn't work
-            Assert.assertTrue(Arrays.deepEquals(l1.toArray(new Object[l1.size()]), l2.toArray(new Object[l2.size()])));
+            Assert.assertTrue(Arrays.deepEquals(l1.toArray(new Object[l1.size()]), l2.toArray(new Object[l2.size()])),
+                    List.class.getName());
             // Assert.assertEquals(l1.toArray(new Object[l1.size()]), l2.toArray(new
             // Object[l2.size()]));
         } else if (expected instanceof Map) {
-            Assert.assertEqualsDeep((Map<?, ?>) actual.get(), (Map<?, ?>) expected);
+            Assert.assertEqualsDeep((Map<?, ?>) actual.get(), (Map<?, ?>) expected, Map.class.getName());
         } else {
-            Assert.assertEquals(actual.get(), expected);
+            Assert.assertEquals(actual.get(), expected, expected == null ? null : expected.getClass().getName());
         }
     }
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
@@ -252,7 +252,7 @@ public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
                 Arrays.asList(Double.valueOf(-1D)) // Tuple
         );
 
-        checkValue(ClickHouseDoubleValue.of(4D/3), false, // isInfinity
+        checkValue(ClickHouseDoubleValue.of(4D / 3), false, // isInfinity
                 false, // isNan
                 false, // isNull
                 true, // boolean
@@ -263,7 +263,7 @@ public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
                 1.3333334F, // float
                 1.3333333333333333D, // double
                 BigDecimal.valueOf(1L), // BigDecimal
-                BigDecimal.valueOf(1333,3), // BigDecimal
+                BigDecimal.valueOf(1333, 3), // BigDecimal
                 BigInteger.ONE, // BigInteger
                 ClickHouseDataType.values()[1].name(), // Enum<ClickHouseDataType>
                 1.3333333333333333D, // Object
@@ -283,6 +283,38 @@ public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
                 buildMap(new Object[] { 1 }, new Object[] { 1.3333333333333333D }), // Map
                 buildMap(new Object[] { 1 }, new Double[] { 1.3333333333333333D }), // typed Map
                 Collections.singletonList(1.3333333333333333D) // Tuple
+        );
+        checkValue(ClickHouseDoubleValue.of(-4D / 3), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                IllegalArgumentException.class, // boolean
+                (byte) -1, // byte
+                (short) -1, // short
+                -1, // int
+                -1L, // long
+                -1.3333334F, // float
+                -1.3333333333333333D, // double
+                BigDecimal.valueOf(-1L), // BigDecimal
+                BigDecimal.valueOf(-1333, 3), // BigDecimal
+                BigInteger.valueOf(-1L), // BigInteger
+                IllegalArgumentException.class, // Enum<ClickHouseDataType>
+                -1.3333333333333333D, // Object
+                LocalDate.ofEpochDay(-1L), // Date
+                LocalDateTime.ofEpochSecond(-1L, 0, ZoneOffset.UTC), // DateTime
+                LocalDateTime.ofEpochSecond(-2L, 666666667, ZoneOffset.UTC), // DateTime(9)
+                Inet4Address.getAllByName("255.255.255.255")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:ff")[0], // Inet6Address
+                "-1.3333333333333333", // String
+                "-1.3333333333333333", // SQL Expression
+                LocalTime.of(23, 59, 59), // Time
+                UUID.fromString("00000000-0000-0000-ffff-ffffffffffff"), // UUID
+                Object.class, // Key class
+                Double.class, // Value class
+                new Object[] { -1.3333333333333333D }, // Array
+                new Double[] { -1.3333333333333333D }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { -1.3333333333333333D }), // Map
+                buildMap(new Object[] { 1 }, new Double[] { -1.3333333333333333D }), // typed Map
+                Collections.singletonList(-1.3333333333333333D) // Tuple
         );
     }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.UUID;
 import org.testng.annotations.Test;
 import com.clickhouse.client.BaseClickHouseValueTest;
@@ -249,6 +250,39 @@ public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
                 buildMap(new Object[] { 1 }, new Object[] { -1D }), // Map
                 buildMap(new Object[] { 1 }, new Double[] { -1D }), // typed Map
                 Arrays.asList(Double.valueOf(-1D)) // Tuple
+        );
+
+        checkValue(ClickHouseDoubleValue.of(4D/3), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                true, // boolean
+                (byte) 1, // byte
+                (short) 1, // short
+                1, // int
+                1L, // long
+                1.3333334F, // float
+                1.3333333333333333D, // double
+                BigDecimal.valueOf(1L), // BigDecimal
+                BigDecimal.valueOf(1333,3), // BigDecimal
+                BigInteger.ONE, // BigInteger
+                ClickHouseDataType.values()[1].name(), // Enum<ClickHouseDataType>
+                1.3333333333333333D, // Object
+                LocalDate.ofEpochDay(1L), // Date
+                LocalDateTime.ofEpochSecond(1L, 0, ZoneOffset.UTC), // DateTime
+                LocalDateTime.ofEpochSecond(1L, 333333333, ZoneOffset.UTC), // DateTime(9)
+                Inet4Address.getAllByName("0.0.0.1")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:1")[0], // Inet6Address
+                "1.3333333333333333", // String
+                "1.3333333333333333", // SQL Expression
+                LocalTime.ofSecondOfDay(1), // Time
+                UUID.fromString("00000000-0000-0000-0000-000000000001"), // UUID
+                Object.class, // Key class
+                Double.class, // Value class
+                new Object[] { 1.3333333333333333D }, // Array
+                new Double[] { 1.3333333333333333D }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { 1.3333333333333333D }), // Map
+                buildMap(new Object[] { 1 }, new Double[] { 1.3333333333333333D }), // typed Map
+                Collections.singletonList(1.3333333333333333D) // Tuple
         );
     }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseFloatValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseFloatValueTest.java
@@ -250,5 +250,70 @@ public class ClickHouseFloatValueTest extends BaseClickHouseValueTest {
                 buildMap(new Object[] { 1 }, new Float[] { -1F }), // typed Map
                 Arrays.asList(Float.valueOf(-1F)) // Tuple
         );
+
+        checkValue(ClickHouseFloatValue.of(4F / 3), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                true, // boolean
+                (byte) 1, // byte
+                (short) 1, // short
+                1, // int
+                1L, // long
+                1.3333334F, // float
+                (double) (4F / 3), // double
+                BigDecimal.valueOf(1L), // BigDecimal
+                BigDecimal.valueOf(1333, 3), // BigDecimal
+                BigInteger.ONE, // BigInteger
+                ClickHouseDataType.values()[1].name(), // Enum<ClickHouseDataType>
+                1.3333334F, // Object
+                LocalDate.ofEpochDay(1L), // Date
+                LocalDateTime.ofEpochSecond(1L, 0, ZoneOffset.UTC), // DateTime
+                LocalDateTime.ofEpochSecond(0L, 1333333, ZoneOffset.UTC), // DateTime(9)
+                Inet4Address.getAllByName("0.0.0.1")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:1")[0], // Inet6Address
+                "1.3333334", // String
+                "1.3333334", // SQL Expression
+                LocalTime.ofSecondOfDay(1), // Time
+                UUID.fromString("00000000-0000-0000-0000-000000000001"), // UUID
+                Object.class, // Key class
+                Float.class, // Value class
+                new Object[] { 1.3333334F }, // Array
+                new Float[] { 1.3333334F }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { 1.3333334F }), // Map
+                buildMap(new Object[] { 1 }, new Float[] { 1.3333334F }), // typed Map
+                Arrays.asList(1.3333334F) // Tuple
+        );
+        checkValue(ClickHouseFloatValue.of(-4F / 3), false, // isInfinity
+                false, // isNan
+                false, // isNull
+                IllegalArgumentException.class, // boolean
+                (byte) -1, // byte
+                (short) -1, // short
+                -1, // int
+                -1L, // long
+                -1.3333334F, // float
+                (double) (-4F / 3), // double
+                BigDecimal.valueOf(-1L), // BigDecimal
+                BigDecimal.valueOf(-1333, 3), // BigDecimal
+                BigInteger.valueOf(-1L), // BigInteger
+                IllegalArgumentException.class, // Enum<ClickHouseDataType>
+                -1.3333334F, // Object
+                LocalDate.ofEpochDay(-1L), // Date
+                LocalDateTime.ofEpochSecond(-1L, 0, ZoneOffset.UTC), // DateTime
+                LocalDateTime.ofEpochSecond(-1L, 998666666, ZoneOffset.UTC), // DateTime(9)
+                Inet4Address.getAllByName("255.255.255.255")[0], // Inet4Address
+                Inet6Address.getAllByName("0:0:0:0:0:0:0:ff")[0], // Inet6Address
+                "-1.3333334", // String
+                "-1.3333334", // SQL Expression
+                LocalTime.of(23, 59, 59), // Time
+                UUID.fromString("00000000-0000-0000-ffff-ffffffffffff"), // UUID
+                Object.class, // Key class
+                Float.class, // Value class
+                new Object[] { -1.3333334F }, // Array
+                new Float[] { -1.3333334F }, // typed Array
+                buildMap(new Object[] { 1 }, new Object[] { -1.3333334F }), // Map
+                buildMap(new Object[] { 1 }, new Float[] { -1.3333334F }), // typed Map
+                Arrays.asList(-1.3333334F) // Tuple
+        );
     }
 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java
@@ -738,11 +738,17 @@ public class ClickHouseResultSet extends AbstractResultSet {
 
     @Override
     public boolean isWrapperFor(Class<?> iface) throws SQLException {
-        return iface == ClickHouseResponse.class || super.isWrapperFor(iface);
+        return iface == ClickHouseResponse.class || iface == ClickHouseRecord.class || super.isWrapperFor(iface);
     }
 
     @Override
     public <T> T unwrap(Class<T> iface) throws SQLException {
-        return iface == ClickHouseResponse.class ? iface.cast(response) : super.unwrap(iface);
+        if (iface == ClickHouseResponse.class) {
+            return iface.cast(response);
+        } else if (iface == ClickHouseRecord.class) {
+            return iface.cast(currentRow);
+        } else {
+            return super.unwrap(iface);
+        }
     }
 }


### PR DESCRIPTION
I have faced with a problem of getting BigDecimal values from  ResultSet:
```java
resultSet.getBigDecimal("avg")
```
For example you can set the **avg**  value = 1.333334 to a cloumn
```sql
`abg` Float64
```

And when you will try to get it you will have the next exception:
```java
java.lang.ArithmeticException: Rounding necessary

	at java.base/java.math.BigDecimal.commonNeedIncrement(BigDecimal.java:4621)
	at java.base/java.math.BigDecimal.needIncrement(BigDecimal.java:4677)
	at java.base/java.math.BigDecimal.divideAndRound(BigDecimal.java:4585)
	at java.base/java.math.BigDecimal.setScale(BigDecimal.java:2891)
	at java.base/java.math.BigDecimal.setScale(BigDecimal.java:2951)
	at com.clickhouse.client.data.ClickHouseDoubleValue.asBigDecimal(ClickHouseDoubleValue.java:140)
	at com.clickhouse.client.ClickHouseValue.asBigDecimal(ClickHouseValue.java:234)
	at com.clickhouse.jdbc.ClickHouseResultSet.getBigDecimal(ClickHouseResultSet.java:237)
```

I added `RoundingMode` in order to handle decimal values
