### PR TITLE
Upgrade gRPC libs

### DIFF
--- a/.github/workflows/third_party_libs.yml
+++ b/.github/workflows/third_party_libs.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Release version"
         required: true
-        default: "1.0.0"
+        default: "1.2.0"
 
 jobs:
   release:

--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -34,6 +34,7 @@ jobs:
         serverTz: ["Asia/Chongqing", "America/Los_Angeles", "Etc/UTC", "Europe/Berlin", "Europe/Moscow"]
         clientTz: ["Asia/Chongqing", "America/Los_Angeles", "Etc/UTC", "Europe/Berlin", "Europe/Moscow"]
       fail-fast: false
+    timeout-minutes: 30
     name: "TimeZone(C/S): ${{ matrix.clientTz }} vs. ${{ matrix.serverTz }}"
     steps:
       - name: Check out Git repository
@@ -67,3 +68,12 @@ jobs:
             -DclickhouseVersion=22.3 \
             -Duser.timezone=${{ matrix.clientTz }} \
             --also-make clean verify
+      - name: Upload test results
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: result ${{ github.job }}
+          path: |
+            **/target/failsafe-reports
+            **/target/surefire-reports
+

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <grpc.version>1.45.1</grpc.version>
         <gson.version>2.9.0</gson.version>
         <httpclient.version>4.5.13</httpclient.version>
-        <protobuf.version>3.17.3</protobuf.version>
+        <protobuf.version>3.19.2</protobuf.version>
         <lz4.version>1.8.0</lz4.version>
         <roaring-bitmap.version>0.9.25</roaring-bitmap.version>
         <slf4j.version>2.0.0-alpha5</slf4j.version>
@@ -100,7 +100,7 @@
         <mysql-driver.version>8.0.28</mysql-driver.version>
         <postgresql-driver.version>42.3.3</postgresql-driver.version>
 
-        <repackaged.version>1.1.2</repackaged.version>
+        <repackaged.version>1.2.0</repackaged.version>
 
         <assembly-plugin.version>3.3.0</assembly-plugin.version>
         <compiler-plugin.version>3.8.1</compiler-plugin.version>

--- a/third-party-libraries/pom.xml
+++ b/third-party-libraries/pom.xml
@@ -68,14 +68,14 @@
     </distributionManagement>
 
     <properties>
-        <revision>1.1.2</revision>
+        <revision>1.2.0</revision>
         <project.current.year>2022</project.current.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <grpc.version>1.45.1</grpc.version>
         <gson.version>2.9.0</gson.version>
         <opencensus.version>0.28.3</opencensus.version>
-        <roaring-bitmap.version>0.9.25</roaring-bitmap.version>
+        <roaring-bitmap.version>0.9.27</roaring-bitmap.version>
         <assembly-plugin.version>3.3.0</assembly-plugin.version>
         <deploy-plugin.version>3.0.0-M1</deploy-plugin.version>
         <flatten-plugin.version>1.2.7</flatten-plugin.version>


### PR DESCRIPTION
This is a follow-up of #936.

CI will fail until we get this PR merged and release 3rd party libs 1.2.0.