### PR TITLE
fixed issue with null in legacy driver's json response deserializer + test

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/response/ClickHouseResponseGsonDeserializer.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/response/ClickHouseResponseGsonDeserializer.java
@@ -78,8 +78,10 @@ public class ClickHouseResponseGsonDeserializer implements JsonDeserializer<Clic
             valueStr = value.getAsString();
         } else if (value.isJsonArray()) {
             valueStr = arrayToString(value);
+        } else if (value.isJsonNull()){
+            valueStr = null;
         } else {
-            throw new IllegalArgumentException("unexpected jsonElementType: " + value.toString());
+            valueStr = value.toString();
         }
         return valueStr;
     }

--- a/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/ClickHouseStatementImplTest.java
+++ b/clickhouse-jdbc/src/test/java/ru/yandex/clickhouse/ClickHouseStatementImplTest.java
@@ -549,6 +549,16 @@ public class ClickHouseStatementImplTest extends JdbcIntegrationTest {
         }
     }
 
+    @Test(groups = "integration")
+    public void testJsonResponseWithNull() throws SQLException {
+        try (ClickHouseStatement s = connection.createStatement()) {
+            ClickHouseResponse response = s.executeQueryClickhouseResponse(
+                    "SELECT 1 AS one, 0/0 AS n");
+            assertNotNull(response);
+            assertEquals(response.getData(), Collections.singletonList(Arrays.asList("1", null)));
+        }
+    }
+
     private static String readQueryId(ClickHouseStatementImpl stmt, long timeoutSecs) {
         long start = System.currentTimeMillis();
         String value;


### PR DESCRIPTION
Hi, it seems, that I missed one corner case in https://github.com/ClickHouse/clickhouse-jdbc/pull/862

If there is NaN in response it is written as null in json "data", and my deserializer didn't check that.

This time I ran my fix through our internal tests (with wide selection of prod-like queries), and it seems that now response is deserialized like it used to before.

Example with NaN:
```
        String connectionUrl = "jdbc:clickhouse://localhost:8123/default";
        ClickHouseConnection clickHouseConnection = (ClickHouseConnection) DataSourceUtils.getConnection(
                new ClickHouseDataSource(connectionUrl, new ClickHouseProperties()));
        ClickHouseResponse clickHouseResponse = clickHouseConnection.createStatement().executeQueryClickhouseResponse("SELECT 0/0 AS n");
```

It failed with exception:
```
Exception in thread "main" java.lang.IllegalArgumentException: unexpected jsonElementType: null
	at ru.yandex.clickhouse.response.ClickHouseResponseGsonDeserializer.getAsString(ClickHouseResponseGsonDeserializer.java:82)
	at ru.yandex.clickhouse.response.ClickHouseResponseGsonDeserializer.lambda$getAsStringArray$2(ClickHouseResponseGsonDeserializer.java:69)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at ru.yandex.clickhouse.response.ClickHouseResponseGsonDeserializer.getAsStringArray(ClickHouseResponseGsonDeserializer.java:68)
	at ru.yandex.clickhouse.response.ClickHouseResponseGsonDeserializer.lambda$deserialize$1(ClickHouseResponseGsonDeserializer.java:32)
	at java.base/java.lang.Iterable.forEach(Iterable.java:75)
	at ru.yandex.clickhouse.response.ClickHouseResponseGsonDeserializer.deserialize(ClickHouseResponseGsonDeserializer.java:31)
	at ru.yandex.clickhouse.response.ClickHouseResponseGsonDeserializer.deserialize(ClickHouseResponseGsonDeserializer.java:14)
	at com.google.gson.internal.bind.TreeTypeAdapter.read(TreeTypeAdapter.java:69)
```