### PR TITLE
Support for custom url path

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -125,21 +125,8 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
         StringBuilder builder = new StringBuilder();
         builder.append(config.isSsl() ? "https" : "http").append("://").append(server.getHost()).append(':')
                 .append(server.getPort()).append('/');
-        String context = (String) config.getOption(ClickHouseHttpOption.WEB_CONTEXT);
-        if (context != null && !context.isEmpty()) {
-            char prev = '/';
-            for (int i = 0, len = context.length(); i < len; i++) {
-                char ch = context.charAt(i);
-                if (ch != '/' || ch != prev) {
-                    builder.append(ch);
-                }
-                prev = ch;
-            }
 
-            if (prev != '/') {
-                builder.append('/');
-            }
-        }
+        builder.append(buildUrlPath(config));
 
         String query = buildQueryParams(request);
         if (!query.isEmpty()) {
@@ -147,6 +134,33 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
         }
 
         return builder.toString();
+    }
+
+    private static String buildUrlPath(ClickHouseConfig config) {
+        StringBuilder contextBuilder = new StringBuilder();
+        String context = (String) config.getOption(ClickHouseHttpOption.WEB_CONTEXT);
+        if (context != null && !context.isEmpty()) {
+
+            char prev = '/';
+            for (int i = 0, len = context.length(); i < len; i++) {
+                char ch = context.charAt(i);
+                if (ch != '/' || ch != prev) {
+                    contextBuilder.append(ch);
+                }
+                prev = ch;
+            }
+
+            if (prev != '/') {
+                contextBuilder.append('/');
+            }
+        }
+
+        String customPath = (String) config.getOption(ClickHouseHttpOption.CUSTOM_URL_PATH);
+        if (customPath != null && !customPath.isEmpty()) {
+            contextBuilder.append(customPath);
+        }
+
+        return contextBuilder.toString();
     }
 
     protected final ClickHouseConfig config;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -150,14 +150,6 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
                 prev = ch;
             }
 
-            if (prev != '/') {
-                contextBuilder.append('/');
-            }
-        }
-
-        String customPath = (String) config.getOption(ClickHouseHttpOption.CUSTOM_URL_PATH);
-        if (customPath != null && !customPath.isEmpty()) {
-            contextBuilder.append(customPath);
         }
 
         return contextBuilder.toString();
@@ -236,6 +228,17 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
         }
 
         return baseUrl;
+    }
+
+    protected String getPingUrl() {
+        StringBuilder pingUrlBuilder = new StringBuilder();
+        String baseUrl = getBaseUrl();
+        pingUrlBuilder.append(baseUrl);
+        if (!baseUrl.endsWith("/")) {
+            pingUrlBuilder.append("/");
+        }
+        pingUrlBuilder.append("ping");
+        return pingUrlBuilder.toString();
     }
 
     /**

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/HttpUrlConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/HttpUrlConnectionImpl.java
@@ -258,7 +258,8 @@ public class HttpUrlConnectionImpl extends ClickHouseHttpConnection {
         String response = (String) config.getOption(ClickHouseHttpOption.DEFAULT_RESPONSE);
         HttpURLConnection c = null;
         try {
-            c = newConnection(getBaseUrl() + "ping", false);
+            String pingUrl = getPingUrl();
+            c = newConnection(pingUrl, false);
             c.setConnectTimeout(timeout);
             c.setReadTimeout(timeout);
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -23,10 +23,6 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      */
     CUSTOM_PARAMS("custom_http_params", "", "Custom HTTP query parameters."),
     /**
-     * Custom additional URL path.
-     */
-    CUSTOM_URL_PATH("custom_url_path", "", "Custom additional URL path."),
-    /**
      * Default server response.
      */
     DEFAULT_RESPONSE("http_server_default_response", "Ok.\n",

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -23,6 +23,10 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      */
     CUSTOM_PARAMS("custom_http_params", "", "Custom HTTP query parameters."),
     /**
+     * Custom additional URL path.
+     */
+    CUSTOM_URL_PATH("custom_url_path", "", "Custom additional URL path."),
+    /**
      * Default server response.
      */
     DEFAULT_RESPONSE("http_server_default_response", "Ok.\n",

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -14,7 +14,6 @@ import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.client.logging.Logger;
 import com.clickhouse.client.logging.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.InputStream;
@@ -119,7 +118,7 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
         }
 
         httpClient = builder.build();
-        pingRequest = newRequest(getBaseUrl() + "ping");
+        pingRequest = newRequest(getPingUrl());
     }
 
     @Override

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
@@ -65,7 +65,7 @@ public class ClickHouseHttpConnectionTest {
                 "http://localhost:8123/?compress=1&extremes=0");
         Assert.assertEquals(
                 ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, ".")),
-                "http://localhost:8123/./?compress=1&extremes=0");
+                "http://localhost:8123/.?compress=1&extremes=0");
         Assert.assertEquals(
                 ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, "./")),
                 "http://localhost:8123/./?compress=1&extremes=0");


### PR DESCRIPTION
Motivation:
Useful with http proxy. Previous version in `ru.yandex.clickhouse` has this feature with option USE_PATH_AS_DB=false.

current driver has WEB_CONTEXT option but it used only with trailing slash