### PR TITLE
Multi-endpoint support

### DIFF
--- a/clickhouse-benchmark/pom.xml
+++ b/clickhouse-benchmark/pom.xml
@@ -37,6 +37,7 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- JDBC drivers -->
         <dependency>
             <groupId>ru.yandex.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>
@@ -49,33 +50,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>clickhouse-client</artifactId>
-            <version>${revision}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>clickhouse-grpc-client</artifactId>
-            <version>${revision}</version>
-            <!-- exclusions>
-                <exclusion>
-                    <groupId>${project.parent.groupId}</groupId>
-                    <artifactId>io.grpc</artifactId>
-                </exclusion>
-            </exclusions -->
-        </dependency>
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-netty-shaded</artifactId>
-        </dependency>
-        <!-- separate classifier did not work well with flatten plugin -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-okhttp</artifactId>
-        </dependency>
-
-        <!-- JDBC drivers -->
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-jdbc</artifactId>

--- a/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
+++ b/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
@@ -49,6 +49,12 @@ public class ClickHouseCommandLineClientTest extends ClientIntegrationTest {
 
     @Test(groups = { "integration" })
     @Override
+    public void testCustomLoad() throws Exception {
+        throw new SkipException("Skip due to time out error");
+    }
+
+    @Test(groups = { "integration" })
+    @Override
     public void testLoadRawData() throws Exception {
         throw new SkipException("Skip due to response summary is always empty");
     }
@@ -56,17 +62,23 @@ public class ClickHouseCommandLineClientTest extends ClientIntegrationTest {
     @Test(groups = { "integration" })
     @Override
     public void testMultipleQueries() throws Exception {
-        // FIXME not sure if the occasional "Stream closed" exception is related to zeroturnaround/zt-exec#30 or not
+        // FIXME not sure if the occasional "Stream closed" exception is related to
+        // zeroturnaround/zt-exec#30 or not
         /*
-        Caused by: java.io.IOException: Stream closed
-            at java.io.BufferedInputStream.getBufIfOpen(BufferedInputStream.java:170)
-            at java.io.BufferedInputStream.read(BufferedInputStream.java:336)
-            at com.clickhouse.client.stream.WrappedInputStream.updateBuffer(WrappedInputStream.java:32)
-            at com.clickhouse.client.stream.AbstractByteArrayInputStream.available(AbstractByteArrayInputStream.java:56)
-            at com.clickhouse.client.ClickHouseDataProcessor.hasNext(ClickHouseDataProcessor.java:126)
+         * Caused by: java.io.IOException: Stream closed
+         * at java.io.BufferedInputStream.getBufIfOpen(BufferedInputStream.java:170)
+         * at java.io.BufferedInputStream.read(BufferedInputStream.java:336)
+         * at com.clickhouse.client.stream.WrappedInputStream.updateBuffer(
+         * WrappedInputStream.java:32)
+         * at com.clickhouse.client.stream.AbstractByteArrayInputStream.available(
+         * AbstractByteArrayInputStream.java:56)
+         * at
+         * com.clickhouse.client.ClickHouseDataProcessor.hasNext(ClickHouseDataProcessor
+         * .java:126)
          */
         throw new SkipException("Skip due to unknown cause");
     }
+
     @Test(groups = { "integration" })
     @Override
     public void testReadWriteGeoTypes() {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/AbstractClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/AbstractClient.java
@@ -7,6 +7,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseHealthCheckMethod;
@@ -206,6 +207,39 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
             }
         }
         return ClickHouseClient.super.accept(protocol);
+    }
+
+    @Override
+    public ClickHouseRequest<?> connect(ClickHouseNode node) {
+        lock.readLock().lock();
+        try {
+            ensureInitialized();
+            return ClickHouseClient.super.connect(node);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public ClickHouseRequest<?> connect(ClickHouseNodes nodes) {
+        lock.readLock().lock();
+        try {
+            ensureInitialized();
+            return ClickHouseClient.super.connect(nodes);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public ClickHouseRequest<?> connect(Function<ClickHouseNodeSelector, ClickHouseNode> nodeFunc) {
+        lock.readLock().lock();
+        try {
+            ensureInitialized();
+            return ClickHouseClient.super.connect(nodeFunc);
+        } finally {
+            lock.readLock().unlock();
+        }
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/AbstractClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/AbstractClient.java
@@ -1,11 +1,15 @@
 package com.clickhouse.client;
 
+import java.io.IOException;
+import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
+import com.clickhouse.client.config.ClickHouseClientOption;
+import com.clickhouse.client.config.ClickHouseHealthCheckMethod;
 import com.clickhouse.client.logging.Logger;
 import com.clickhouse.client.logging.LoggerFactory;
 
@@ -36,6 +40,8 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
         return initialized;
     }
 
+    protected abstract boolean checkHealth(ClickHouseNode server, int timeout);
+
     protected CompletableFuture<ClickHouseResponse> failedResponse(Throwable ex) {
         CompletableFuture<ClickHouseResponse> future = new CompletableFuture<>();
         future.completeExceptionally(ex);
@@ -58,6 +64,13 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
             lock.readLock().unlock();
         }
     }
+
+    /**
+     * Gets list of supported protocols.
+     *
+     * @return non-null list of supported protocols
+     */
+    protected abstract Collection<ClickHouseProtocol> getSupportedProtocols();
 
     /**
      * Gets current server.
@@ -118,6 +131,42 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
     protected abstract void closeConnection(T connection, boolean force);
 
     /**
+     * Gets arguments required for async execution. This method will be executed in
+     * current thread right before {@link #sendAsync(ClickHouseRequest, Object...)}.
+     *
+     * @param sealedRequest non-null sealed request
+     * @return arguments required for async execution
+     */
+    protected Object[] getAsyncExecArguments(ClickHouseRequest<?> sealedRequest) {
+        return new Object[0];
+    }
+
+    /**
+     * Sends the request to server in a separate thread.
+     *
+     * @param sealedRequest non-null sealed request
+     * @param args          arguments required for sending out the request
+     * @return non-null response
+     * @throws ClickHouseException when error server failed to process the request
+     * @throws IOException         when error occurred sending the request
+     */
+    protected ClickHouseResponse sendAsync(ClickHouseRequest<?> sealedRequest, Object... args)
+            throws ClickHouseException, IOException {
+        return send(sealedRequest);
+    }
+
+    /**
+     * Sends the request to server in a current thread.
+     *
+     * @param sealedRequest non-null sealed request
+     * @return non-null response
+     * @throws ClickHouseException when error server failed to process the request
+     * @throws IOException         when error occurred sending the request
+     */
+    protected abstract ClickHouseResponse send(ClickHouseRequest<?> sealedRequest)
+            throws ClickHouseException, IOException;
+
+    /**
      * Gets a connection according to the given request.
      *
      * @param request non-null request
@@ -150,6 +199,16 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
     }
 
     @Override
+    public boolean accept(ClickHouseProtocol protocol) {
+        for (ClickHouseProtocol p : getSupportedProtocols()) {
+            if (p == protocol) {
+                return true;
+            }
+        }
+        return ClickHouseClient.super.accept(protocol);
+    }
+
+    @Override
     public final ClickHouseConfig getConfig() {
         lock.readLock().lock();
         try {
@@ -166,7 +225,12 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
 
         lock.writeLock().lock();
         try {
-            this.config = config;
+            Collection<ClickHouseProtocol> protocols = getSupportedProtocols();
+            this.config = new ClickHouseConfig(config.getAllOptions(), config.getDefaultCredentials(),
+                    config.getNodeSelector() != ClickHouseNodeSelector.EMPTY || protocols.isEmpty()
+                            ? config.getNodeSelector()
+                            : ClickHouseNodeSelector.of(protocols, null),
+                    config.getMetricRegistry().orElse(null));
             if (this.executor == null) { // only initialize once
                 int threads = config.getMaxThreadsPerClient();
                 this.executor = threads < 1 ? ClickHouseClient.getExecutorService()
@@ -176,6 +240,29 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
             initialized = true;
         } finally {
             lock.writeLock().unlock();
+        }
+    }
+
+    @Override
+    public CompletableFuture<ClickHouseResponse> execute(ClickHouseRequest<?> request) {
+        // sealedRequest is an immutable copy of the original request
+        final ClickHouseRequest<?> sealedRequest = request.seal();
+
+        if (sealedRequest.getConfig().isAsync()) {
+            final Object[] args = getAsyncExecArguments(sealedRequest);
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    return sendAsync(sealedRequest, args);
+                } catch (ClickHouseException | IOException e) {
+                    throw new CompletionException(ClickHouseException.of(e, sealedRequest.getServer()));
+                }
+            }, getExecutor());
+        } else {
+            try {
+                return CompletableFuture.completedFuture(send(sealedRequest));
+            } catch (ClickHouseException | IOException e) {
+                return failedResponse(ClickHouseException.of(e, sealedRequest.getServer()));
+            }
         }
     }
 
@@ -222,5 +309,20 @@ public abstract class AbstractClient<T> implements ClickHouseClient {
                 lock.writeLock().unlock();
             }
         }
+    }
+
+    @Override
+    public boolean ping(ClickHouseNode server, int timeout) {
+        if (server == null) {
+            return false;
+        } else if (server.config.getOption(ClickHouseClientOption.HEALTH_CHECK_METHOD,
+                getConfig()) != ClickHouseHealthCheckMethod.PING) {
+            return ClickHouseClient.super.ping(server, timeout);
+        }
+
+        if (server.getProtocol() == ClickHouseProtocol.ANY) {
+            server = ClickHouseNode.probe(server.getHost(), server.getPort(), timeout);
+        }
+        return checkHealth(server, timeout);
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClientBuilder.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClientBuilder.java
@@ -5,9 +5,19 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.clickhouse.client.config.ClickHouseOption;
+import com.clickhouse.client.logging.Logger;
+import com.clickhouse.client.logging.LoggerFactory;
+import com.clickhouse.client.ClickHouseNode.Status;
 import com.clickhouse.client.config.ClickHouseDefaults;
 
 /**
@@ -16,10 +26,203 @@ import com.clickhouse.client.config.ClickHouseDefaults;
  * multi-threading as it's NOT thread-safe.
  */
 public class ClickHouseClientBuilder {
+    /**
+     * Dummy client which is only used {@link Agent}.
+     */
+    static class DummyClient implements ClickHouseClient {
+        static final ClickHouseConfig CONFIG = new ClickHouseConfig();
+        static final DummyClient INSTANCE = new DummyClient();
+
+        @Override
+        public boolean accept(ClickHouseProtocol protocol) {
+            return true;
+        }
+
+        @Override
+        public CompletableFuture<ClickHouseResponse> execute(ClickHouseRequest<?> request) {
+            return CompletableFuture.completedFuture(ClickHouseResponse.EMPTY);
+        }
+
+        @Override
+        public ClickHouseConfig getConfig() {
+            return CONFIG;
+        }
+
+        @Override
+        public void close() {
+            // do nothing
+        }
+
+        @Override
+        public boolean ping(ClickHouseNode server, int timeout) {
+            return true;
+        }
+    }
+
+    /**
+     * Thread-safe wrapper of {@link ClickHouseClient} for collecting metrics and
+     * fail-over.
+     */
+    static final class Agent implements ClickHouseClient {
+        private static final Logger log = LoggerFactory.getLogger(Agent.class);
+
+        private final AtomicReference<ClickHouseClient> client;
+
+        Agent(ClickHouseClient client) {
+            this.client = new AtomicReference<>(client != null ? client : DummyClient.INSTANCE);
+        }
+
+        ClickHouseClient getClient() {
+            return client.get();
+        }
+
+        ClickHouseResponse failover(ClickHouseRequest<?> sealedRequest, Throwable cause, int times) {
+            for (int i = 1; i <= times; i++) {
+                log.debug("Failover %d of %d due to: %s", i, times, cause.getMessage());
+                ClickHouseNode current = sealedRequest.getServer();
+                ClickHouseNodeManager manager = current.manager.get();
+                if (manager == null) {
+                    break;
+                }
+                ClickHouseNode next = manager.suggestNode(current, cause);
+                if (next == current) {
+                    break;
+                }
+                current.update(Status.FAULTY);
+                next = sealedRequest.changeServer(current, next);
+                if (next == current) {
+                    break;
+                }
+
+                log.info("Switching to %s due to connection issue with %s", next, current);
+                final ClickHouseProtocol protocol = next.getProtocol();
+                client.getAndUpdate(c -> {
+                    if (!c.accept(protocol)) {
+                        c.close();
+                        return ClickHouseClient.newInstance(protocol);
+                    }
+                    return c;
+                });
+                try {
+                    return sendOnce(sealedRequest);
+                } catch (Exception exp) {
+                    cause = exp.getCause();
+                    if (cause == null) {
+                        cause = exp;
+                    }
+                }
+            }
+
+            throw new CompletionException(cause);
+        }
+
+        ClickHouseResponse retry(ClickHouseRequest<?> sealedRequest, Throwable cause, int times) {
+            for (int i = 1; i <= times; i++) {
+                log.debug("Retry %d of %d due to: %s", i, times, cause.getMessage());
+                // TODO retry idempotent query
+                if (cause instanceof ClickHouseException
+                        && ((ClickHouseException) cause).getErrorCode() == ClickHouseException.ERROR_NETWORK) {
+                    log.info("Retry request on %s due to connection issue", sealedRequest.getServer());
+                    try {
+                        return sendOnce(sealedRequest);
+                    } catch (Exception exp) {
+                        cause = exp.getCause();
+                        if (cause == null) {
+                            cause = exp;
+                        }
+                    }
+                }
+            }
+
+            throw new CompletionException(cause);
+        }
+
+        ClickHouseResponse handle(ClickHouseRequest<?> sealedRequest, Throwable cause) {
+            try {
+                int times = sealedRequest.getConfig().getFailover();
+                if (times > 0) {
+                    return failover(sealedRequest, cause, times);
+                }
+
+                // different from failover: 1) retry on the same node; 2) never retry on timeout
+                times = sealedRequest.getConfig().getRetry();
+                if (times > 0) {
+                    return retry(sealedRequest, cause, times);
+                }
+
+                throw new CompletionException(cause);
+            } catch (CompletionException e) {
+                throw e;
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+        }
+
+        ClickHouseResponse sendOnce(ClickHouseRequest<?> sealedRequest) {
+            try {
+                return getClient().execute(sealedRequest).get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new CancellationException("Execution was interrupted");
+            } catch (ExecutionException e) {
+                throw new CompletionException(e.getCause());
+            }
+        }
+
+        ClickHouseResponse send(ClickHouseRequest<?> sealedRequest) {
+            try {
+                return sendOnce(sealedRequest);
+            } catch (CompletionException e) {
+                return handle(sealedRequest, e.getCause());
+            }
+        }
+
+        @Override
+        public boolean accept(ClickHouseProtocol protocol) {
+            return client.get().accept(protocol);
+        }
+
+        @Override
+        public Class<? extends ClickHouseOption> getOptionClass() {
+            return client.get().getOptionClass();
+        }
+
+        @Override
+        public void init(ClickHouseConfig config) {
+            client.get().init(config);
+        }
+
+        @Override
+        public boolean ping(ClickHouseNode server, int timeout) {
+            return client.get().ping(server, timeout);
+        }
+
+        @Override
+        public CompletableFuture<ClickHouseResponse> execute(ClickHouseRequest<?> request) {
+            final ClickHouseRequest<?> sealedRequest = request.seal();
+            return sealedRequest.getConfig().isAsync()
+                    ? getClient().execute(sealedRequest)
+                            .handle((r, t) -> t == null ? r : handle(sealedRequest, t.getCause()))
+                    : CompletableFuture.completedFuture(send(sealedRequest));
+        }
+
+        @Override
+        public ClickHouseConfig getConfig() {
+            return client.get().getConfig();
+        }
+
+        @Override
+        public void close() {
+            client.get().close();
+        }
+    }
+
     // expose method to change default thread pool in runtime? JMX?
     static final ExecutorService defaultExecutor;
+    static final ScheduledExecutorService defaultScheduler;
 
     static {
+        int maxSchedulers = (int) ClickHouseDefaults.MAX_SCHEDULER_THREADS.getEffectiveDefaultValue();
         int maxThreads = (int) ClickHouseDefaults.MAX_THREADS.getEffectiveDefaultValue();
         int maxRequests = (int) ClickHouseDefaults.MAX_REQUESTS.getEffectiveDefaultValue();
         long keepAliveTimeoutMs = (long) ClickHouseDefaults.THREAD_KEEPALIVE_TIMEOUT.getEffectiveDefaultValue();
@@ -27,14 +230,30 @@ public class ClickHouseClientBuilder {
         if (maxThreads <= 0) {
             maxThreads = Runtime.getRuntime().availableProcessors();
         }
+        if (maxSchedulers <= 0) {
+            maxSchedulers = Runtime.getRuntime().availableProcessors();
+        } else if (maxSchedulers > maxThreads) {
+            maxSchedulers = maxThreads;
+        }
+
         if (maxRequests <= 0) {
             maxRequests = 0;
         }
 
-        defaultExecutor = ClickHouseUtils.newThreadPool(ClickHouseClient.class.getSimpleName(), maxThreads,
-                maxThreads * 2, maxRequests, keepAliveTimeoutMs, false);
+        String prefix = "ClickHouseClientWorker";
+        defaultExecutor = ClickHouseUtils.newThreadPool(prefix, maxThreads, maxThreads * 2, maxRequests,
+                keepAliveTimeoutMs, false);
+        prefix = "ClickHouseClientScheduler";
+        defaultScheduler = maxSchedulers == 1 ? Executors
+                .newSingleThreadScheduledExecutor(new ClickHouseThreadFactory(prefix))
+                : Executors.newScheduledThreadPool(maxSchedulers, new ClickHouseThreadFactory(prefix));
     }
 
+    static ServiceLoader<ClickHouseClient> loadClients() {
+        return ServiceLoader.load(ClickHouseClient.class, ClickHouseClientBuilder.class.getClassLoader());
+    }
+
+    protected boolean agent;
     protected ClickHouseConfig config;
 
     protected ClickHouseCredentials credentials;
@@ -47,6 +266,10 @@ public class ClickHouseClientBuilder {
      * Default constructor.
      */
     protected ClickHouseClientBuilder() {
+        agent = true;
+        config = null;
+        metricRegistry = null;
+        nodeSelector = null;
         options = new HashMap<>();
     }
 
@@ -91,7 +314,7 @@ public class ClickHouseClientBuilder {
         boolean noSelector = nodeSelector == null || nodeSelector == ClickHouseNodeSelector.EMPTY;
         int counter = 0;
         ClickHouseConfig conf = getConfig();
-        for (ClickHouseClient c : ServiceLoader.load(ClickHouseClient.class, getClass().getClassLoader())) {
+        for (ClickHouseClient c : loadClients()) {
             c.init(conf);
 
             counter++;
@@ -106,7 +329,19 @@ public class ClickHouseClientBuilder {
                     ClickHouseUtils.format("No suitable ClickHouse client(out of %d) found in classpath.", counter));
         }
 
-        return client;
+        return agent ? new Agent(client) : client;
+    }
+
+    /**
+     * Sets whether agent should be used for advanced feature like failover and
+     * retry.
+     *
+     * @param agent whether to use agent
+     * @return this builder
+     */
+    public ClickHouseClientBuilder agent(boolean agent) {
+        this.agent = agent;
+        return this;
     }
 
     /**
@@ -190,7 +425,7 @@ public class ClickHouseClientBuilder {
      * @return this builder
      */
     public ClickHouseClientBuilder defaultCredentials(ClickHouseCredentials credentials) {
-        if (!ClickHouseChecker.nonNull(credentials, "credentials").equals(this.credentials)) {
+        if (!Objects.equals(this.credentials, credentials)) {
             this.credentials = credentials;
             resetConfig();
         }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseColumn.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseColumn.java
@@ -521,6 +521,10 @@ public final class ClickHouseColumn implements Serializable {
         return dataType == ClickHouseDataType.Tuple;
     }
 
+    public boolean isNestedType() {
+        return dataType.isNested();
+    }
+
     public int getArrayNestedLevel() {
         return arrayLevel;
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataStreamFactory.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataStreamFactory.java
@@ -140,7 +140,9 @@ public class ClickHouseDataStreamFactory {
     /**
      * Creates a piped output stream.
      *
-     * @param config non-null configuration
+     * @param config          non-null configuration
+     * @param postCloseAction custom action will be performed right after closing
+     *                        the output stream
      * @return piped output stream
      */
     public ClickHousePipedOutputStream createPipedOutputStream(ClickHouseConfig config, Runnable postCloseAction) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataType.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataType.java
@@ -31,72 +31,76 @@ import java.util.UUID;
  */
 @SuppressWarnings("squid:S115")
 public enum ClickHouseDataType {
-    IntervalYear(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalQuarter(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalMonth(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalWeek(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalDay(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalHour(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalMinute(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    IntervalSecond(Long.class, false, true, true, 8, 19, 0, 0, 0),
-    UInt8(Short.class, false, true, false, 1, 3, 0, 0, 0, "INT1 UNSIGNED", "TINYINT UNSIGNED"),
-    UInt16(Integer.class, false, true, false, 2, 5, 0, 0, 0, "SMALLINT UNSIGNED"),
-    UInt32(Long.class, false, true, false, 4, 10, 0, 0, 0, "INT UNSIGNED", "INTEGER UNSIGNED", "MEDIUMINT UNSIGNED"),
-    UInt64(Long.class, false, true, false, 8, 20, 0, 0, 0, "BIGINT UNSIGNED"),
-    UInt128(BigInteger.class, false, true, false, 16, 39, 0, 0, 0),
-    UInt256(BigInteger.class, false, true, false, 32, 78, 0, 0, 0),
-    Int8(Byte.class, false, true, true, 1, 3, 0, 0, 0, "BYTE", "INT1", "INT1 SIGNED", "TINYINT", "TINYINT SIGNED"),
-    Int16(Short.class, false, true, true, 2, 5, 0, 0, 0, "SMALLINT", "SMALLINT SIGNED"),
-    Int32(Integer.class, false, true, true, 4, 10, 0, 0, 0, "INT", "INTEGER", "MEDIUMINT", "INT SIGNED",
+    IntervalYear(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalQuarter(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalMonth(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalWeek(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalDay(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalHour(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalMinute(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    IntervalSecond(Long.class, false, true, true, 8, 19, 0, 0, 0, false),
+    UInt8(Short.class, false, true, false, 1, 3, 0, 0, 0, false, "INT1 UNSIGNED", "TINYINT UNSIGNED"),
+    UInt16(Integer.class, false, true, false, 2, 5, 0, 0, 0, false, "SMALLINT UNSIGNED"),
+    UInt32(Long.class, false, true, false, 4, 10, 0, 0, 0, false, "INT UNSIGNED", "INTEGER UNSIGNED",
+            "MEDIUMINT UNSIGNED"),
+    UInt64(Long.class, false, true, false, 8, 20, 0, 0, 0, false, "BIGINT UNSIGNED"),
+    UInt128(BigInteger.class, false, true, false, 16, 39, 0, 0, 0, false),
+    UInt256(BigInteger.class, false, true, false, 32, 78, 0, 0, 0, false),
+    Int8(Byte.class, false, true, true, 1, 3, 0, 0, 0, false, "BYTE", "INT1", "INT1 SIGNED", "TINYINT",
+            "TINYINT SIGNED"),
+    Int16(Short.class, false, true, true, 2, 5, 0, 0, 0, false, "SMALLINT", "SMALLINT SIGNED"),
+    Int32(Integer.class, false, true, true, 4, 10, 0, 0, 0, false, "INT", "INTEGER", "MEDIUMINT", "INT SIGNED",
             "INTEGER SIGNED", "MEDIUMINT SIGNED"),
-    Int64(Long.class, false, true, true, 8, 19, 0, 0, 0, "BIGINT", "BIGINT SIGNED"),
-    Int128(BigInteger.class, false, true, true, 16, 39, 0, 0, 0),
-    Int256(BigInteger.class, false, true, true, 32, 77, 0, 0, 0),
-    Bool(Boolean.class, false, false, true, 1, 1, 0, 0, 0, "BOOLEAN"),
-    Date(LocalDate.class, false, false, false, 2, 10, 0, 0, 0),
-    Date32(LocalDate.class, false, false, false, 4, 10, 0, 0, 0),
-    DateTime(LocalDateTime.class, true, false, false, 0, 29, 0, 0, 9, "TIMESTAMP"),
-    DateTime32(LocalDateTime.class, true, false, false, 4, 19, 0, 0, 0),
-    DateTime64(LocalDateTime.class, true, false, false, 8, 29, 3, 0, 9),
-    Decimal(BigDecimal.class, true, false, true, 0, 76, 0, 0, 76, "DEC", "NUMERIC", "FIXED"),
-    Decimal32(BigDecimal.class, true, false, true, 4, 9, 9, 0, 9),
-    Decimal64(BigDecimal.class, true, false, true, 8, 18, 18, 0, 18),
-    Decimal128(BigDecimal.class, true, false, true, 16, 38, 38, 0, 38),
-    Decimal256(BigDecimal.class, true, false, true, 32, 76, 20, 0, 76),
-    UUID(UUID.class, false, true, false, 16, 69, 0, 0, 0),
+    Int64(Long.class, false, true, true, 8, 19, 0, 0, 0, false, "BIGINT", "BIGINT SIGNED"),
+    Int128(BigInteger.class, false, true, true, 16, 39, 0, 0, 0, false),
+    Int256(BigInteger.class, false, true, true, 32, 77, 0, 0, 0, false),
+    Bool(Boolean.class, false, false, true, 1, 1, 0, 0, 0, false, "BOOLEAN"),
+    Date(LocalDate.class, false, false, false, 2, 10, 0, 0, 0, false),
+    Date32(LocalDate.class, false, false, false, 4, 10, 0, 0, 0, false),
+    DateTime(LocalDateTime.class, true, false, false, 0, 29, 0, 0, 9, false, "TIMESTAMP"),
+    DateTime32(LocalDateTime.class, true, false, false, 4, 19, 0, 0, 0, false),
+    DateTime64(LocalDateTime.class, true, false, false, 8, 29, 3, 0, 9, false),
+    Decimal(BigDecimal.class, true, false, true, 0, 76, 0, 0, 76, false, "DEC", "NUMERIC", "FIXED"),
+    Decimal32(BigDecimal.class, true, false, true, 4, 9, 9, 0, 9, false),
+    Decimal64(BigDecimal.class, true, false, true, 8, 18, 18, 0, 18, false),
+    Decimal128(BigDecimal.class, true, false, true, 16, 38, 38, 0, 38, false),
+    Decimal256(BigDecimal.class, true, false, true, 32, 76, 20, 0, 76, false),
+    UUID(UUID.class, false, true, false, 16, 69, 0, 0, 0, false),
     /**
      * Enum data type.
      *
      * @deprecated will be removed in v0.3.3, please use {@link #Enum8} instead
      */
     @Deprecated
-    Enum(String.class, true, true, false, 1, 0, 0, 0, 0),
-    Enum8(String.class, true, true, false, 1, 0, 0, 0, 0), // "ENUM"),
-    Enum16(String.class, true, true, false, 2, 0, 0, 0, 0),
-    Float32(Float.class, false, true, true, 4, 12, 0, 0, 38, "FLOAT", "REAL", "SINGLE"),
-    Float64(Double.class, false, true, true, 16, 22, 0, 0, 308, "DOUBLE", "DOUBLE PRECISION"),
-    IPv4(Inet4Address.class, false, true, false, 4, 10, 0, 0, 0, "INET4"),
-    IPv6(Inet6Address.class, false, true, false, 16, 39, 0, 0, 0, "INET6"),
-    FixedString(String.class, true, true, false, 0, 0, 0, 0, 0, "BINARY"),
-    String(String.class, false, true, false, 0, 0, 0, 0, 0, "BINARY LARGE OBJECT", "BINARY VARYING", "BLOB", "BYTEA",
+    Enum(String.class, true, true, false, 1, 0, 0, 0, 0, false),
+    Enum8(String.class, true, true, false, 1, 0, 0, 0, 0, false), // "ENUM"),
+    Enum16(String.class, true, true, false, 2, 0, 0, 0, 0, false),
+    Float32(Float.class, false, true, true, 4, 12, 0, 0, 38, false, "FLOAT", "REAL", "SINGLE"),
+    Float64(Double.class, false, true, true, 16, 22, 0, 0, 308, false, "DOUBLE", "DOUBLE PRECISION"),
+    IPv4(Inet4Address.class, false, true, false, 4, 10, 0, 0, 0, false, "INET4"),
+    IPv6(Inet6Address.class, false, true, false, 16, 39, 0, 0, 0, false, "INET6"),
+    FixedString(String.class, true, true, false, 0, 0, 0, 0, 0, false, "BINARY"),
+    String(String.class, false, true, false, 0, 0, 0, 0, 0, false, "BINARY LARGE OBJECT", "BINARY VARYING", "BLOB",
+            "BYTEA",
             "CHAR", "CHARACTER", "CHARACTER LARGE OBJECT", "CHARACTER VARYING", "CHAR LARGE OBJECT", "CHAR VARYING",
             "CLOB", "LONGBLOB", "LONGTEXT", "MEDIUMBLOB", "MEDIUMTEXT", "NATIONAL CHAR", "NATIONAL CHARACTER",
             "NATIONAL CHARACTER LARGE OBJECT", "NATIONAL CHARACTER VARYING", "NATIONAL CHAR VARYING", "NCHAR",
             "NCHAR LARGE OBJECT", "NCHAR VARYING", "NVARCHAR", "TEXT", "TINYBLOB", "TINYTEXT", "VARBINARY", "VARCHAR",
             "VARCHAR2"),
-    AggregateFunction(String.class, true, true, false, 0, 0, 0, 0, 0), // implementation-defined intermediate state
-    SimpleAggregateFunction(String.class, true, true, false, 0, 0, 0, 0, 0),
-    Array(Object.class, true, true, false, 0, 0, 0, 0, 0),
-    Map(Map.class, true, true, false, 0, 0, 0, 0, 0),
-    Nested(Object.class, true, true, false, 0, 0, 0, 0, 0),
-    Tuple(List.class, true, true, false, 0, 0, 0, 0, 0),
-    Object(Object.class, true, true, false, 0, 0, 0, 0, 0),
-    JSON(Object.class, false, false, false, 0, 0, 0, 0, 0), // same as Object('JSON')
-    Point(Object.class, false, true, true, 33, 0, 0, 0, 0), // same as Tuple(Float64, Float64)
-    Polygon(Object.class, false, true, true, 0, 0, 0, 0, 0), // same as Array(Ring)
-    MultiPolygon(Object.class, false, true, true, 0, 0, 0, 0, 0), // same as Array(Polygon)
-    Ring(Object.class, false, true, true, 0, 0, 0, 0, 0), // same as Array(Point)
-    Nothing(Object.class, false, true, false, 0, 0, 0, 0, 0);
+    AggregateFunction(String.class, true, true, false, 0, 0, 0, 0, 0, true), // implementation-defined intermediate
+                                                                             // state
+    SimpleAggregateFunction(String.class, true, true, false, 0, 0, 0, 0, 0, false),
+    Array(Object.class, true, true, false, 0, 0, 0, 0, 0, true),
+    Map(Map.class, true, true, false, 0, 0, 0, 0, 0, true),
+    Nested(Object.class, true, true, false, 0, 0, 0, 0, 0, true),
+    Tuple(List.class, true, true, false, 0, 0, 0, 0, 0, true),
+    Object(Object.class, true, true, false, 0, 0, 0, 0, 0, true),
+    JSON(Object.class, false, false, false, 0, 0, 0, 0, 0, true), // same as Object('JSON')
+    Point(Object.class, false, true, true, 33, 0, 0, 0, 0, true), // same as Tuple(Float64, Float64)
+    Polygon(Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Array(Ring)
+    MultiPolygon(Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Array(Polygon)
+    Ring(Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Array(Point)
+    Nothing(Object.class, false, true, false, 0, 0, 0, 0, 0, true);
 
     /**
      * Immutable set(sorted) for all aliases.
@@ -294,9 +298,10 @@ public enum ClickHouseDataType {
     private final int defaultScale;
     private final int minScale;
     private final int maxScale;
+    private final boolean nestedType;
 
     ClickHouseDataType(Class<?> javaClass, boolean parameter, boolean caseSensitive, boolean signed, int byteLength,
-            int maxPrecision, int defaultScale, int minScale, int maxScale, String... aliases) {
+            int maxPrecision, int defaultScale, int minScale, int maxScale, boolean nestedType, String... aliases) {
         this.objectType = toObjectType(javaClass);
         this.primitiveType = toPrimitiveType(javaClass);
         this.parameter = parameter;
@@ -307,6 +312,7 @@ public enum ClickHouseDataType {
         this.defaultScale = defaultScale;
         this.minScale = minScale;
         this.maxScale = maxScale;
+        this.nestedType = nestedType;
         if (aliases == null || aliases.length == 0) {
             this.aliases = Collections.emptyList();
         } else {
@@ -344,7 +350,7 @@ public enum ClickHouseDataType {
     }
 
     /**
-     * Checks if name of this data type is case sensistive or not.
+     * Checks if name of this data type is case sensitive or not.
      *
      * @return true if it's case sensitive; false otherwise
      */
@@ -353,13 +359,12 @@ public enum ClickHouseDataType {
     }
 
     /**
-     * Checks if this data type could be a nested structure.
+     * Checks if this data type uses a nested structure.
      *
-     * @return true if it could be a nested structure; false otherwise
+     * @return true if it uses a nested structure; false otherwise
      */
     public boolean isNested() {
-        return this == AggregateFunction || this == Array || this == Map || this == Nested || this == Tuple
-                || this == Object || this == JSON;
+        return nestedType;
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDeferredValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDeferredValue.java
@@ -90,7 +90,7 @@ public final class ClickHouseDeferredValue<T> implements Supplier<T> {
 
     @Override
     public T get() {
-        return getOptional().get();
+        return getOptional().orElse(null);
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
@@ -79,7 +79,8 @@ public class ClickHouseException extends Exception {
         }
 
         Throwable rootCause = t;
-        while (rootCause.getCause() != null && rootCause.getCause() != rootCause) {
+        while (!(rootCause instanceof ClickHouseException) && rootCause.getCause() != null
+                && rootCause.getCause() != rootCause) {
             rootCause = rootCause.getCause();
         }
         return rootCause;
@@ -134,10 +135,12 @@ public class ClickHouseException extends Exception {
 
         Throwable cause = getRootCause(e);
         ClickHouseException exp;
-        // If we've got SocketTimeoutException, we'll say that the query is not good.
-        // This is not the same as SOCKET_TIMEOUT of clickhouse but it actually could be
-        // a failing ClickHouse
-        if (cause instanceof SocketTimeoutException || cause instanceof TimeoutException) {
+        if (cause instanceof ClickHouseException) {
+            exp = (ClickHouseException) cause;
+        } else if (cause instanceof SocketTimeoutException || cause instanceof TimeoutException) {
+            // If we've got SocketTimeoutException, we'll say that the query is not good.
+            // This is not the same as SOCKET_TIMEOUT of clickhouse but it actually could be
+            // a failing ClickHouse
             exp = new ClickHouseException(ERROR_TIMEOUT, cause, server);
         } else if (cause instanceof ConnectException || cause instanceof UnknownHostException) {
             exp = new ClickHouseException(ERROR_NETWORK, cause, server);

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseFormat.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseFormat.java
@@ -11,8 +11,8 @@ public enum ClickHouseFormat {
     RowBinaryWithNamesAndTypes(true, true, true, true, true, RowBinary), // https://clickhouse.com/docs/en/interfaces/formats/#rowbinarywithnamesandtypes
     TabSeparated(true, true, false, false, true), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparated
     TabSeparatedRaw(true, true, false, false, true), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedraw
-    TabSeparatedRawWithNames(true, true, false, true, true, TabSeparated), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedrawwithnames
-    TabSeparatedRawWithNamesAndTypes(true, true, false, true, true, TabSeparated), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedrawwithnamesandtypes
+    TabSeparatedRawWithNames(true, true, false, true, true, TabSeparatedRaw), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedrawwithnames
+    TabSeparatedRawWithNamesAndTypes(true, true, false, true, true, TabSeparatedRaw), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedrawwithnamesandtypes
     TabSeparatedWithNames(true, true, false, true, true, TabSeparated), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedwithnames
     TabSeparatedWithNamesAndTypes(true, true, false, true, true, TabSeparated), // https://clickhouse.com/docs/en/interfaces/formats/#tabseparatedwithnamesandtypes
     // and the rest

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
@@ -236,6 +236,18 @@ public abstract class ClickHouseLoadBalancingPolicy implements Serializable {
             }
         }
         if (node == null) {
+            for (ClickHouseNode n : manager.faultyNodes) {
+                ClickHouseNode probed = n.probe();
+                if (noSelector || t.match(probed)) {
+                    node = probed;
+                }
+                if (i++ >= idx && node != null) {
+                    break;
+                }
+            }
+        }
+
+        if (node == null) {
             throw new IllegalArgumentException(ClickHouseUtils.format(ERROR_NO_SUITABLE_NODE, manager, t));
         }
         return node;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
@@ -1,0 +1,354 @@
+package com.clickhouse.client;
+
+import java.io.Serializable;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.clickhouse.client.ClickHouseNode.Status;
+
+/**
+ * Load balancing policy. In general, a policy is responsible for 3 things: 1)
+ * get node from a managed list; 2) managing node's status; and 3) optionally
+ * schedule background tasks like node discovery and health check.
+ */
+public abstract class ClickHouseLoadBalancingPolicy implements Serializable {
+    static class DefaultPolicy extends ClickHouseLoadBalancingPolicy {
+        @Override
+        protected ScheduledExecutorService getScheduler() {
+            return null;
+        }
+    }
+
+    static class FirstAlivePolicy extends ClickHouseLoadBalancingPolicy {
+        @Override
+        protected ClickHouseNode get(ClickHouseNodes manager, ClickHouseNodeSelector t) {
+            boolean noSelector = t == null || t == ClickHouseNodeSelector.EMPTY;
+            ClickHouseNode node = null;
+            for (ClickHouseNode n : manager.nodes) {
+                if (noSelector || t.match(n)) {
+                    node = n;
+                }
+                if (node != null && !manager.faultyNodes.contains(node)) {
+                    break;
+                }
+            }
+            if (node == null) {
+                throw new IllegalArgumentException(ClickHouseUtils.format(ERROR_NO_SUITABLE_NODE, manager, t));
+            }
+            return node;
+        }
+
+        @Override
+        protected void update(ClickHouseNodes manager, ClickHouseNode node, Status status) {
+            if (status != Status.HEALTHY && status != Status.FAULTY && status != Status.UNHEALTHY) {
+                super.update(manager, node, status);
+                return;
+            }
+
+            if (status == Status.HEALTHY) {
+                manager.faultyNodes.remove(node);
+            } else if (!manager.faultyNodes.contains(node)) {
+                manager.faultyNodes.add(node);
+                manager.scheduleHealthCheck();
+            }
+        }
+    }
+
+    static class RandomPolicy extends ClickHouseLoadBalancingPolicy {
+        private final Random rand;
+
+        protected RandomPolicy() {
+            this.rand = new Random(System.currentTimeMillis());
+        }
+
+        @Override
+        protected ClickHouseNode get(ClickHouseNodes manager, ClickHouseNodeSelector t) {
+            int size = manager.nodes.size();
+            manager.index.set(size < 1 ? 0 : rand.nextInt(size));
+            return super.get(manager, t);
+        }
+    }
+
+    static class RoundRobinPolicy extends ClickHouseLoadBalancingPolicy {
+        @Override
+        protected ClickHouseNode get(ClickHouseNodes manager, ClickHouseNodeSelector t) {
+            boolean noSelector = t == null || t == ClickHouseNodeSelector.EMPTY;
+            int idx = manager.index.getAndUpdate(v -> v + 1 >= manager.nodes.size() ? 0 : v + 1);
+            int i = 0;
+            ClickHouseNode node = null;
+            for (ClickHouseNode n : manager.nodes) {
+                if (noSelector || t.match(n)) {
+                    node = n;
+                }
+                if (i++ >= idx && node != null) {
+                    break;
+                }
+            }
+            if (node == null) {
+                throw new IllegalArgumentException(ClickHouseUtils.format(ERROR_NO_SUITABLE_NODE, manager, t));
+            }
+            return node;
+        }
+    }
+
+    private static final long serialVersionUID = 1481796695764210324L;
+    private static final Map<String, ClickHouseLoadBalancingPolicy> policies = new ConcurrentHashMap<>();
+
+    static final ClickHouseLoadBalancingPolicy DEFAULT = new DefaultPolicy();
+
+    static final String ERROR_NO_SUITABLE_NODE = "%s does not contain suitable node for %s";
+
+    public static final String QUERY_GET_ALL_NODES = "select cluster, host_address, host_name, "
+            + "replica_num, shard_num, shard_weight from system.clusters where is_local=1";
+    public static final String QUERY_GET_CLUSTER_NODES = "select cluster, host_address, host_name, "
+            + "replica_num, shard_num, shard_weight from system.clusters where is_local=1 and cluster=:cluster";
+    public static final String QUERY_GET_OTHER_NODES = "select distinct cluster, :host, replica_num, shard_num, shard_weight "
+            + "from system.clusters where is_local=0 and cluster in :cluster "
+            + "order by estimated_recovery_time asc, shard_weight desc, shard_num asc, (errors_count + slowdowns_count) desc";
+
+    /**
+     * Similar as the default policy, which always picks the first healthy node.
+     * Besides, it provides scheduler for node discovery and health check.
+     */
+    public static final String FIRST_ALIVE = "firstAlive";
+    /**
+     * Policy to pick a healthy node randomly from the list.
+     */
+    public static final String RANDOM = "random";
+    /**
+     * Policy to pick healthy node one after another based their order in the list.
+     */
+    public static final String ROUND_ROBIN = "roundRobin";
+
+    /**
+     * Creates policy.
+     *
+     * @param name policy name or a full qualified class name
+     * @return non-null policy
+     * @throw IllegalArgumentException when failed to create policy
+     */
+    static ClickHouseLoadBalancingPolicy create(String name) {
+        ClickHouseLoadBalancingPolicy policy;
+
+        if (FIRST_ALIVE.equalsIgnoreCase(name)) {
+            policy = new FirstAlivePolicy();
+        } else if (RANDOM.equalsIgnoreCase(name)) {
+            policy = new RandomPolicy();
+        } else if (ROUND_ROBIN.equalsIgnoreCase(name)) {
+            policy = new RoundRobinPolicy();
+        } else {
+            try {
+                Class<?> clazz = ClickHouseLoadBalancingPolicy.class.getClassLoader().loadClass(name);
+                if (!ClickHouseLoadBalancingPolicy.class.isAssignableFrom(clazz)) {
+                    throw new IllegalArgumentException(
+                            ClickHouseUtils.format("Unsupported policy: class [%s] must extend [%s]", name,
+                                    ClickHouseLoadBalancingPolicy.class.getName()));
+                }
+                policy = (ClickHouseLoadBalancingPolicy) clazz.getDeclaredConstructor().newInstance();
+            } catch (ClassNotFoundException e) {
+                throw new IllegalArgumentException("Unknown policy: " + name, e);
+            } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException
+                    | SecurityException e) {
+                throw new IllegalArgumentException("Failed to instantiate policy: " + name, e);
+            }
+
+        }
+        return policy;
+    }
+
+    /**
+     * Gets or creates singleton load balancing policy.
+     *
+     * @param name policy name, one of {@link #FIRST_ALIVE},{@link #RANDOM} and
+     *             {@link #ROUND_ROBIN}, or a fully qualified class name
+     * @return non-null load balancing policy
+     */
+    public static ClickHouseLoadBalancingPolicy of(String name) {
+        return ClickHouseChecker.isNullOrEmpty(name) ? DEFAULT
+                : policies.computeIfAbsent(name.toLowerCase(Locale.ROOT), k -> create(name));
+    }
+
+    /**
+     * Gets a SQL query for finding all local nodes regardless which cluster it
+     * belongs to. Defaults to {@link #QUERY_GET_ALL_NODES}.
+     *
+     * @return non-null SQL query
+     */
+    protected String getQueryForAllLocalNodes() {
+        return QUERY_GET_ALL_NODES;
+    }
+
+    /**
+     * Gets a parameterized SQL query for finding all local nodes of a specific
+     * cluster. Defaults to {@link #QUERY_GET_CLUSTER_NODES}.
+     *
+     * @return non-null SQL query
+     */
+    protected String getQueryForClusterLocalNodes() {
+        return QUERY_GET_CLUSTER_NODES;
+    }
+
+    /**
+     * Gets a parameterized SQL query for finding all non-local nodes in one or many
+     * clusters. Defaults to {@link #QUERY_GET_OTHER_NODES}.
+     *
+     * @return non-null SQL query
+     */
+    protected String getQueryForNonLocalNodes() {
+        return QUERY_GET_OTHER_NODES;
+    }
+
+    /**
+     * Gets next node available in the list.
+     *
+     * @param manager managed nodes
+     * @return next node
+     */
+    protected final ClickHouseNode get(ClickHouseNodes manager) {
+        return get(manager, manager.getNodeSelector());
+    }
+
+    /**
+     * Gets next node available in the list according to the given node selector.
+     *
+     * @param manager managed nodes
+     * @param t       node selector
+     * @return next node
+     * @throws IllegalArgumentException when no node available to use
+     */
+    protected ClickHouseNode get(ClickHouseNodes manager, ClickHouseNodeSelector t) {
+        boolean noSelector = t == null || t == ClickHouseNodeSelector.EMPTY;
+        int idx = manager.index.get();
+        int i = 0;
+        ClickHouseNode node = null;
+        for (ClickHouseNode n : manager.nodes) {
+            if (noSelector || t.match(n)) {
+                node = n;
+            }
+            if (i++ >= idx && node != null) {
+                break;
+            }
+        }
+        if (node == null) {
+            throw new IllegalArgumentException(ClickHouseUtils.format(ERROR_NO_SUITABLE_NODE, manager, t));
+        }
+        return node;
+    }
+
+    /**
+     * Sugguests a new node as replacement of the given one in order to recover from
+     * the failure, which is usually a connection error.
+     *
+     * @param manager non-null manager for finding suitable node
+     * @param server  non-null server to replace
+     * @param failure non-null recoverable exception
+     * @return new server, or the exact same server from input when running out of
+     *         options
+     */
+    protected ClickHouseNode suggest(ClickHouseNodes manager, ClickHouseNode server, Throwable failure) {
+        if (manager == null || server == null || !(failure instanceof ClickHouseException)) {
+            return server;
+        }
+
+        ClickHouseException exp = (ClickHouseException) failure;
+        // only connection errors at this point
+        if (exp.getErrorCode() == ClickHouseException.ERROR_NETWORK
+                || ClickHouseException.isConnectTimedOut(exp.getCause())) {
+            ClickHouseNodeSelector selector = manager.getNodeSelector();
+            for (ClickHouseNode node : manager.nodes) {
+                if (selector.match(node) && !node.isSameEndpoint(server)) {
+                    return node;
+                }
+            }
+        }
+        return server;
+    }
+
+    /**
+     * Updates node status to one of {@link ClickHouseNode.Status}.
+     *
+     * @param manager non-null node manager
+     * @param node    non-null node to update
+     * @param status  non-null status of the node
+     */
+    protected void update(ClickHouseNodes manager, ClickHouseNode node, Status status) {
+        switch (status) {
+            case MANAGED:
+                node.setManager(manager);
+                if (!manager.nodes.contains(node) && !manager.faultyNodes.contains(node)) {
+                    if (node.getProtocol() == ClickHouseProtocol.ANY) {
+                        manager.faultyNodes.add(node);
+                    } else {
+                        manager.nodes.add(node);
+                    }
+                }
+                break;
+            case HEALTHY:
+                manager.faultyNodes.remove(node);
+                if (!manager.nodes.contains(node)) {
+                    manager.nodes.add(node);
+                }
+                break;
+            case UNHEALTHY:
+            case FAULTY:
+                manager.nodes.remove(node);
+                if (!manager.faultyNodes.contains(node)) {
+                    manager.faultyNodes.add(node);
+                    // in case scheduled check was stopped(e.g. aborted or no faulty node)
+                    manager.scheduleHealthCheck();
+                }
+                break;
+            case UNMANAGED:
+            case STANDALONE:
+                boolean removed = manager.nodes.remove(node);
+                removed = manager.faultyNodes.remove(node) || removed;
+                if (removed) {
+                    node.setManager(null);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * Gets scheduled executor service for auto discovery and health check.
+     *
+     * @return scheduled executor service, null will turn off auto discovery and
+     *         health check
+     */
+    protected ScheduledExecutorService getScheduler() {
+        return ClickHouseClientBuilder.defaultScheduler;
+    }
+
+    /**
+     * Schedules the {@code task} to run only when {@code current} run has been
+     * completed/cancelled or does not exist.
+     *
+     * @param current  current task, which could be null or in running status
+     * @param task     scheduled task to run
+     * @param interval interval between each run
+     * @return future object representing the scheduled task, could be null when no
+     *         scheduler available({@link #getScheduler()} returns null)
+     */
+    protected ScheduledFuture<?> schedule(ScheduledFuture<?> current, Runnable task, long interval) {
+        ScheduledExecutorService scheduler = getScheduler();
+        if (scheduler == null || task == null || (current != null && !current.isDone() && !current.isCancelled())) {
+            return null;
+        }
+        return interval < 1L ? scheduler.schedule(task, 0L, TimeUnit.MILLISECONDS)
+                : scheduler.scheduleAtFixedRate(task, 0L, interval, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder(110).append("ClickHouseLoadBalancingPolicy [name=").append(getClass().getSimpleName())
+                .append(", scheduler=").append(getScheduler() != null).append("]@").append(hashCode()).toString();
+    }
+}

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
@@ -1,19 +1,45 @@
 package com.clickhouse.client;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
 import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
-import java.util.function.BiConsumer;
+import java.util.WeakHashMap;
+import java.util.Map.Entry;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
+import com.clickhouse.client.config.ClickHouseOption;
+import com.clickhouse.client.config.ClickHouseSslMode;
+import com.clickhouse.client.logging.Logger;
+import com.clickhouse.client.logging.LoggerFactory;
 
 /**
  * This class depicts a ClickHouse server, essentially a combination of host,
@@ -24,56 +50,68 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * Node status.
      */
     public enum Status {
-        HEALTHY, UNHEALTHY, MANAGED, UNMANAGED
+        /**
+         * Healthy status.
+         */
+        HEALTHY,
+        /**
+         * Faulty status.
+         * 
+         * @deprecated will be removed in v0.3.3, please use {@link #FAULTY} instead
+         */
+        @Deprecated
+        UNHEALTHY,
+        /**
+         * Managed status.
+         */
+        MANAGED,
+        /**
+         * Unmanaged status.
+         * 
+         * @deprecated will be removed in v0.3.3, please use {@link #STANDALONE} instead
+         */
+        @Deprecated
+        UNMANAGED,
+        /**
+         * Faulty status.
+         */
+        FAULTY,
+        /**
+         * Standalone status.
+         */
+        STANDALONE;
     }
 
     /**
      * Mutable and non-thread safe builder.
      */
     public static class Builder {
-        protected String cluster;
         protected String host;
-        protected Integer port;
-        protected InetSocketAddress address;
         protected ClickHouseProtocol protocol;
+        protected Integer port;
         protected ClickHouseCredentials credentials;
-        protected String database;
-        // label is more expressive, but is slow for comparison
-        protected Set<String> tags;
-        protected Integer weight;
 
-        protected TimeZone tz;
-        protected ClickHouseVersion version;
+        protected final Map<String, String> options;
+        // label is more expressive, but is slow for comparison
+        protected final Set<String> tags;
 
         /**
          * Default constructor.
          */
         protected Builder() {
-            this.tags = new HashSet<>(3);
+            this.host = null;
+            this.protocol = null;
+            this.port = null;
+            this.credentials = null;
+            this.options = new LinkedHashMap<>();
+            this.tags = new LinkedHashSet<>();
         }
 
-        protected String getCluster() {
-            if (cluster == null) {
-                cluster = (String) ClickHouseDefaults.CLUSTER.getEffectiveDefaultValue();
-            }
-
-            return cluster;
-        }
-
-        protected InetSocketAddress getAddress() {
-            if (host == null) {
+        protected String getHost() {
+            if (ClickHouseChecker.isNullOrEmpty(host)) {
                 host = (String) ClickHouseDefaults.HOST.getEffectiveDefaultValue();
             }
-
-            if (port == null) {
-                port = (Integer) ClickHouseDefaults.PORT.getEffectiveDefaultValue();
-            }
-
-            if (address == null) {
-                address = InetSocketAddress.createUnresolved(host, port);
-            }
-
-            return address;
+            return host;
         }
 
         protected ClickHouseProtocol getProtocol() {
@@ -83,39 +121,23 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
             return protocol;
         }
 
+        protected int getPort() {
+            if (port == null) {
+                port = getProtocol().getDefaultPort();
+            }
+            return port;
+        }
+
         protected ClickHouseCredentials getCredentials() {
             return credentials;
         }
 
-        protected String getDatabase() {
-            return database;
+        protected Map<String, String> getOptions() {
+            return options;
         }
 
         protected Set<String> getTags() {
-            int size = tags == null ? 0 : tags.size();
-            if (size == 0) {
-                return Collections.emptySet();
-            }
-
-            Set<String> s = new HashSet<>(size);
-            s.addAll(tags);
-            return Collections.unmodifiableSet(s);
-        }
-
-        protected int getWeight() {
-            if (weight == null) {
-                weight = (Integer) ClickHouseDefaults.WEIGHT.getEffectiveDefaultValue();
-            }
-
-            return weight.intValue();
-        }
-
-        protected TimeZone getTimeZone() {
-            return tz;
-        }
-
-        protected ClickHouseVersion getVersion() {
-            return version;
+            return tags;
         }
 
         /**
@@ -125,7 +147,11 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder cluster(String cluster) {
-            this.cluster = cluster;
+            if (!ClickHouseChecker.isNullOrEmpty(cluster)) {
+                options.put(PARAM_CLUSTER, cluster);
+            } else {
+                options.remove(PARAM_CLUSTER);
+            }
             return this;
         }
 
@@ -136,10 +162,6 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder host(String host) {
-            if (!Objects.equals(this.host, host)) {
-                this.address = null;
-            }
-
             this.host = host;
             return this;
         }
@@ -161,7 +183,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder port(ClickHouseProtocol protocol) {
-            return port(protocol, ClickHouseChecker.nonNull(protocol, "protocol").getDefaultPort());
+            return port(protocol, null);
         }
 
         /**
@@ -172,12 +194,8 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder port(ClickHouseProtocol protocol, Integer port) {
-            if (!Objects.equals(this.port, port)) {
-                this.address = null;
-            }
-
-            this.port = port;
             this.protocol = protocol;
+            this.port = port;
             return this;
         }
 
@@ -201,13 +219,13 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder address(ClickHouseProtocol protocol, InetSocketAddress address) {
-            if (!Objects.equals(this.address, address)) {
-                this.host = null;
-                this.port = null;
+            if (address != null) {
+                host(address.getHostName());
+                port(protocol, address.getPort());
+            } else {
+                host(null);
+                port(protocol, null);
             }
-
-            this.address = address;
-            this.protocol = protocol;
             return this;
         }
 
@@ -218,7 +236,11 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder database(String database) {
-            this.database = database;
+            if (!ClickHouseChecker.isNullOrEmpty(database)) {
+                options.put(ClickHouseClientOption.DATABASE.getKey(), database);
+            } else {
+                options.remove(ClickHouseClientOption.DATABASE.getKey());
+            }
             return this;
         }
 
@@ -237,14 +259,49 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
         }
 
         /**
+         * Adds an option for this node.
+         *
+         * @param option option name, null value will be ignored
+         * @param value  option value
+         * @return this builder
+         */
+        public Builder addOption(String option, String value) {
+            if (option != null) {
+                if (value != null) {
+                    options.put(option, value);
+                } else {
+                    options.remove(option);
+                }
+            }
+
+            return this;
+        }
+
+        /**
+         * Sets all options for this node. Use null or empty value to clear all existing
+         * options.
+         *
+         * @param options options for the node
+         * @return this builder
+         */
+        public Builder options(Map<String, String> options) {
+            this.options.clear();
+
+            if (options != null) {
+                this.options.putAll(options);
+            }
+            return this;
+        }
+
+        /**
          * Adds a tag for this node.
          *
          * @param tag tag for the node, null or duplicate tag will be ignored
          * @return this builder
          */
         public Builder addTag(String tag) {
-            if (tag != null) {
-                this.tags.add(tag);
+            if (!ClickHouseChecker.isNullOrEmpty(tag)) {
+                tags.add(tag);
             }
 
             return this;
@@ -257,8 +314,8 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder removeTag(String tag) {
-            if (tag != null) {
-                this.tags.remove(tag);
+            if (!ClickHouseChecker.isNullOrEmpty(tag)) {
+                tags.remove(tag);
             }
 
             return this;
@@ -279,10 +336,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
 
             if (more != null) {
                 for (String t : more) {
-                    if (t == null) {
-                        continue;
-                    }
-                    this.tags.add(t);
+                    addTag(t);
                 }
             }
 
@@ -301,13 +355,33 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
 
             if (tags != null) {
                 for (String t : tags) {
-                    if (t == null) {
-                        continue;
-                    }
-                    this.tags.add(t);
+                    addTag(t);
                 }
             }
 
+            return this;
+        }
+
+        public Builder replica(Integer num) {
+            if (num != null) {
+                options.put(PARAM_REPLICA_NUM, num.toString());
+            } else {
+                options.remove(PARAM_REPLICA_NUM);
+            }
+            return this;
+        }
+
+        public Builder shard(Integer num, Integer weight) {
+            if (num != null) {
+                options.put(PARAM_SHARD_NUM, num.toString());
+            } else {
+                options.remove(PARAM_SHARD_NUM);
+            }
+            if (weight != null) {
+                options.put(PARAM_SHARD_WEIGHT, weight.toString());
+            } else {
+                options.remove(PARAM_SHARD_WEIGHT);
+            }
             return this;
         }
 
@@ -319,7 +393,11 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder weight(Integer weight) {
-            this.weight = weight;
+            if (weight != null) {
+                options.put(PARAM_WEIGHT, weight.toString());
+            } else {
+                options.remove(PARAM_WEIGHT);
+            }
             return this;
         }
 
@@ -330,7 +408,11 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder timeZone(String tz) {
-            this.tz = tz != null ? TimeZone.getTimeZone(tz) : null;
+            if (!ClickHouseChecker.isNullOrEmpty(tz)) {
+                options.put(ClickHouseClientOption.SERVER_TIME_ZONE.getKey(), tz);
+            } else {
+                options.remove(ClickHouseClientOption.SERVER_TIME_ZONE.getKey());
+            }
             return this;
         }
 
@@ -341,7 +423,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder timeZone(TimeZone tz) {
-            this.tz = tz;
+            timeZone(tz != null ? tz.getID() : null);
             return this;
         }
 
@@ -352,7 +434,11 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder version(String version) {
-            this.version = version != null ? ClickHouseVersion.of(version) : null;
+            if (!ClickHouseChecker.isNullOrEmpty(version)) {
+                options.put(ClickHouseClientOption.SERVER_VERSION.getKey(), version);
+            } else {
+                options.remove(ClickHouseClientOption.SERVER_VERSION.getKey());
+            }
             return this;
         }
 
@@ -363,7 +449,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
          * @return this builder
          */
         public Builder version(ClickHouseVersion version) {
-            this.version = version;
+            version(version != null ? version.toString() : null);
             return this;
         }
 
@@ -375,6 +461,229 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
         public ClickHouseNode build() {
             return new ClickHouseNode(this);
         }
+    }
+
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseNode.class);
+    private static final long serialVersionUID = 8342604784121795372L;
+    private static final Map<String, URI> cache = Collections.synchronizedMap(new WeakHashMap<>());
+
+    static final ClickHouseNode DEFAULT = new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null);
+
+    static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
+
+    static final int MAX_PORT_NUM = 65535;
+    static final int MIN_PORT_NUM = 0;
+
+    static final String PARAM_CLUSTER = "cluster";
+    static final String PARAM_SHARD_NUM = "shard_num";
+    static final String PARAM_SHARD_WEIGHT = "shard_weight";
+    static final String PARAM_REPLICA_NUM = "replica_num";
+    static final String PARAM_WEIGHT = "weight";
+
+    static final int DEFAULT_SHARD_NUM = 0;
+    static final int DEFAULT_SHARD_WEIGHT = 0;
+    static final int DEFAULT_REPLICA_NUM = 0;
+    static final int DEFAULT_WEIGHT = 1;
+
+    public static final String SCHEME_DELIMITER = "://";
+
+    /**
+     * Decode given string using {@link URLDecoder} and
+     * {@link StandardCharsets#UTF_8}.
+     *
+     * @param encodedString encoded string
+     * @return non-null decoded string
+     */
+    static String decode(String encodedString) {
+        if (ClickHouseChecker.isNullOrEmpty(encodedString)) {
+            return "";
+        }
+
+        try {
+            return URLDecoder.decode(encodedString, DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            return encodedString;
+        }
+    }
+
+    /**
+     * Encode given string using {@link URLEncoder} and
+     * {@link StandardCharsets#UTF_8}.
+     *
+     * @param str string to encode
+     * @return non-null encoded string
+     */
+    static String encode(String str) {
+        if (ClickHouseChecker.isNullOrEmpty(str)) {
+            return "";
+        }
+
+        try {
+            return URLEncoder.encode(str, DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            return str;
+        }
+    }
+
+    static void parseOptions(String query, Map<String, String> params) {
+        if (ClickHouseChecker.isNullOrEmpty(query)) {
+            return;
+        }
+        int len = query.length();
+        for (int i = 0; i < len; i++) {
+            int index = query.indexOf('&', i);
+            if (index == i) {
+                continue;
+            }
+
+            String param;
+            if (index < 0) {
+                param = query.substring(i);
+                i = len;
+            } else {
+                param = query.substring(i, index);
+                i = index;
+            }
+            index = param.indexOf('=');
+            String key;
+            String value;
+            if (index < 0) {
+                key = decode(param);
+                if (key.charAt(0) == '!') {
+                    key = key.substring(1);
+                    value = Boolean.FALSE.toString();
+                } else {
+                    value = Boolean.TRUE.toString();
+                }
+            } else {
+                key = decode(param.substring(0, index));
+                value = decode(param.substring(index + 1));
+            }
+
+            // any multi-value option? cluster?
+            params.put(key, value);
+        }
+    }
+
+    static void parseTags(String fragment, Set<String> tags) {
+        if (ClickHouseChecker.isNullOrEmpty(fragment)) {
+            return;
+        }
+
+        for (int i = 0, len = fragment.length(); i < len; i++) {
+            int index = fragment.indexOf(',', i);
+            if (index == i) {
+                continue;
+            }
+
+            String tag;
+            if (index < 0) {
+                tag = fragment.substring(i).trim();
+                i = len;
+            } else {
+                tag = fragment.substring(i, index).trim();
+                i = index;
+            }
+            if (!tag.isEmpty()) {
+                tags.add(tag);
+            }
+        }
+    }
+
+    static ClickHouseNode probe(String host, int port, ClickHouseSslMode mode, String rootCaFile, String certFile,
+            String keyFile, int timeout) {
+        if (mode == null) {
+            return probe(host, port, timeout);
+        }
+
+        Map<ClickHouseOption, Serializable> options = new HashMap<>();
+        options.put(ClickHouseClientOption.SSL, true);
+        options.put(ClickHouseClientOption.SSL_MODE, mode);
+        options.put(ClickHouseClientOption.SSL_ROOT_CERTIFICATE, rootCaFile);
+        options.put(ClickHouseClientOption.SSL_CERTIFICATE, certFile);
+        options.put(ClickHouseClientOption.SSL_KEY, keyFile);
+        ClickHouseConfig config = new ClickHouseConfig(options, null, null, null);
+        SSLContext sslContext = null;
+        try {
+            sslContext = ClickHouseSslContextProvider.getProvider().getSslContext(SSLContext.class, config)
+                    .orElse(null);
+        } catch (SSLException e) {
+            log.debug("Failed to create SSL context due to: %s", e.getMessage());
+        }
+        if (sslContext == null) {
+            return probe(host, port, timeout);
+        }
+
+        SSLSocketFactory factory = sslContext.getSocketFactory();
+        ClickHouseDnsResolver resolver = ClickHouseDnsResolver.getInstance();
+        ClickHouseProtocol p = ClickHouseProtocol.HTTP;
+        InetSocketAddress address = resolver != null
+                ? resolver.resolve(ClickHouseProtocol.ANY, host, port)
+                : new InetSocketAddress(host, port);
+        try (SSLSocket client = (SSLSocket) factory.createSocket()) {
+            client.setKeepAlive(false);
+            client.setSoTimeout(timeout);
+            client.connect(address, timeout);
+            client.startHandshake();
+
+            try (OutputStream out = client.getOutputStream(); InputStream in = client.getInputStream()) {
+                out.write("GET /ping HTTP/1.1\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+                out.flush();
+                byte[] buf = new byte[12]; // HTTP/1.x xxx
+                int read = in.read(buf);
+                if (read == -1) {
+                    p = ClickHouseProtocol.GRPC;
+                } else if (buf[0] == 72 && buf[9] == 52) {
+                    p = ClickHouseProtocol.TCP;
+                }
+            }
+        } catch (IOException e) {
+            // MYSQL does not support SSL
+            // and PostgreSQL will end up with SocketTimeoutException
+            log.debug("Failed to probe %s:%d", host, port, e);
+        }
+        return new ClickHouseNode(host, p, port, null, null, null);
+    }
+
+    static ClickHouseNode probe(String host, int port, int timeout) {
+        ClickHouseDnsResolver resolver = ClickHouseDnsResolver.getInstance();
+        InetSocketAddress address = resolver != null
+                ? resolver.resolve(ClickHouseProtocol.ANY, host, port)
+                : new InetSocketAddress(host, port);
+
+        ClickHouseProtocol p = ClickHouseProtocol.HTTP;
+        // TODO needs a better way so that we can detect PostgreSQL port as well
+        try (Socket client = new Socket()) {
+            client.setKeepAlive(false);
+            client.connect(address, timeout);
+            client.setSoTimeout(timeout);
+            try (OutputStream out = client.getOutputStream(); InputStream in = client.getInputStream()) {
+                out.write("GET /ping HTTP/1.1\r\n\r\n".getBytes(StandardCharsets.US_ASCII));
+                out.flush();
+                byte[] buf = new byte[12]; // HTTP/1.x xxx
+                int read = in.read(buf);
+                if (read == buf.length && buf[0] == 0) {
+                    p = ClickHouseProtocol.GRPC;
+                } else if (buf[0] != 0 && buf[3] == 0) {
+                    p = ClickHouseProtocol.MYSQL;
+                } else if (buf[0] == 72 && buf[9] == 52) {
+                    p = ClickHouseProtocol.TCP;
+                }
+            }
+        } catch (IOException e) {
+            // PostgreSQL will end up with SocketTimeoutException
+            log.debug("Failed to probe %s:%d", host, port, e);
+        }
+
+        return new ClickHouseNode(host, p, port, null, null, null);
+    }
+
+    static String value(String value, String defaultValue) {
+        return ClickHouseChecker.isNullOrEmpty(value) ? defaultValue : value;
+    }
+
+    static int value(String value, int defaultValue) {
+        return ClickHouseChecker.isNullOrEmpty(value) ? defaultValue : Integer.parseInt(value);
     }
 
     /**
@@ -395,10 +704,14 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
     public static Builder builder(ClickHouseNode base) {
         Builder b = new Builder();
         if (base != null) {
-            b.cluster(base.getCluster()).host(base.getHost()).port(base.getProtocol(), base.getPort())
-                    .credentials(base.getCredentials().orElse(null)).database(base.getDatabase().orElse(null))
-                    .tags(base.getTags()).weight(base.getWeight()).timeZone(base.getTimeZone().orElse(null))
-                    .version(base.getVersion().orElse(null));
+            Map<String, String> map = new LinkedHashMap<>(base.options);
+            map.put(PARAM_CLUSTER, base.getCluster());
+            map.put(PARAM_REPLICA_NUM, Integer.toString(base.replicaNum));
+            map.put(PARAM_SHARD_NUM, Integer.toString(base.shardNum));
+            map.put(PARAM_SHARD_WEIGHT, Integer.toString(base.shardWeight));
+            map.put(PARAM_WEIGHT, Integer.toString(base.getWeight()));
+            b.host(base.getHost()).port(base.getProtocol(), base.getPort()).credentials(base.credentials).options(map)
+                    .tags(base.getTags());
         }
         return b;
     }
@@ -412,7 +725,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @param port     port number
      * @param database database name, null means {@link ClickHouseDefaults#DATABASE}
      * @param tags     tags for the node, null tag will be ignored
-     * @return node object
+     * @return non-null node object
      */
     public static ClickHouseNode of(String host, ClickHouseProtocol protocol, int port, String database,
             String... tags) {
@@ -424,40 +737,277 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
     }
 
     /**
-     * Generated UID.
+     * Creates a node object using given URI. Same as
+     * {@code of(uri, ClickHouseProtocol.ANY)}.
+     *
+     * @param uri non-empty URI
+     * @return non-null node object
      */
-    private static final long serialVersionUID = 8342604784121795372L;
+    public static ClickHouseNode of(String uri) {
+        return of(uri, DEFAULT);
+    }
 
-    private final String cluster;
+    /**
+     * Creates a node object using given URI. Same as
+     * {@code of(uri, ClickHouseProtocol.ANY)}.
+     *
+     * @param uri     non-empty URI
+     * @param options default options
+     * @return non-null node object
+     */
+    public static ClickHouseNode of(String uri, Map<?, ?> options) {
+        ClickHouseNode template = DEFAULT;
+        if (options != null && !options.isEmpty()) {
+            Builder builder = builder(DEFAULT);
+            for (Entry<?, ?> entry : options.entrySet()) {
+                if (entry.getKey() != null) {
+                    builder.addOption(entry.getKey().toString(),
+                            entry.getValue() != null ? entry.getValue().toString() : null);
+                }
+            }
+            String user = builder.options.remove(ClickHouseDefaults.USER.getKey());
+            String passwd = builder.options.remove(ClickHouseDefaults.PASSWORD.getKey());
+            if (!ClickHouseChecker.isNullOrEmpty(user)) {
+                builder.credentials(ClickHouseCredentials.fromUserAndPassword(user, passwd == null ? "" : passwd));
+            }
+            template = builder.build();
+        }
+        return of(uri, template);
+    }
+
+    /**
+     * Creates a node object using given URI and template.
+     *
+     * @param uri      non-empty URI
+     * @param template optinal template used for creating the node
+     * @return non-null node object
+     */
+    public static ClickHouseNode of(String uri, ClickHouseNode template) {
+        int index = ClickHouseChecker.nonEmpty(uri, "URI").indexOf(SCHEME_DELIMITER);
+        String normalized;
+        if (index < 0) {
+            normalized = new StringBuilder()
+                    .append((template != null ? template.getProtocol() : ClickHouseProtocol.ANY).name()
+                            .toLowerCase())
+                    .append(SCHEME_DELIMITER)
+                    .append(uri.trim()).toString();
+        } else {
+            normalized = uri.trim();
+        }
+        return of(cache.computeIfAbsent(normalized, k -> {
+            try {
+                return new URI(k);
+            } catch (URISyntaxException e) {
+                throw new IllegalArgumentException("Invalid URI", e);
+            }
+        }), template);
+    }
+
+    /**
+     * Creates a node object using given URI.
+     *
+     * @param uri      non-null URI which contains scheme(protocol), host and
+     *                 optionally port
+     * @param template optinal template used for creating the node object
+     * @return non-null node object
+     */
+    public static ClickHouseNode of(URI uri, ClickHouseNode template) {
+        String host = ClickHouseChecker.nonNull(uri, "URI").getHost();
+        String scheme = ClickHouseChecker.nonEmpty(uri.getScheme(), "Protocol");
+        if (template == null) {
+            template = DEFAULT;
+        }
+        if (ClickHouseChecker.isNullOrEmpty(host)) {
+            host = template.getHost();
+        }
+
+        int port = uri.getPort();
+        Map<String, String> params = new LinkedHashMap<>(template.options);
+        ClickHouseProtocol protocol = ClickHouseProtocol.fromUriScheme(scheme);
+        if (port < MIN_PORT_NUM || port > MAX_PORT_NUM) {
+            port = MIN_PORT_NUM;
+        }
+        if (protocol != ClickHouseProtocol.POSTGRESQL && scheme.charAt(scheme.length() - 1) == 's') {
+            params.put(ClickHouseClientOption.SSL.getKey(), Boolean.TRUE.toString());
+            params.put(ClickHouseClientOption.SSL_MODE.getKey(), ClickHouseSslMode.NONE.name());
+        }
+
+        ClickHouseCredentials credentials = template.credentials;
+        String user = "";
+        String passwd = "";
+        if (credentials != null && !credentials.useAccessToken()) {
+            user = credentials.getUserName();
+            passwd = credentials.getPassword();
+        }
+        String auth = uri.getRawUserInfo();
+        if (!ClickHouseChecker.isNullOrEmpty(auth)) {
+            int index = auth.indexOf(':');
+            if (index < 0) {
+                user = decode(auth);
+            } else {
+                String str = decode(auth.substring(0, index));
+                if (!ClickHouseChecker.isNullOrEmpty(str)) {
+                    user = str;
+                }
+                passwd = decode(auth.substring(index + 1));
+            }
+        }
+
+        String db = params.get(ClickHouseClientOption.DATABASE.getKey());
+        if (ClickHouseChecker.isNullOrEmpty(db)) {
+            db = uri.getPath();
+            if (!ClickHouseChecker.isNullOrEmpty(db) && db.length() > 1) {
+                params.put(ClickHouseClientOption.DATABASE.getKey(), db.substring(1));
+            }
+        }
+
+        parseOptions(uri.getRawQuery(), params);
+
+        String str = params.remove(ClickHouseDefaults.USER.getKey());
+        if (!ClickHouseChecker.isNullOrEmpty(str)) {
+            user = str;
+        }
+        str = params.remove(ClickHouseDefaults.PASSWORD.getKey());
+        if (str != null) {
+            passwd = str;
+        }
+        if (!ClickHouseChecker.isNullOrEmpty(user)) {
+            credentials = ClickHouseCredentials.fromUserAndPassword(user, passwd);
+        } else if (!ClickHouseChecker.isNullOrEmpty(passwd)) {
+            credentials = ClickHouseCredentials
+                    .fromUserAndPassword((String) ClickHouseDefaults.USER.getEffectiveDefaultValue(), passwd);
+        }
+
+        if (protocol != ClickHouseProtocol.ANY && port == MIN_PORT_NUM) {
+            if (Boolean.TRUE.toString().equals(params.get(ClickHouseClientOption.SSL.getKey()))) {
+                port = protocol.getDefaultSecurePort();
+            } else {
+                port = protocol.getDefaultPort();
+            }
+        }
+
+        Set<String> tags = new LinkedHashSet<>(template.tags);
+        parseTags(uri.getRawFragment(), tags);
+
+        // TODO allow to define scope of client option
+        for (String key : new String[] {
+                ClickHouseClientOption.LOAD_BALANCING_POLICY.getKey(),
+                ClickHouseClientOption.LOAD_BALANCING_TAGS.getKey(),
+                ClickHouseClientOption.FAILOVER.getKey(),
+                ClickHouseClientOption.NODE_DISCOVERY_INTERVAL.getKey(),
+                ClickHouseClientOption.NODE_DISCOVERY_LIMIT.getKey(),
+                ClickHouseClientOption.HEALTH_CHECK_INTERVAL.getKey(),
+                ClickHouseClientOption.NODE_GROUP_SIZE.getKey(),
+                ClickHouseClientOption.CHECK_ALL_NODES.getKey()
+        }) {
+            if (template.options.containsKey(key)) {
+                params.remove(key);
+            }
+        }
+
+        return new ClickHouseNode(host, protocol, port, credentials, params, tags);
+    }
+
+    private final String host;
     private final ClickHouseProtocol protocol;
-    private final InetSocketAddress address;
+    private final int port;
     private final ClickHouseCredentials credentials;
-    private final String database;
+    private final Map<String, String> options;
     private final Set<String> tags;
+    // cluster-specific properties
+    private final String cluster;
+    private final int replicaNum;
+    private final int shardNum;
+    private final int shardWeight;
     private final int weight;
-
-    // extended attributes, better to use a map and offload to sub class?
-    private final TimeZone tz;
-    private final ClickHouseVersion version;
+    // cache
+    private final String baseUri;
+    /**
+     * Last update time in milliseconds.
+     */
+    protected final AtomicLong lastUpdateTime;
     // TODO: metrics
 
-    private transient BiConsumer<ClickHouseNode, Status> manager;
+    // consolidated copy of credentials, options and tags
+    protected final ClickHouseConfig config;
+    protected final AtomicReference<ClickHouseNodeManager> manager;
 
     protected ClickHouseNode(Builder builder) {
-        ClickHouseChecker.nonNull(builder, "builder");
+        this(ClickHouseChecker.nonNull(builder, "builder").getHost(), builder.getProtocol(), builder.getPort(),
+                builder.getCredentials(), builder.getOptions(), builder.getTags());
+    }
 
-        this.cluster = builder.getCluster();
-        this.protocol = builder.getProtocol();
-        this.address = builder.getAddress();
-        this.credentials = builder.getCredentials();
-        this.database = builder.getDatabase();
-        this.tags = builder.getTags();
-        this.weight = builder.getWeight();
+    protected ClickHouseNode(String host, ClickHouseProtocol protocol, int port, ClickHouseCredentials credentials,
+            Map<String, String> options, Set<String> tags) {
+        this.host = ClickHouseChecker.nonEmpty(host, "Host");
+        this.protocol = protocol != null ? protocol : ClickHouseProtocol.ANY;
+        this.port = port < MIN_PORT_NUM || port > MAX_PORT_NUM ? this.protocol.getDefaultPort() : port;
+        this.credentials = credentials;
+        if (options != null && !options.isEmpty()) {
+            Map<String, String> map = new LinkedHashMap<>(options);
+            this.cluster = value(map.remove(PARAM_CLUSTER), "");
+            this.replicaNum = value(map.remove(PARAM_REPLICA_NUM), DEFAULT_REPLICA_NUM);
+            this.shardNum = value(map.remove(PARAM_SHARD_NUM), DEFAULT_SHARD_NUM);
+            this.shardWeight = value(map.remove(PARAM_SHARD_WEIGHT), DEFAULT_SHARD_WEIGHT);
+            this.weight = value(map.remove(PARAM_WEIGHT), DEFAULT_WEIGHT);
+            this.options = map.isEmpty() ? Collections.emptyMap() : Collections.unmodifiableMap(map);
+        } else {
+            this.cluster = "";
+            this.replicaNum = DEFAULT_REPLICA_NUM;
+            this.shardNum = DEFAULT_SHARD_NUM;
+            this.shardWeight = DEFAULT_SHARD_WEIGHT;
+            this.weight = DEFAULT_WEIGHT;
+            this.options = Collections.emptyMap();
+        }
+        this.lastUpdateTime = new AtomicLong(0L);
+        this.tags = tags == null || tags.isEmpty() ? Collections.emptySet()
+                : Collections.unmodifiableSet(new LinkedHashSet<>(tags));
 
-        this.tz = builder.getTimeZone();
-        this.version = builder.getVersion();
+        this.config = new ClickHouseConfig(ClickHouseConfig.toClientOptions(options), credentials, null, null);
+        this.manager = new AtomicReference<>(null);
 
-        this.manager = null;
+        StringBuilder builder = new StringBuilder().append(protocol.name().toLowerCase());
+        if (config.isSsl()) {
+            builder.append('s');
+        }
+        builder.append(SCHEME_DELIMITER);
+        builder.append(host).append(':').append(port).append('/');
+        this.baseUri = builder.toString();
+    }
+
+    protected ClickHouseNode probe() {
+        if (protocol != ClickHouseProtocol.ANY) {
+            return this;
+        }
+
+        ClickHouseNode newNode;
+        if (config.isSsl()) {
+            newNode = probe(host, port, config.getSslMode(), config.getSslRootCert(), config.getSslCert(),
+                    config.getSslKey(), config.getConnectionTimeout());
+        } else {
+            newNode = probe(host, port, config.getConnectionTimeout());
+        }
+        return newNode;
+    }
+
+    /**
+     * Sets manager for this node.
+     * 
+     * @param m node manager
+     * @return this node
+     */
+    protected ClickHouseNode setManager(ClickHouseNodeManager m) {
+        this.manager.getAndUpdate(v -> {
+            boolean sameManager = Objects.equals(v, m);
+            if (v != null && !sameManager) {
+                v.update(ClickHouseNode.this, Status.STANDALONE);
+            }
+            return sameManager ? v : null;
+        });
+        if (m != null && manager.compareAndSet(null, m)) {
+            m.update(ClickHouseNode.this, Status.MANAGED);
+        }
+        return this;
     }
 
     /**
@@ -466,7 +1016,16 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return socket address to connect to the node
      */
     public InetSocketAddress getAddress() {
-        return this.address;
+        return new InetSocketAddress(host, port);
+    }
+
+    /**
+     * Gets base URI which is composed of protocol, host and port.
+     *
+     * @return non-emtpy base URI
+     */
+    public String getBaseUri() {
+        return this.baseUri;
     }
 
     /**
@@ -497,7 +1056,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return host of the node
      */
     public String getHost() {
-        return this.address.getHostString();
+        return host;
     }
 
     /**
@@ -506,7 +1065,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return port of the node
      */
     public int getPort() {
-        return this.address.getPort();
+        return port;
     }
 
     /**
@@ -515,7 +1074,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return database of the node
      */
     public Optional<String> getDatabase() {
-        return Optional.ofNullable(database);
+        return hasPreferredDatabase() ? Optional.of(this.config.getDatabase()) : Optional.empty();
     }
 
     /**
@@ -527,7 +1086,16 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      */
     public String getDatabase(ClickHouseConfig config) {
         return !ClickHouseChecker.nonNull(config, "config").hasOption(ClickHouseClientOption.DATABASE)
-                && hasPreferredDatabase() ? database : config.getDatabase();
+                && hasPreferredDatabase() ? this.config.getDatabase() : config.getDatabase();
+    }
+
+    /**
+     * Gets all options of the node.
+     *
+     * @return options of the node
+     */
+    public Map<String, String> getOptions() {
+        return this.options;
     }
 
     /**
@@ -545,7 +1113,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return weight of the node
      */
     public int getWeight() {
-        return this.weight;
+        return weight;
     }
 
     /**
@@ -554,7 +1122,9 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return time zone of the node
      */
     public Optional<TimeZone> getTimeZone() {
-        return Optional.ofNullable(tz);
+        return this.config.hasOption(ClickHouseClientOption.SERVER_TIME_ZONE)
+                ? Optional.of(this.config.getServerTimeZone())
+                : Optional.empty();
     }
 
     /**
@@ -565,7 +1135,8 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return time zone of the node
      */
     public TimeZone getTimeZone(ClickHouseConfig config) {
-        return tz != null ? tz : ClickHouseChecker.nonNull(config, "config").getServerTimeZone();
+        return this.config.hasOption(ClickHouseClientOption.SERVER_TIME_ZONE) ? this.config.getServerTimeZone()
+                : ClickHouseChecker.nonNull(config, "config").getServerTimeZone();
     }
 
     /**
@@ -574,7 +1145,9 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return version of the node
      */
     public Optional<ClickHouseVersion> getVersion() {
-        return Optional.ofNullable(version);
+        return this.config.hasOption(ClickHouseClientOption.SERVER_VERSION)
+                ? Optional.of(this.config.getServerVersion())
+                : Optional.empty();
     }
 
     /**
@@ -585,7 +1158,8 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return version of the node
      */
     public ClickHouseVersion getVersion(ClickHouseConfig config) {
-        return version != null ? version : ClickHouseChecker.nonNull(config, "config").getServerVersion();
+        return this.config.hasOption(ClickHouseClientOption.SERVER_VERSION) ? this.config.getServerVersion()
+                : ClickHouseChecker.nonNull(config, "config").getServerVersion();
     }
 
     /**
@@ -594,7 +1168,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return cluster name of node
      */
     public String getCluster() {
-        return this.cluster;
+        return cluster;
     }
 
     /**
@@ -613,91 +1187,175 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return true if preferred database was specified; false otherwise
      */
     public boolean hasPreferredDatabase() {
-        return database != null && !database.isEmpty();
+        return this.config.hasOption(ClickHouseClientOption.DATABASE);
     }
 
     /**
-     * Sets manager for this node.
-     * 
-     * @param manager function to manage status of the node
+     * Checks whether the node is managed by a {@link ClickHouseCluster} ro
+     * {@link ClickHouseNodes}.
+     *
+     * @return true if the node is managed; false otherwise
      */
-    public synchronized void setManager(BiConsumer<ClickHouseNode, Status> manager) {
-        if (this.manager != null && !this.manager.equals(manager)) {
-            this.manager.accept(this, Status.UNMANAGED);
-        }
-
-        if (manager != null && !manager.equals(this.manager)) {
-            manager.accept(this, Status.MANAGED);
-            this.manager = manager;
-        }
+    public boolean isManaged() {
+        return manager.get() != null;
     }
 
     /**
-     * Updates status of the node. This will only work when a manager function
-     * exists via {@link #setManager(BiConsumer)}.
-     * 
-     * @param status node status
+     * Checks whether the node is not managed by any {@link ClickHouseCluster} ro
+     * {@link ClickHouseNodes}.
+     *
+     * @return true if the node is not managed; false otherwise
      */
-    public synchronized void updateStatus(Status status) {
-        if (this.manager != null) {
-            this.manager.accept(this, status);
+    public boolean isStandalone() {
+        return manager.get() == null;
+    }
+
+    /**
+     * Checks if the given node has same base URI as current one.
+     *
+     * @param node node to test
+     * @return true if the nodes are same endpoint; false otherwise
+     */
+    public boolean isSameEndpoint(ClickHouseNode node) {
+        if (node == null) {
+            return false;
+        }
+
+        return baseUri.equals(node.baseUri);
+    }
+
+    /**
+     * Updates status of the node. This will only work when the node is
+     * managed({@link #isManaged()} returns {@code true}).
+     * 
+     * @param status non-null node status
+     */
+    public void update(Status status) {
+        ClickHouseNodeManager m = this.manager.get();
+        if (m != null) {
+            m.update(this, status);
         }
     }
 
     @Override
     public ClickHouseNode apply(ClickHouseNodeSelector t) {
-        if (t != null && t != ClickHouseNodeSelector.EMPTY
-                && (!t.matchAnyOfPreferredProtocols(protocol) || !t.matchAllPreferredTags(tags))) {
-            throw new IllegalArgumentException("No suitable node found");
+        final ClickHouseNodeManager m = manager.get();
+        if (m != null) { // managed
+            return m.apply(m.getNodeSelector());
         }
 
+        if (t != null && t != ClickHouseNodeSelector.EMPTY
+                && (!t.matchAnyOfPreferredProtocols(protocol) || !t.matchAllPreferredTags(tags))) {
+            throw new IllegalArgumentException(ClickHouseUtils.format("%s expects a node rather than %s", t, this));
+        }
         return this;
     }
 
     @Override
-    public String toString() {
-        StringBuilder builder = new StringBuilder().append(getClass().getSimpleName()).append('(');
-        boolean hasCluster = cluster != null && !cluster.isEmpty();
-        if (hasCluster) {
-            builder.append("cluster=").append(cluster).append(", ");
-        }
-        builder.append("addr=").append(protocol.name().toLowerCase()).append(":").append(address).append(", db=")
-                .append(database);
-        if (tz != null) {
-            builder.append(", tz=").append(tz.getID());
-        }
-        if (version != null) {
-            builder.append(", ver=").append(version);
-        }
-        if (tags != null && !tags.isEmpty()) {
-            builder.append(", tags=").append(tags);
-        }
-        if (hasCluster) {
-            builder.append(", weight=").append(weight);
-        }
-
-        return builder.append(')').append('@').append(hashCode()).toString();
-    }
-
-    @Override
     public int hashCode() {
-        return Objects.hash(address, cluster, credentials, database, protocol, tags, weight, tz, version);
+        return Objects.hash(host, port, protocol, credentials, options, tags, cluster, replicaNum, shardNum,
+                shardWeight, weight);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || obj.getClass() != getClass()) {
+        if (this == obj) {
+            return true;
+        } else if (obj == null || getClass() != obj.getClass()) {
             return false;
         }
 
-        if (this == obj) {
-            return true;
+        ClickHouseNode other = (ClickHouseNode) obj;
+        return host.equals(other.host) && port == other.port && protocol == other.protocol
+                && Objects.equals(credentials, other.credentials) && options.equals(other.options)
+                && tags.equals(other.tags) && cluster.equals(other.cluster) && replicaNum == other.replicaNum
+                && shardNum == other.shardNum && shardWeight == other.shardWeight && weight == other.weight;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder builder = new StringBuilder().append("ClickHouseNode [uri=").append(baseUri)
+                .append(config.getDatabase());
+        if (!cluster.isEmpty()) {
+            builder.append(", cluster=").append(cluster).append("(s").append(shardNum).append(",w").append(shardWeight)
+                    .append(",r").append(replicaNum).append(')');
         }
 
-        ClickHouseNode node = (ClickHouseNode) obj;
-        return address.equals(node.address) && cluster.equals(node.cluster)
-                && Objects.equals(credentials, node.credentials) && Objects.equals(database, node.database)
-                && protocol == node.protocol && tags.equals(node.tags) && weight == node.weight
-                && Objects.equals(tz, node.tz) && Objects.equals(version, node.version);
+        StringBuilder optsBuilder = new StringBuilder();
+        for (Entry<String, String> option : options.entrySet()) {
+            String key = option.getKey();
+            if (!ClickHouseClientOption.DATABASE.getKey().equals(key)
+                    && !ClickHouseClientOption.SSL.getKey().equals(key)) {
+                optsBuilder.append(key).append('=').append(option.getValue()).append(",");
+            }
+        }
+        if (optsBuilder.length() > 0) {
+            optsBuilder.setLength(optsBuilder.length() - 1);
+            builder.append(", options={").append(optsBuilder).append('}');
+        }
+        if (!tags.isEmpty()) {
+            builder.append(", tags=").append(tags);
+        }
+        return builder.append(']').toString();
+    }
+
+    /**
+     * Converts to URI, without credentials for security reason.
+     *
+     * @return non-null URI
+     */
+    public URI toUri() {
+        return toUri(null);
+    }
+
+    /**
+     * Converts to URI, without credentials for security reason.
+     *
+     * @param schemePrefix optional prefix of scheme
+     * @return non-null URI
+     */
+    public URI toUri(String schemePrefix) {
+        StringBuilder builder = new StringBuilder();
+        String db = getDatabase().orElse(null);
+        for (Entry<String, String> entry : options.entrySet()) {
+            if (ClickHouseClientOption.DATABASE.getKey().equals(entry.getKey())) {
+                db = entry.getValue();
+                continue;
+            }
+            builder.append(encode(entry.getKey())).append('=').append(encode(entry.getValue())).append('&');
+        }
+        String query = null;
+        if (builder.length() > 0) {
+            builder.setLength(builder.length() - 1);
+            query = builder.toString();
+        }
+
+        builder.setLength(0);
+        boolean first = true;
+        for (String tag : tags) {
+            if (first) {
+                first = false;
+            } else {
+                builder.append(',');
+            }
+            builder.append(encode(tag));
+        }
+
+        String p = protocol.name().toLowerCase(Locale.ROOT);
+        if (ClickHouseChecker.isNullOrEmpty(schemePrefix)) {
+            schemePrefix = p;
+        } else {
+            if (schemePrefix.charAt(schemePrefix.length() - 1) == ':') {
+                schemePrefix = schemePrefix.concat(p);
+            } else {
+                schemePrefix = new StringBuilder(schemePrefix).append(':').append(p).toString();
+            }
+        }
+        try {
+            return new URI(schemePrefix, null, host, port, ClickHouseChecker.isNullOrEmpty(db) ? "" : "/".concat(db),
+                    query, builder.length() > 0 ? builder.toString() : null);
+        } catch (URISyntaxException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeManager.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeManager.java
@@ -27,7 +27,8 @@ public interface ClickHouseNodeManager extends Function<ClickHouseNodeSelector, 
      * Gets a copy of filtered nodes.
      *
      * @param selector  node selector for filtering out nodes, null means no filter
-     * @param groupSize maximum number of nodes to get, zero or negative means all
+     * @param groupSize maximum number of nodes to get, zero or negative value
+     *                  means all
      * @return non-null nodes
      */
     List<ClickHouseNode> getNodes(ClickHouseNodeSelector selector, int groupSize);
@@ -43,7 +44,8 @@ public interface ClickHouseNodeManager extends Function<ClickHouseNodeSelector, 
      * Gets a copy of filtered faulty nodes.
      *
      * @param selector  node selector for filtering out nodes, null means no filter
-     * @param groupSize maximum number of nodes to get, zero or negative means all
+     * @param groupSize maximum number of nodes to get, zero or negative value means
+     *                  all
      * @return non-null faulty nodes
      */
     List<ClickHouseNode> getFaultyNodes(ClickHouseNodeSelector selector, int groupSize);

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeManager.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeManager.java
@@ -1,0 +1,103 @@
+package com.clickhouse.client;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Function;
+
+import com.clickhouse.client.ClickHouseNode.Status;
+
+/**
+ * Node manager is responsible for managing list of nodes and their status. It
+ * also runs scheduled tasks in background for node discovery and health check.
+ */
+public interface ClickHouseNodeManager extends Function<ClickHouseNodeSelector, ClickHouseNode>, Serializable {
+    /**
+     * Gets a copy of nodes, which in most cases are in healthy status. However,
+     * this really depends on how {@link ClickHouseLoadBalancingPolicy} manages node
+     * status. In first-alive policy, it's acutally a full list regardless node
+     * status.
+     *
+     * @return non-null nodes
+     */
+    List<ClickHouseNode> getNodes();
+
+    /**
+     * Gets a copy of filtered nodes.
+     *
+     * @param selector  node selector for filtering out nodes, null means no filter
+     * @param groupSize maximum number of nodes to get, zero or negative means all
+     * @return non-null nodes
+     */
+    List<ClickHouseNode> getNodes(ClickHouseNodeSelector selector, int groupSize);
+
+    /**
+     * Gets a copy of faulty nodes.
+     *
+     * @return non-null faulty nodes
+     */
+    List<ClickHouseNode> getFaultyNodes();
+
+    /**
+     * Gets a copy of filtered faulty nodes.
+     *
+     * @param selector  node selector for filtering out nodes, null means no filter
+     * @param groupSize maximum number of nodes to get, zero or negative means all
+     * @return non-null faulty nodes
+     */
+    List<ClickHouseNode> getFaultyNodes(ClickHouseNodeSelector selector, int groupSize);
+
+    /**
+     * Gets load balancing policy.
+     *
+     * @return non-null load balancing policy
+     */
+    ClickHouseLoadBalancingPolicy getPolicy();
+
+    /**
+     * Gets node selector for filtering out nodes.
+     *
+     * @return non-null node selector
+     */
+    ClickHouseNodeSelector getNodeSelector();
+
+    /**
+     * Schedule node discovery task immediately. Nothing will happen when task
+     * scheduler does not exist(e.g. {@code getPolicy().getScheduler()} returns
+     * null) or there's a task running for node discovery.
+     *
+     * @return optional future for retrieving the running task
+     */
+    Optional<ScheduledFuture<?>> scheduleDiscovery();
+
+    /**
+     * Schedule node discovery task immediately. Nothing will happen when task
+     * scheduler does not exist(e.g. {@code getPolicy().getScheduler()} returns
+     * null) or there's a task running for health check.
+     *
+     * @return optional future for retrieving the running task
+     */
+    Optional<ScheduledFuture<?>> scheduleHealthCheck();
+
+    /**
+     * Suggests a different node in order to recover from a failure, which is
+     * usually a connection error.
+     *
+     * @param server  node related to the failure(e.g. the node couldn't be
+     *                connected)
+     * @param failure recoverable failure
+     * @return non-null node which may or may not be same as the given one
+     */
+    ClickHouseNode suggestNode(ClickHouseNode server, Throwable failure);
+
+    /**
+     * Updates node status to one of {@link ClickHouseNode.Status}. It simply
+     * delegates the call to {@code getPolicy().update(node, status)} in a
+     * thread-safe manner.
+     *
+     * @param node   non-null node to update
+     * @param status non-null status of the node
+     */
+    void update(ClickHouseNode node, Status status);
+}

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
@@ -540,7 +540,8 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
                 ClickHouseNode n = node.probe();
                 // probe is faster than ping but it cannot tell if the server works or not
                 boolean isAlive = false;
-                try (ClickHouseClient client = ClickHouseClient.newInstance(n.getProtocol())) {
+                try (ClickHouseClient client = ClickHouseClient.builder().agent(false).config(n.config)
+                        .nodeSelector(ClickHouseNodeSelector.of(n.getProtocol())).build()) {
                     isAlive = client.ping(n, n.config.getConnectionTimeout());
                 } catch (Exception e) {
                     // ignore

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
@@ -1,0 +1,751 @@
+package com.clickhouse.client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.WeakHashMap;
+import java.util.Map.Entry;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.clickhouse.client.ClickHouseNode.Status;
+import com.clickhouse.client.config.ClickHouseClientOption;
+import com.clickhouse.client.config.ClickHouseDefaults;
+import com.clickhouse.client.logging.Logger;
+import com.clickhouse.client.logging.LoggerFactory;
+
+/**
+ * A generic node manager for managing one or more nodes which may or may not
+ * belong to same cluster. It maintains two lists - one for healthy nodes and
+ * the other for faulty ones. Behind the scene, there's background thread(s) for
+ * discovering nodes and health check. Besides,
+ * {@link ClickHouseLoadBalancingPolicy} is used to pickup available node and
+ * moving node between lists according to its status.
+ */
+public class ClickHouseNodes implements ClickHouseNodeManager {
+    private static final Logger log = LoggerFactory.getLogger(ClickHouseNodes.class);
+    private static final long serialVersionUID = 4931904980127690349L;
+
+    private static final Map<String, ClickHouseNodes> cache = Collections.synchronizedMap(new WeakHashMap<>());
+    private static final char[] separators = new char[] { '/', '?', '#' };
+
+    /**
+     * Build unique key for the given base URI and options.
+     *
+     * @param uri     non-null URI
+     * @param options options
+     * @return non-null unique key for caching
+     */
+    static String buildKey(String uri, Map<?, ?> options) {
+        if (uri == null) {
+            throw new IllegalArgumentException("Non-null URI required");
+        } else if ((uri = uri.trim()).isEmpty()) {
+            throw new IllegalArgumentException("Non-blank URI required");
+        }
+        if (options == null || options.isEmpty()) {
+            return uri;
+        }
+
+        SortedMap<Object, Object> sorted;
+        if (options instanceof SortedMap) {
+            sorted = (SortedMap<Object, Object>) options;
+        } else {
+            sorted = new TreeMap<>();
+            for (Entry<?, ?> entry : options.entrySet()) {
+                if (entry.getKey() != null) {
+                    sorted.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+
+        StringBuilder builder = new StringBuilder(uri).append('|');
+        for (Entry<Object, Object> entry : sorted.entrySet()) {
+            if (entry.getKey() != null) {
+                builder.append(entry.getKey()).append('=').append(entry.getValue()).append(',');
+            }
+        }
+        return builder.toString();
+    }
+
+    /**
+     * Creates list of managed {@link ClickHouseNode} for load balancing and
+     * fail-over.
+     *
+     * @param enpoints       non-empty URIs separated by comma
+     * @param defaultOptions default options
+     * @return non-null list of nodes
+     */
+    static ClickHouseNodes create(String enpoints, Map<?, ?> defaultOptions) {
+        int index = enpoints.indexOf(ClickHouseNode.SCHEME_DELIMITER);
+        String defaultProtocol = ((ClickHouseProtocol) ClickHouseDefaults.PROTOCOL
+                .getEffectiveDefaultValue()).name();
+        if (index > 0) {
+            defaultProtocol = enpoints.substring(0, index);
+            if (ClickHouseProtocol.fromUriScheme(defaultProtocol) == ClickHouseProtocol.ANY) {
+                defaultProtocol = ClickHouseProtocol.ANY.name();
+                index = 0;
+            } else {
+                index += 3;
+            }
+        } else {
+            index = 0;
+        }
+
+        String defaultParams = "";
+        Set<String> list = new LinkedHashSet<>();
+        char stopChar = ',';
+        for (int i = index, len = enpoints.length(); i < len; i++) {
+            char ch = enpoints.charAt(i);
+            if (ch == ',' || Character.isWhitespace(ch)) {
+                index++;
+                continue;
+            } else if (ch == '/' || ch == '?' || ch == '#') {
+                defaultParams = enpoints.substring(i);
+                break;
+            }
+            switch (ch) {
+                case '(':
+                    stopChar = ')';
+                    index++;
+                    break;
+                case '{':
+                    stopChar = '}';
+                    index++;
+                    break;
+                default:
+                    break;
+            }
+
+            int endIndex = i;
+            for (int j = i + 1; j < len; j++) {
+                ch = enpoints.charAt(j);
+                if (ch == stopChar || Character.isWhitespace(ch)) {
+                    endIndex = j;
+                    break;
+                }
+            }
+            if (endIndex > i) {
+                list.add(enpoints.substring(index, endIndex).trim());
+                i = endIndex;
+                index = endIndex + 1;
+                stopChar = ',';
+            } else {
+                String last = enpoints.substring(index);
+                int sepIndex = last.indexOf(ClickHouseNode.SCHEME_DELIMITER);
+                int startIndex = sepIndex < 0 ? 0 : sepIndex + 3;
+                for (char spec : separators) {
+                    sepIndex = last.indexOf(spec, startIndex);
+                    if (sepIndex > 0) {
+                        break;
+                    }
+                }
+                if (sepIndex > 0) {
+                    defaultParams = last.substring(sepIndex);
+                    list.add(last.substring(0, sepIndex).trim());
+                } else {
+                    list.add(last.trim());
+                }
+                break;
+            }
+        }
+        list.remove("");
+        if (list.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "No valid URI found, please try 'http://localhost:8123' or simply 'localhost:8123' if you don't know protocol");
+        }
+
+        if (list.size() == 1 && defaultParams.isEmpty()) {
+            enpoints = new StringBuilder().append(defaultProtocol).append(ClickHouseNode.SCHEME_DELIMITER)
+                    .append(list.iterator().next()).toString();
+            return new ClickHouseNodes(Collections.singletonList(ClickHouseNode.of(enpoints, defaultOptions)));
+        }
+
+        ClickHouseNode defaultNode = ClickHouseNode.of(defaultProtocol + "://localhost" + defaultParams,
+                defaultOptions);
+        List<ClickHouseNode> nodes = new LinkedList<>();
+        for (String uri : list) {
+            nodes.add(ClickHouseNode.of(uri, defaultNode));
+        }
+        return new ClickHouseNodes(nodes, defaultNode);
+    }
+
+    /**
+     * Picks node from {@code source} and put into {@code target}.
+     *
+     * @param source    list of nodes to pick
+     * @param selector  node selector for filtering out nodes
+     * @param groupSize maximum number of nodes allowed
+     * @return non-null selected nodes
+     */
+    static List<ClickHouseNode> pickNodes(Collection<ClickHouseNode> source, ClickHouseNodeSelector selector,
+            int groupSize) {
+        boolean hasSelector = selector != null && selector != ClickHouseNodeSelector.EMPTY;
+        final List<ClickHouseNode> list;
+        if (groupSize < 1) {
+            if (hasSelector) {
+                list = new LinkedList<>();
+                for (ClickHouseNode node : source) {
+                    if (selector.match(node)) {
+                        list.add(node);
+                    }
+                }
+            } else {
+                list = new ArrayList<>(source);
+            }
+        } else {
+            list = new ArrayList<>(groupSize);
+            int count = 0;
+            for (ClickHouseNode node : source) {
+                if (!hasSelector || selector.match(node)) {
+                    list.add(node);
+                    count++;
+                }
+                if (count >= groupSize) {
+                    break;
+                }
+            }
+        }
+        return list;
+    }
+
+    /**
+     * Picks node from {@code source} and put into {@code target}.
+     *
+     * @param source      list of nodes to pick
+     * @param selector    node selector for filtering out nodes
+     * @param target      container for selected nodes
+     * @param groupSize   maximum number of nodes allowed
+     * @param currentTime current timestamp for filtering
+     */
+    static void pickNodes(Collection<ClickHouseNode> source, ClickHouseNodeSelector selector,
+            Set<ClickHouseNode> target, int groupSize, long currentTime) {
+        boolean hasSelector = selector != null && selector != ClickHouseNodeSelector.EMPTY;
+        int count = target.size();
+        for (ClickHouseNode node : source) {
+            if (!hasSelector || selector.match(node)) {
+                int interval = node.config.getNodeCheckInterval();
+                if (interval < 1 || (currentTime - node.lastUpdateTime.get()) >= interval) {
+                    target.add(node);
+                    count++;
+                }
+            }
+            if (groupSize > 0 && count >= groupSize) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Gets or creates list of managed {@link ClickHouseNode} for load balancing
+     * and fail-over.
+     *
+     * @param enpoints non-empty URIs separated by comma
+     * @return non-null list of nodes
+     */
+    public static ClickHouseNodes of(String enpoints) {
+        return of(enpoints, Collections.emptyMap());
+    }
+
+    /**
+     * Gets or creates list of managed {@link ClickHouseNode} for load balancing
+     * and fail-over.
+     *
+     * @param enpoints non-empty URIs separated by comma
+     * @param options  default options
+     * @return non-null list of nodes
+     */
+    public static ClickHouseNodes of(String enpoints, Map<?, ?> options) {
+        // TODO discover endpoints from a URL or custom service, for examples:
+        // discover://(smb://fs1/ch-list.txt),(smb://fs1/ch-dc.json)
+        // discover:com.mycompany.integration.clickhouse.Endpoints
+        return cache.computeIfAbsent(buildKey(ClickHouseChecker.nonEmpty(enpoints, "Endpoints"), options),
+                k -> create(enpoints, options));
+    }
+
+    /**
+     * Flag for exclusive health check.
+     */
+    protected final AtomicBoolean checking;
+    /**
+     * Index for retrieving next node.
+     */
+    protected final AtomicInteger index;
+    /**
+     * Lock for read and write {@code nodes} and {@code faultyNodes}.
+     */
+    protected final ReentrantReadWriteLock lock;
+    /**
+     * Maximum number of nodes can be used for operation at a time.
+     */
+    protected final int groupSize;
+    /**
+     * List of healthy nodes.
+     */
+    protected final LinkedList<ClickHouseNode> nodes;
+    /**
+     * List of faulty nodes.
+     */
+    protected final LinkedList<ClickHouseNode> faultyNodes;
+    /**
+     * Reference holding future of scheduled discovery.
+     */
+    protected final AtomicReference<ScheduledFuture<?>> discoveryFuture;
+    /**
+     * Reference holding future of scheduled health check.
+     */
+    protected final AtomicReference<ScheduledFuture<?>> healthCheckFuture;
+    /**
+     * Load balancing policy.
+     */
+    protected final ClickHouseLoadBalancingPolicy policy;
+    /**
+     * Load balancing tags for filtering out nodes.
+     */
+    protected final ClickHouseNodeSelector selector;
+    /**
+     * Template node.
+     */
+    protected final ClickHouseNode template;
+
+    /**
+     * Constructor for testing purpose.
+     *
+     * @param nodes non-empty list of nodes
+     */
+    ClickHouseNodes(Collection<ClickHouseNode> nodes) {
+        this(nodes, nodes.iterator().next());
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param nodes    non-empty list of nodes
+     * @param template non-null template node
+     */
+    protected ClickHouseNodes(Collection<ClickHouseNode> nodes, ClickHouseNode template) {
+        this.checking = new AtomicBoolean(false);
+        this.index = new AtomicInteger(0);
+        this.lock = new ReentrantReadWriteLock();
+        this.nodes = new LinkedList<>(); // usually just healthy nodes
+        this.faultyNodes = new LinkedList<>();
+
+        this.discoveryFuture = new AtomicReference<>(null);
+        this.healthCheckFuture = new AtomicReference<>(null);
+
+        this.template = template;
+        this.groupSize = (int) template.config.getOption(ClickHouseClientOption.NODE_GROUP_SIZE);
+
+        Set<String> tags = new LinkedHashSet<>();
+        ClickHouseNode.parseTags((String) template.config.getOption(ClickHouseClientOption.LOAD_BALANCING_TAGS), tags);
+        this.policy = ClickHouseLoadBalancingPolicy
+                .of((String) template.config.getOption(ClickHouseClientOption.LOAD_BALANCING_POLICY));
+        this.selector = tags.isEmpty() ? ClickHouseNodeSelector.EMPTY : ClickHouseNodeSelector.of(null, tags);
+        boolean autoDiscovery = false;
+        for (ClickHouseNode n : nodes) {
+            autoDiscovery = autoDiscovery || n.config.isAutoDiscovery();
+            n.setManager(this);
+        }
+        if (autoDiscovery) {
+            this.discoveryFuture.getAndUpdate(current -> policy.schedule(current, ClickHouseNodes.this::discover,
+                    (int) template.config.getOption(ClickHouseClientOption.NODE_DISCOVERY_INTERVAL)));
+        }
+        this.healthCheckFuture.getAndUpdate(current -> policy.schedule(current, ClickHouseNodes.this::check,
+                (int) template.config.getOption(ClickHouseClientOption.HEALTH_CHECK_INTERVAL)));
+    }
+
+    protected void queryClusterNodes(Collection<ClickHouseNode> seeds, Collection<ClickHouseNode> allNodes,
+            Collection<ClickHouseNode> newHealthyNodes, Collection<ClickHouseNode> newFaultyNodes,
+            Collection<ClickHouseNode> useless) {
+        for (ClickHouseNode node : seeds) {
+            ClickHouseNode server = null;
+            try {
+                server = node.probe();
+            } catch (Exception e) {
+                // ignore
+            }
+            if (server == null) {
+                newFaultyNodes.add(node);
+                continue;
+            } else if (!server.equals(node)) {
+                allNodes.add(server);
+                useless.add(node);
+            }
+
+            try (ClickHouseClient client = ClickHouseClient.builder().agent(false)
+                    .nodeSelector(ClickHouseNodeSelector.of(server.getProtocol())).build()) {
+                ClickHouseRequest<?> request = client.connect(server)
+                        .format(ClickHouseFormat.RowBinaryWithNamesAndTypes);
+                String clusterName = server.getCluster();
+                Set<String> clusters = new LinkedHashSet<>();
+                if (!ClickHouseChecker.isNullOrEmpty(clusterName)) {
+                    clusters.add(clusterName);
+                }
+                boolean isAddress = true;
+                boolean proceed = false;
+                try (ClickHouseResponse response = request
+                        .query(clusters.isEmpty() ? policy.getQueryForAllLocalNodes()
+                                : policy.getQueryForClusterLocalNodes())
+                        .params(ClickHouseValues.convertToQuotedString(clusterName))
+                        .executeAndWait()) {
+                    for (ClickHouseRecord r : response.records()) {
+                        int idx = 0;
+                        String cluster = r.getValue(idx++).asString();
+                        clusters.add(cluster);
+                        String addr = r.getValue(idx++).asString();
+                        String name = r.getValue(idx++).asString();
+                        if (!(isAddress = server.getHost().equals(addr)) && !server.getHost().equals(name)) {
+                            log.warn(
+                                    "Auto discovery may not work as no host_name and host_address in system.clusters matched with %s",
+                                    server);
+                            isAddress = true; // fall back to host_address
+                        }
+                        ClickHouseNode discovered = ClickHouseNode.builder(server).cluster(cluster)
+                                .replica(r.getValue(idx++).asInteger())
+                                .shard(r.getValue(idx++).asInteger(), r.getValue(idx++).asInteger()).build();
+                        if (!discovered.equals(server)) {
+                            allNodes.remove(server);
+                            allNodes.add(discovered);
+                            newHealthyNodes.add(discovered);
+                            useless.add(server);
+                        }
+                        proceed = true;
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to query system.clusters using %s, due to: %s", server, e.getMessage());
+                    if (e.getCause() instanceof IOException) {
+                        useless.add(server);
+                        continue;
+                    }
+                }
+
+                if (!proceed) {
+                    continue;
+                }
+
+                String query = policy.getQueryForNonLocalNodes();
+                int limit = (int) template.config.getOption(ClickHouseClientOption.NODE_DISCOVERY_LIMIT);
+                if (limit > 0) {
+                    query = query + " limit " + limit;
+                }
+                try (ClickHouseResponse response = request.query(query)
+                        .params(isAddress ? "host_address" : "host_name",
+                                ClickHouseValues.convertToSqlExpression(
+                                        clusters != null ? clusters : Collections.singleton(clusterName)))
+                        .executeAndWait()) {
+                    for (ClickHouseRecord r : response.records()) {
+                        int idx = 0;
+                        ClickHouseNode n = ClickHouseNode.builder(server).cluster(r.getValue(idx++).asString())
+                                .addOption(ClickHouseClientOption.AUTO_DISCOVERY.getKey(), "false")
+                                .host(r.getValue(idx++).asString()).replica(r.getValue(idx++).asInteger())
+                                .shard(r.getValue(idx++).asInteger(), r.getValue(idx++).asInteger()).build();
+                        allNodes.add(n);
+                        // we have seed nodes so here we can be more defensive
+                        newFaultyNodes.add(n);
+                    }
+                } catch (Exception e) {
+                    log.warn("Failed to query system.clusters using %s", server, e);
+                    newHealthyNodes.remove(server);
+                    newFaultyNodes.add(server);
+                }
+            }
+        }
+    }
+
+    /**
+     * Gets next node available.
+     *
+     * @return non-null node
+     */
+    protected ClickHouseNode get() {
+        return apply(selector);
+    }
+
+    @Override
+    public ClickHouseNode apply(ClickHouseNodeSelector t) {
+        lock.readLock().lock();
+        try {
+            return policy.get(this, t);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public ClickHouseNode suggestNode(ClickHouseNode server, Throwable failure) {
+        lock.readLock().lock();
+        try {
+            return policy.suggest(this, server, failure);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public void update(ClickHouseNode node, Status status) {
+        lock.writeLock().lock();
+        try {
+            if (node.config.getNodeCheckInterval() > 0) {
+                node.lastUpdateTime.set(System.currentTimeMillis());
+            }
+            policy.update(this, node, status);
+        } finally {
+            lock.writeLock().unlock();
+        }
+    }
+
+    /**
+     * Checks (faulty) node status.
+     */
+    public void check() {
+        // exclusive access
+        if (!checking.compareAndSet(false, true)) {
+            return;
+        }
+
+        Set<ClickHouseNode> list = new LinkedHashSet<>();
+        long currentTime = System.currentTimeMillis();
+        boolean checkAll = (boolean) template.config.getOption(ClickHouseClientOption.CHECK_ALL_NODES);
+        int healthyNodeStartIndex = -1;
+        lock.readLock().lock();
+        // TODO:
+        // 1) minimize the list;
+        // 2) detect flaky node and check it again later in a less frequent way
+        try {
+            pickNodes(faultyNodes, selector, list, groupSize, currentTime);
+            if (checkAll) {
+                healthyNodeStartIndex = list.size();
+                pickNodes(nodes, selector, list, groupSize, currentTime);
+            }
+        } finally {
+            checking.set(false);
+            lock.readLock().unlock();
+        }
+
+        boolean hasFaultyNode = false;
+        int count = 0;
+        try {
+            for (ClickHouseNode node : list) {
+                ClickHouseNode n = node.probe();
+                // probe is faster than ping but it cannot tell if the server works or not
+                boolean isAlive = false;
+                try (ClickHouseClient client = ClickHouseClient.newInstance(n.getProtocol())) {
+                    isAlive = client.ping(n, n.config.getConnectionTimeout());
+                } catch (Exception e) {
+                    // ignore
+                }
+                if (!n.equals(node)) {
+                    update(n, Status.MANAGED);
+                    update(node, Status.STANDALONE);
+                }
+
+                if (isAlive) {
+                    if (healthyNodeStartIndex < 0 || count < healthyNodeStartIndex) {
+                        update(n, Status.HEALTHY);
+                    }
+                } else {
+                    hasFaultyNode = true;
+                    if (healthyNodeStartIndex >= count) {
+                        update(n, Status.FAULTY);
+                    }
+                }
+                count++;
+            }
+        } catch (Exception e) {
+            log.warn("Unexpected error occurred when checking node status", e);
+        } finally {
+            if (checkAll || hasFaultyNode) {
+                scheduleHealthCheck();
+            }
+        }
+    }
+
+    /**
+     * Discovers nodes in the same cluster by querying against
+     * {@code system.clusters} table.
+     */
+    public void discover() {
+        // FIXME too aggressive for a large cluster, NODE_GROUP_SIZE should be
+        // considered
+        Set<ClickHouseNode> allNodes = new LinkedHashSet<>();
+        Set<ClickHouseNode> seeds = new LinkedHashSet<>();
+        lock.readLock().lock();
+        try {
+            // discover nodes freely only when auto discovery is enabled
+            for (ClickHouseNode node : nodes) {
+                if (node.config.isAutoDiscovery()) {
+                    seeds.add(node);
+                } else {
+                    allNodes.add(node);
+                }
+            }
+
+            // seeds without protocol
+            for (ClickHouseNode node : faultyNodes) {
+                if (node.config.isAutoDiscovery()) {
+                    seeds.add(node);
+                } else {
+                    allNodes.add(node);
+                }
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        if (seeds.isEmpty()) {
+            return;
+        }
+
+        Set<ClickHouseNode> newHealthyNodes = new LinkedHashSet<>();
+        Set<ClickHouseNode> newFaultyNodes = new LinkedHashSet<>();
+        Set<ClickHouseNode> useless = new LinkedHashSet<>();
+
+        queryClusterNodes(seeds, allNodes, newHealthyNodes, newFaultyNodes, useless);
+
+        lock.readLock().lock();
+        try {
+            // check if there's any new node or decommission as needed
+            for (ClickHouseNode n : nodes) {
+                if (!allNodes.remove(n)) {
+                    useless.add(n);
+                }
+                newHealthyNodes.remove(n); // just in case
+            }
+            for (ClickHouseNode n : faultyNodes) {
+                if (!allNodes.remove(n)) {
+                    useless.add(n);
+                }
+                newFaultyNodes.remove(n); // just in case
+            }
+        } finally {
+            lock.readLock().unlock();
+        }
+
+        boolean noUselessNode = useless.isEmpty();
+        if (allNodes.isEmpty() && noUselessNode) {
+            return;
+        }
+
+        for (ClickHouseNode n : allNodes) { // all new nodes
+            update(n, Status.MANAGED);
+        }
+        for (ClickHouseNode n : newHealthyNodes) {
+            update(n, Status.HEALTHY);
+        }
+        for (ClickHouseNode n : newFaultyNodes) {
+            update(n, Status.FAULTY);
+        }
+        for (ClickHouseNode n : useless) {
+            update(n, Status.STANDALONE);
+        }
+
+        if (!noUselessNode) {
+            scheduleHealthCheck();
+        }
+    }
+
+    public ClickHouseNode getTemplate() {
+        return template;
+    }
+
+    @Override
+    public final List<ClickHouseNode> getNodes() {
+        return getNodes(selector, groupSize);
+    }
+
+    @Override
+    public List<ClickHouseNode> getNodes(ClickHouseNodeSelector selector, int groupSize) {
+        lock.readLock().lock();
+        try {
+            return pickNodes(nodes, selector, groupSize);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public final List<ClickHouseNode> getFaultyNodes() {
+        return getFaultyNodes(selector, groupSize);
+    }
+
+    @Override
+    public List<ClickHouseNode> getFaultyNodes(ClickHouseNodeSelector selector, int groupSize) {
+        lock.readLock().lock();
+        try {
+            return pickNodes(faultyNodes, selector, groupSize);
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
+    @Override
+    public ClickHouseLoadBalancingPolicy getPolicy() {
+        return policy;
+    }
+
+    @Override
+    public ClickHouseNodeSelector getNodeSelector() {
+        return selector;
+    }
+
+    @Override
+    public Optional<ScheduledFuture<?>> scheduleDiscovery() {
+        return Optional.ofNullable(discoveryFuture.getAndUpdate(current -> {
+            return policy.schedule(current, ClickHouseNodes.this::discover, 0L);
+        }));
+    }
+
+    @Override
+    public Optional<ScheduledFuture<?>> scheduleHealthCheck() {
+        return Optional.ofNullable(healthCheckFuture.getAndUpdate(current -> {
+            return policy.schedule(current, ClickHouseNodes.this::check, 0L);
+        }));
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = prime + checking.hashCode();
+        result = prime * result + index.hashCode();
+        result = prime * result + policy.hashCode();
+        result = prime * result + selector.hashCode();
+        result = prime * result + nodes.hashCode();
+        result = prime * result + faultyNodes.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        ClickHouseNodes other = (ClickHouseNodes) obj;
+        // FIXME ignore order when comparing node lists
+        return policy.equals(other.policy) && selector.equals(other.selector) && nodes.equals(other.nodes)
+                && faultyNodes.equals(other.faultyNodes);
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("ClickHouseNodes [checking=").append(checking.get()).append(", index=")
+                .append(index.get()).append(", lock=r").append(lock.getReadHoldCount()).append('w')
+                .append(lock.getWriteHoldCount()).append(", nodes=").append(nodes.size()).append(", faulty=")
+                .append(faultyNodes.size()).append(", policy=").append(policy.getClass().getSimpleName())
+                .append(", tags=").append(selector.getPreferredTags()).append(']').toString();
+    }
+}

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseProtocol.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseProtocol.java
@@ -11,7 +11,7 @@ public enum ClickHouseProtocol {
     /**
      * Protocol detection is needed when establishing connection.
      */
-    ANY(8123),
+    ANY(0, "anys"),
     /**
      * HTTP/HTTPS interface.
      */
@@ -19,11 +19,11 @@ public enum ClickHouseProtocol {
     /**
      * Native interface.
      */
-    TCP(9000, 9440, "native", "tcp"),
+    TCP(9000, 9440, "native", "tcp", "tcps"),
     /**
      * MySQL interface.
      */
-    MYSQL(9004, "mysql"),
+    MYSQL(9004, "mysql"), // ClickHouse does not support secured MySQL interface
     /**
      * PostgreSQL interface.
      */
@@ -35,7 +35,7 @@ public enum ClickHouseProtocol {
     /**
      * GRPC interface.
      */
-    GRPC(9100, "grpc");
+    GRPC(9100, "grpc", "grpcs");
 
     /**
      * Gets most suitable protocol according to given URI scheme.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
@@ -505,8 +505,7 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
      * @return data format for input
      */
     public ClickHouseFormat getInputFormat() {
-        ClickHouseFormat format = getFormat();
-        return options.containsKey(ClickHouseClientOption.FORMAT) ? format : format.defaultInputFormat();
+        return getFormat().defaultInputFormat();
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
@@ -259,9 +259,8 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
 
     private final boolean sealed;
 
-    private transient ClickHouseClient client;
+    private final ClickHouseClient client;
 
-    protected final ClickHouseConfig clientConfig;
     protected final Function<ClickHouseNodeSelector, ClickHouseNode> server;
     protected final AtomicReference<ClickHouseNode> serverRef;
     protected final transient List<ClickHouseExternalTable> externalTables;
@@ -291,7 +290,6 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         this.client = client;
-        this.clientConfig = client.getConfig();
         this.server = (Function<ClickHouseNodeSelector, ClickHouseNode> & Serializable) server;
         this.serverRef = ref == null ? new AtomicReference<>(null) : ref;
         this.sealed = sealed;
@@ -327,7 +325,7 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
 
     protected ClickHouseClient getClient() {
         if (client == null) {
-            client = ClickHouseClient.builder().config(clientConfig).build();
+            throw new IllegalStateException("Non-null client is required");
         }
 
         return client;
@@ -426,6 +424,7 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
      */
     public ClickHouseConfig getConfig() {
         if (config == null) {
+            ClickHouseConfig clientConfig = getClient().getConfig();
             if (options.isEmpty()) {
                 config = clientConfig;
             } else {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseUtils.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseUtils.java
@@ -6,9 +6,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +51,11 @@ public final class ClickHouseUtils {
      * Default buffer size.
      */
     public static final int DEFAULT_BUFFER_SIZE = 8192;
+
+    /**
+     * Default charset.
+     */
+    public static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
 
     /**
      * Maximum buffer size.
@@ -100,6 +109,44 @@ public final class ClickHouseUtils {
 
     public static String applyVariables(String template, Map<String, String> variables) {
         return applyVariables(template, variables == null || variables.isEmpty() ? null : variables::get);
+    }
+
+    /**
+     * Decode given string using {@link URLDecoder} and
+     * {@link StandardCharsets#UTF_8}.
+     *
+     * @param encodedString encoded string
+     * @return non-null decoded string
+     */
+    public static String decode(String encodedString) {
+        if (ClickHouseChecker.isNullOrEmpty(encodedString)) {
+            return "";
+        }
+
+        try {
+            return URLDecoder.decode(encodedString, DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            return encodedString;
+        }
+    }
+
+    /**
+     * Encode given string using {@link URLEncoder} and
+     * {@link StandardCharsets#UTF_8}.
+     *
+     * @param str string to encode
+     * @return non-null encoded string
+     */
+    public static String encode(String str) {
+        if (ClickHouseChecker.isNullOrEmpty(str)) {
+            return "";
+        }
+
+        try {
+            return URLEncoder.encode(str, DEFAULT_CHARSET);
+        } catch (UnsupportedEncodingException e) {
+            return str;
+        }
     }
 
     private static <T> T findFirstService(Class<? extends T> serviceInterface) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValue.java
@@ -662,6 +662,13 @@ public interface ClickHouseValue extends Serializable {
     }
 
     /**
+     * Resets to default value of corresponding data type.
+     *
+     * @return this object
+     */
+    ClickHouseValue resetToDefault();
+
+    /**
      * Resets value to null, or empty when null is not supported(e.g. Array, Tuple
      * and Map etc.).
      *

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
@@ -76,6 +76,7 @@ public final class ClickHouseValues {
     public static final LocalTime TIME_ZERO = LocalTime.ofSecondOfDay(0L);
 
     public static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];
+    public static final Object[][] EMPTY_OBJECT_ARRAY2 = new Object[0][];
     public static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
     public static final short[] EMPTY_SHORT_ARRAY = new short[0];
     public static final int[] EMPTY_INT_ARRAY = new int[0];

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -29,40 +29,40 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      * Load balancing policy.
      */
     LOAD_BALANCING_POLICY("load_balancing_policy", "",
-            "Load balancing policy, can be one of 'dummy', 'firstAlive', 'random', 'roundRobin', or full qualified class name implementing ClickHouseLoadBalancingPolicy."),
+            "Load balancing policy, can be one of '', 'firstAlive', 'random', 'roundRobin', or full qualified class name implementing ClickHouseLoadBalancingPolicy."),
     /**
      * Load balancing tags for filtering out nodes.
      */
-    LOAD_BALANCING_TAGS("load_balancing_tags", "", "Load balancing tagsfor filtering out nodes."),
+    LOAD_BALANCING_TAGS("load_balancing_tags", "", "Load balancing tags for filtering out nodes."),
     /**
      * Health check interval in milliseconds.
      */
     HEALTH_CHECK_INTERVAL("health_check_interval", 0,
-            "Health check interval in milliseconds, zero or negative means one-time."),
+            "Health check interval in milliseconds, zero or negative value means one-time."),
     /**
      * Health check method.
      */
     HEALTH_CHECK_METHOD("health_check_method", ClickHouseHealthCheckMethod.SELECT_ONE, "Health check method."),
     /**
-     * Discovery interval in milliseconds.
+     * Node discovery interval in milliseconds.
      */
     NODE_DISCOVERY_INTERVAL("node_discovery_interval", 0,
-            "Discovery interval in milliseconds, zero or negative means one-time discovery."),
+            "Node discovery interval in milliseconds, zero or negative value means one-time discovery."),
     /**
-     * Discovery interval in milliseconds.
+     * Maximum number of nodes can be discovered at a time.
      */
     NODE_DISCOVERY_LIMIT("node_discovery_limit", 100,
-            "Maximum number of nodes can be discovered in one run, zero or negative means no limit."),
+            "Maximum number of nodes can be discovered at a time, zero or negative value means no limit."),
     /**
      * Node check interval in milliseconds.
      */
     NODE_CHECK_INTERVAL("node_check_interval", 0,
-            "Node check interval in milliseconds, negative is treated as zero."),
+            "Node check interval in milliseconds, negative number is treated as zero."),
     /**
      * Maximum number of nodes can be used for operation at a time.
      */
     NODE_GROUP_SIZE("node_group_size", 50,
-            "Maximum number of nodes can be used for operation at a time, zero or negative means all."),
+            "Maximum number of nodes can be used for operation at a time, zero or negative value means all."),
     /**
      * Whether to perform health check against all nodes or just faulty ones.
      */
@@ -155,7 +155,7 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      * Maximum number of times failover can happen for a request.
      */
     FAILOVER("failover", 0,
-            "Maximum number of times failover can happen for a request, zero or negative number means no failover."),
+            "Maximum number of times failover can happen for a request, zero or negative value means no failover."),
     /**
      * Default format.
      */
@@ -214,7 +214,7 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      * Maximum number of times retry can happen for a request.
      */
     RETRY("retry", 0,
-            "Maximum number of times retry can happen for a request, zero or negative number means no retry."),
+            "Maximum number of times retry can happen for a request, zero or negative value means no retry."),
     /**
      * Whether to reuse wrapper of value(e.g. ClickHouseValue or
      * ClickHouseRecord) for memory efficiency.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -20,6 +20,55 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      */
     ASYNC("async", true, "Whether the client should run in async mode."),
     /**
+     * Whether the client should discover more nodes from system tables and/or
+     * clickhouse-keeper/zookeeper.
+     */
+    AUTO_DISCOVERY("auto_discovery", false,
+            "Whether the client should discover more nodes from system tables and/or clickhouse-keeper/zookeeper."),
+    /**
+     * Load balancing policy.
+     */
+    LOAD_BALANCING_POLICY("load_balancing_policy", "",
+            "Load balancing policy, can be one of 'dummy', 'firstAlive', 'random', 'roundRobin', or full qualified class name implementing ClickHouseLoadBalancingPolicy."),
+    /**
+     * Load balancing tags for filtering out nodes.
+     */
+    LOAD_BALANCING_TAGS("load_balancing_tags", "", "Load balancing tagsfor filtering out nodes."),
+    /**
+     * Health check interval in milliseconds.
+     */
+    HEALTH_CHECK_INTERVAL("health_check_interval", 0,
+            "Health check interval in milliseconds, zero or negative means one-time."),
+    /**
+     * Health check method.
+     */
+    HEALTH_CHECK_METHOD("health_check_method", ClickHouseHealthCheckMethod.SELECT_ONE, "Health check method."),
+    /**
+     * Discovery interval in milliseconds.
+     */
+    NODE_DISCOVERY_INTERVAL("node_discovery_interval", 0,
+            "Discovery interval in milliseconds, zero or negative means one-time discovery."),
+    /**
+     * Discovery interval in milliseconds.
+     */
+    NODE_DISCOVERY_LIMIT("node_discovery_limit", 100,
+            "Maximum number of nodes can be discovered in one run, zero or negative means no limit."),
+    /**
+     * Node check interval in milliseconds.
+     */
+    NODE_CHECK_INTERVAL("node_check_interval", 0,
+            "Node check interval in milliseconds, negative is treated as zero."),
+    /**
+     * Maximum number of nodes can be used for operation at a time.
+     */
+    NODE_GROUP_SIZE("node_group_size", 50,
+            "Maximum number of nodes can be used for operation at a time, zero or negative means all."),
+    /**
+     * Whether to perform health check against all nodes or just faulty ones.
+     */
+    CHECK_ALL_NODES("check_all_nodes", false,
+            "Whether to perform health check against all nodes or just faulty ones."),
+    /**
      * Default buffer size in byte for both request and response. It will be reset
      * to {@link #MAX_BUFFER_SIZE} if it's too large.
      */
@@ -96,12 +145,17 @@ public enum ClickHouseClientOption implements ClickHouseOption {
     /**
      * Connection timeout in milliseconds.
      */
-    CONNECTION_TIMEOUT("connect_timeout", 10 * 1000,
+    CONNECTION_TIMEOUT("connect_timeout", 5000,
             "Connection timeout in milliseconds. It's also used for waiting a connection being closed."),
     /**
      * Default database.
      */
     DATABASE("database", "", "Default database."),
+    /**
+     * Maximum number of times failover can happen for a request.
+     */
+    FAILOVER("failover", 0,
+            "Maximum number of times failover can happen for a request, zero or negative number means no failover."),
     /**
      * Default format.
      */
@@ -157,15 +211,20 @@ public enum ClickHouseClientOption implements ClickHouseOption {
     RENAME_RESPONSE_COLUMN("rename_response_column", ClickHouseRenameMethod.NONE,
             "Method to rename response columns."),
     /**
-     * Whether to enable retry.
+     * Maximum number of times retry can happen for a request.
      */
-    RETRY("retry", true, "Whether to retry when there's connection issue."),
+    RETRY("retry", 0,
+            "Maximum number of times retry can happen for a request, zero or negative number means no retry."),
     /**
      * Whether to reuse wrapper of value(e.g. ClickHouseValue or
      * ClickHouseRecord) for memory efficiency.
      */
     REUSE_VALUE_WRAPPER("reuse_value_wrapper", true,
             "Whether to reuse wrapper of value(e.g. ClickHouseValue or ClickHouseRecord) for memory efficiency."),
+    /**
+     * Server revision.
+     */
+    SERVER_REVISION("server_revision", 54442, "Server revision."),
     /**
      * Server timezone.
      */
@@ -174,6 +233,13 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      * Server version.
      */
     SERVER_VERSION("server_version", "", "Server version."),
+    /**
+     * Server weight.
+     *
+     * @deprecated will be removed in v0.3.3
+     */
+    @Deprecated
+    SERVER_WEIGHT("server_weight", 1, "Server weight. Only will be considered in load balancing mode."),
     /**
      * Session id.
      */

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaults.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaults.java
@@ -32,7 +32,10 @@ public enum ClickHouseDefaults implements ClickHouseOption {
     BUFFERING("buffering", ClickHouseBufferingMode.RESOURCE_EFFICIENT, "Buffering mode."),
     /**
      * Default cluster.
+     *
+     * @deprecated will be removed in v0.3.3
      */
+    @Deprecated
     CLUSTER("cluster", "", "Cluster name."),
     /**
      * Default server host.
@@ -44,11 +47,17 @@ public enum ClickHouseDefaults implements ClickHouseOption {
     PROTOCOL("protocol", ClickHouseProtocol.ANY, "Protocol to use."),
     /**
      * Default server port.
+     *
+     * @deprecated will be removed in v0.3.3
      */
+    @Deprecated
     PORT("port", 8123, "Port to connect to."),
     /**
      * Default server weight.
+     *
+     * @deprecated will be removed in v0.3.3
      */
+    @Deprecated
     WEIGHT("weight", 1, "Server weight which might be used for load balancing."),
     /**
      * Default database.
@@ -66,6 +75,12 @@ public enum ClickHouseDefaults implements ClickHouseOption {
      * Default format.
      */
     FORMAT("format", ClickHouseFormat.TabSeparated, "Preferred data format for serialization and deserialization."),
+    /**
+     * Maximum number of threads that the scheduler(shared by all client instances)
+     * can use to run the adhoc/scheduled tasks like discovery and health check.
+     */
+    MAX_SCHEDULER_THREADS("max_scheduler_threads", 1,
+            "Maximum number of threads that the scheduler(shared by all client instances) can use to run the adhoc/scheduled tasks like discovery and health check.."),
     /**
      * Max threads.
      */

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseHealthCheckMethod.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseHealthCheckMethod.java
@@ -1,0 +1,14 @@
+package com.clickhouse.client.config;
+
+public enum ClickHouseHealthCheckMethod {
+    /**
+     * Ping is the protocol-specific approach for health check, which in general is
+     * faster.
+     */
+    PING,
+    /**
+     * Issue query "select 1" for health check, slightly slower compare to ping but
+     * works the best with 3party tools.
+     */
+    SELECT_ONE;
+}

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseOption.java
@@ -47,7 +47,22 @@ public interface ClickHouseOption extends Serializable {
         } else if (double.class == clazz || Double.class == clazz) {
             result = clazz.cast(value.isEmpty() ? Double.valueOf(0D) : Double.valueOf(value));
         } else if (Enum.class.isAssignableFrom(clazz)) {
-            result = (T) Enum.valueOf((Class<? extends Enum>) clazz, value);
+            Enum enumValue = null;
+            try {
+                enumValue = Enum.valueOf((Class<? extends Enum>) clazz, value);
+            } catch (IllegalArgumentException exp) {
+                for (Enum<?> e : ((Class<? extends Enum>) clazz).getEnumConstants()) {
+                    if (e.name().equalsIgnoreCase(value)) {
+                        enumValue = e;
+                        break;
+                    }
+                }
+            }
+            if (enumValue == null) {
+                throw new IllegalArgumentException("No enum constant " + clazz.getCanonicalName() + "." + value);
+            } else {
+                result = (T) enumValue;
+            }
         } else if (TimeZone.class.isAssignableFrom(clazz)) {
             result = (T) TimeZone.getTimeZone(value);
         } else {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseOption.java
@@ -3,6 +3,7 @@ package com.clickhouse.client.config;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Optional;
+import java.util.TimeZone;
 
 /**
  * This defines a configuration option. To put it in a nutshell, an option is
@@ -47,6 +48,8 @@ public interface ClickHouseOption extends Serializable {
             result = clazz.cast(value.isEmpty() ? Double.valueOf(0D) : Double.valueOf(value));
         } else if (Enum.class.isAssignableFrom(clazz)) {
             result = (T) Enum.valueOf((Class<? extends Enum>) clazz, value);
+        } else if (TimeZone.class.isAssignableFrom(clazz)) {
+            result = (T) TimeZone.getTimeZone(value);
         } else {
             result = clazz.cast(value);
         }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseArrayValue.java
@@ -135,9 +135,14 @@ public class ClickHouseArrayValue<T> extends ClickHouseObjectValue<T[]> {
 
     @Override
     @SuppressWarnings("unchecked")
-    public ClickHouseArrayValue<T> resetToNullOrEmpty() {
+    public ClickHouseArrayValue<T> resetToDefault() {
         set((T[]) ClickHouseValues.EMPTY_OBJECT_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseArrayValue<T> resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBigDecimalValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBigDecimalValue.java
@@ -139,6 +139,12 @@ public class ClickHouseBigDecimalValue extends ClickHouseObjectValue<BigDecimal>
     }
 
     @Override
+    public ClickHouseBigDecimalValue resetToDefault() {
+        set(BigDecimal.ZERO);
+        return this;
+    }
+
+    @Override
     public String toSqlExpression() {
         return isNullOrEmpty() ? ClickHouseValues.NULL_EXPR : String.valueOf(getValue());
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBigIntegerValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBigIntegerValue.java
@@ -116,6 +116,12 @@ public class ClickHouseBigIntegerValue extends ClickHouseObjectValue<BigInteger>
     }
 
     @Override
+    public ClickHouseBigIntegerValue resetToDefault() {
+        set(BigInteger.ZERO);
+        return this;
+    }
+
+    @Override
     public String toSqlExpression() {
         return isNullOrEmpty() ? ClickHouseValues.NULL_EXPR : String.valueOf(getValue());
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBitmapValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBitmapValue.java
@@ -173,6 +173,12 @@ public class ClickHouseBitmapValue extends ClickHouseObjectValue<ClickHouseBitma
     }
 
     @Override
+    public ClickHouseBitmapValue resetToDefault() {
+        set(ClickHouseBitmap.empty());
+        return this;
+    }
+
+    @Override
     public String toSqlExpression() {
         return isNullOrEmpty() ? ClickHouseValues.NULL_EXPR : String.valueOf(getValue());
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBoolValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBoolValue.java
@@ -175,6 +175,11 @@ public class ClickHouseBoolValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseBoolValue resetToDefault() {
+        return set(false, false);
+    }
+
+    @Override
     public ClickHouseBoolValue resetToNullOrEmpty() {
         return set(true, false);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseByteValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseByteValue.java
@@ -169,6 +169,11 @@ public class ClickHouseByteValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseByteValue resetToDefault() {
+        return set(false, (byte) 0);
+    }
+
+    @Override
     public ClickHouseByteValue resetToNullOrEmpty() {
         return set(true, (byte) 0);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateTimeValue.java
@@ -24,7 +24,7 @@ public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime
     /**
      * Default value.
      */
-    public static final LocalDateTime DEFAULT = LocalDate.EPOCH.atStartOfDay();
+    public static final LocalDateTime DEFAULT = ClickHouseDateValue.DEFAULT.atStartOfDay();
 
     static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateTimeValue.java
@@ -21,6 +21,11 @@ import com.clickhouse.client.ClickHouseValues;
  * Wraper class of LocalDateTime.
  */
 public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime> {
+    /**
+     * Default value.
+     */
+    public static final LocalDateTime DEFAULT = LocalDate.EPOCH.atStartOfDay();
+
     static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     /**
@@ -228,6 +233,12 @@ public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime
         }
 
         return str;
+    }
+
+    @Override
+    public ClickHouseDateTimeValue resetToDefault() {
+        set(DEFAULT);
+        return this;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateValue.java
@@ -17,6 +17,11 @@ import com.clickhouse.client.ClickHouseValues;
  */
 public class ClickHouseDateValue extends ClickHouseObjectValue<LocalDate> {
     /**
+     * Default date.
+     */
+    public static final LocalDate DEFAULT = LocalDate.of(1970, 1, 1);
+
+    /**
      * Create a new instance representing null value.
      *
      * @return new instance representing null value
@@ -154,7 +159,7 @@ public class ClickHouseDateValue extends ClickHouseObjectValue<LocalDate> {
 
     @Override
     public ClickHouseDateValue resetToDefault() {
-        set(LocalDate.EPOCH);
+        set(DEFAULT);
         return this;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateValue.java
@@ -153,6 +153,12 @@ public class ClickHouseDateValue extends ClickHouseObjectValue<LocalDate> {
     }
 
     @Override
+    public ClickHouseDateValue resetToDefault() {
+        set(LocalDate.EPOCH);
+        return this;
+    }
+
+    @Override
     public String toSqlExpression() {
         if (isNullOrEmpty()) {
             return ClickHouseValues.NULL_EXPR;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
@@ -180,6 +180,11 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseDoubleValue resetToDefault() {
+        return set(false, 0D);
+    }
+
+    @Override
     public ClickHouseDoubleValue resetToNullOrEmpty() {
         return set(true, 0D);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseEmptyValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseEmptyValue.java
@@ -71,6 +71,11 @@ public final class ClickHouseEmptyValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseValue resetToDefault() {
+        return INSTANCE;
+    }
+
+    @Override
     public ClickHouseValue resetToNullOrEmpty() {
         return INSTANCE;
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseEnumValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseEnumValue.java
@@ -227,6 +227,11 @@ public class ClickHouseEnumValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseEnumValue resetToDefault() {
+        return set(false, (byte) 0);
+    }
+
+    @Override
     public ClickHouseEnumValue resetToNullOrEmpty() {
         return set(true, (byte) 0);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
@@ -200,6 +200,11 @@ public class ClickHouseFloatValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseFloatValue resetToDefault() {
+        return set(false, 0F);
+    }
+
+    @Override
     public ClickHouseFloatValue resetToNullOrEmpty() {
         return set(true, 0F);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoMultiPolygonValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoMultiPolygonValue.java
@@ -155,9 +155,14 @@ public class ClickHouseGeoMultiPolygonValue extends ClickHouseObjectValue<double
     }
 
     @Override
-    public ClickHouseGeoMultiPolygonValue resetToNullOrEmpty() {
+    public ClickHouseGeoMultiPolygonValue resetToDefault() {
         set(EMPTY_VALUE);
         return this;
+    }
+
+    @Override
+    public ClickHouseGeoMultiPolygonValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPointValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPointValue.java
@@ -101,9 +101,14 @@ public class ClickHouseGeoPointValue extends ClickHouseObjectValue<double[]> {
     }
 
     @Override
-    public ClickHouseGeoPointValue resetToNullOrEmpty() {
+    public ClickHouseGeoPointValue resetToDefault() {
         set(new double[] { 0D, 0D });
         return this;
+    }
+
+    @Override
+    public ClickHouseGeoPointValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPolygonValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPolygonValue.java
@@ -150,9 +150,14 @@ public class ClickHouseGeoPolygonValue extends ClickHouseObjectValue<double[][][
     }
 
     @Override
-    public ClickHouseGeoPolygonValue resetToNullOrEmpty() {
+    public ClickHouseGeoPolygonValue resetToDefault() {
         set(EMPTY_VALUE);
         return this;
+    }
+
+    @Override
+    public ClickHouseGeoPolygonValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoRingValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoRingValue.java
@@ -147,9 +147,14 @@ public class ClickHouseGeoRingValue extends ClickHouseObjectValue<double[][]> {
     }
 
     @Override
-    public ClickHouseGeoRingValue resetToNullOrEmpty() {
+    public ClickHouseGeoRingValue resetToDefault() {
         set(EMPTY_VALUE);
         return this;
+    }
+
+    @Override
+    public ClickHouseGeoRingValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseInstantValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseInstantValue.java
@@ -232,6 +232,12 @@ public class ClickHouseInstantValue extends ClickHouseObjectValue<Instant> {
     }
 
     @Override
+    public ClickHouseInstantValue resetToDefault() {
+        set(Instant.EPOCH);
+        return this;
+    }
+
+    @Override
     public String toSqlExpression() {
         if (isNullOrEmpty()) {
             return ClickHouseValues.NULL_EXPR;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseInstantValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseInstantValue.java
@@ -21,6 +21,11 @@ import com.clickhouse.client.ClickHouseValues;
  */
 public class ClickHouseInstantValue extends ClickHouseObjectValue<Instant> {
     /**
+     * Default instant.
+     */
+    public static final Instant DEFAULT = Instant.ofEpochMilli(0L);
+
+    /**
      * Create a new instance representing null getValue().
      *
      * @param scale scale
@@ -233,7 +238,7 @@ public class ClickHouseInstantValue extends ClickHouseObjectValue<Instant> {
 
     @Override
     public ClickHouseInstantValue resetToDefault() {
-        set(Instant.EPOCH);
+        set(DEFAULT);
         return this;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIntegerValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIntegerValue.java
@@ -159,6 +159,11 @@ public class ClickHouseIntegerValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseIntegerValue resetToDefault() {
+        return set(false, 0);
+    }
+
+    @Override
     public ClickHouseIntegerValue resetToNullOrEmpty() {
         return set(true, 0);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv4Value.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv4Value.java
@@ -4,6 +4,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -19,6 +21,17 @@ import com.clickhouse.client.ClickHouseValues;
  * Wraper class of Inet4Address.
  */
 public class ClickHouseIpv4Value extends ClickHouseObjectValue<Inet4Address> {
+    public static final Inet4Address DEFAULT;
+
+    static {
+        try {
+            DEFAULT = (Inet4Address) InetAddress.getByAddress("0.0.0.0", new byte[4]);
+        } catch (UnknownHostException e) {
+            // should not happen
+            throw new IllegalStateException("Failed to create default Ipv4 value", e);
+        }
+    }
+
     /**
      * Create a new instance representing null value.
      *
@@ -146,6 +159,12 @@ public class ClickHouseIpv4Value extends ClickHouseObjectValue<Inet4Address> {
         }
 
         return str;
+    }
+
+    @Override
+    public ClickHouseIpv4Value resetToDefault() {
+        set(DEFAULT);
+        return this;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv6Value.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv6Value.java
@@ -4,6 +4,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -19,6 +21,17 @@ import com.clickhouse.client.ClickHouseValues;
  * Wraper class of Inet6Address.
  */
 public class ClickHouseIpv6Value extends ClickHouseObjectValue<Inet6Address> {
+    public static final Inet6Address DEFAULT;
+
+    static {
+        try {
+            DEFAULT = (Inet6Address) InetAddress.getByAddress("::0", new byte[16]);
+        } catch (UnknownHostException e) {
+            // should not happen
+            throw new IllegalStateException("Failed to create default Ipv6 value", e);
+        }
+    }
+
     /**
      * Create a new instance representing null value.
      *
@@ -146,6 +159,12 @@ public class ClickHouseIpv6Value extends ClickHouseObjectValue<Inet6Address> {
         }
 
         return str;
+    }
+
+    @Override
+    public ClickHouseIpv6Value resetToDefault() {
+        set(DEFAULT);
+        return this;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseLongValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseLongValue.java
@@ -186,6 +186,11 @@ public class ClickHouseLongValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseLongValue resetToDefault() {
+        return set(false, unsigned, 0L);
+    }
+
+    @Override
     public ClickHouseLongValue resetToNullOrEmpty() {
         return set(true, false, 0L);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseMapValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseMapValue.java
@@ -159,9 +159,14 @@ public class ClickHouseMapValue extends ClickHouseObjectValue<Map<?, ?>> {
     }
 
     @Override
-    public ClickHouseMapValue resetToNullOrEmpty() {
+    public ClickHouseMapValue resetToDefault() {
         set(Collections.emptyMap());
         return this;
+    }
+
+    @Override
+    public ClickHouseMapValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseNestedValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseNestedValue.java
@@ -194,9 +194,14 @@ public class ClickHouseNestedValue extends ClickHouseObjectValue<Object[][]> {
     }
 
     @Override
-    public ClickHouseNestedValue resetToNullOrEmpty() {
-        set(new Object[0][]);
+    public ClickHouseNestedValue resetToDefault() {
+        set(ClickHouseValues.EMPTY_OBJECT_ARRAY2);
         return this;
+    }
+
+    @Override
+    public ClickHouseNestedValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
@@ -22,6 +22,11 @@ import com.clickhouse.client.ClickHouseValues;
  */
 public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetDateTime> {
     /**
+     * Default value.
+     */
+    public static final OffsetDateTime DEFAULT = Instant.EPOCH.atOffset(ZoneOffset.UTC);
+
+    /**
      * Create a new instance representing null getValue().
      *
      * @param scale scale
@@ -212,6 +217,12 @@ public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetD
         }
 
         return str;
+    }
+
+    @Override
+    public ClickHouseOffsetDateTimeValue resetToDefault() {
+        set(tz == null ? DEFAULT : Instant.EPOCH.atOffset(tz.toZoneId().getRules().getOffset(Instant.EPOCH)));
+        return this;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
@@ -24,7 +24,7 @@ public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetD
     /**
      * Default value.
      */
-    public static final OffsetDateTime DEFAULT = Instant.EPOCH.atOffset(ZoneOffset.UTC);
+    public static final OffsetDateTime DEFAULT = ClickHouseInstantValue.DEFAULT.atOffset(ZoneOffset.UTC);
 
     /**
      * Create a new instance representing null getValue().
@@ -221,7 +221,9 @@ public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetD
 
     @Override
     public ClickHouseOffsetDateTimeValue resetToDefault() {
-        set(tz == null ? DEFAULT : Instant.EPOCH.atOffset(tz.toZoneId().getRules().getOffset(Instant.EPOCH)));
+        set(tz == null ? DEFAULT
+                : ClickHouseInstantValue.DEFAULT
+                        .atOffset(tz.toZoneId().getRules().getOffset(ClickHouseInstantValue.DEFAULT)));
         return this;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseShortValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseShortValue.java
@@ -169,6 +169,11 @@ public class ClickHouseShortValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseShortValue resetToDefault() {
+        return set(false, (short) 0);
+    }
+
+    @Override
     public ClickHouseShortValue resetToNullOrEmpty() {
         return set(true, (short) 0);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStringValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStringValue.java
@@ -260,6 +260,11 @@ public class ClickHouseStringValue implements ClickHouseValue {
     }
 
     @Override
+    public ClickHouseStringValue resetToDefault() {
+        return set("");
+    }
+
+    @Override
     public ClickHouseStringValue resetToNullOrEmpty() {
         return set((String) null);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTupleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTupleValue.java
@@ -158,9 +158,14 @@ public class ClickHouseTupleValue extends ClickHouseObjectValue<List<Object>> {
     }
 
     @Override
-    public ClickHouseTupleValue resetToNullOrEmpty() {
+    public ClickHouseTupleValue resetToDefault() {
         set(Collections.emptyList());
         return this;
+    }
+
+    @Override
+    public ClickHouseTupleValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseUuidValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseUuidValue.java
@@ -17,6 +17,11 @@ import com.clickhouse.client.ClickHouseValues;
  */
 public class ClickHouseUuidValue extends ClickHouseObjectValue<UUID> {
     /**
+     * Default value.
+     */
+    public static final UUID DEFAULT = new UUID(0L, 0L);
+
+    /**
      * Create a new instance representing null value.
      *
      * @return new instance representing null value
@@ -116,6 +121,12 @@ public class ClickHouseUuidValue extends ClickHouseObjectValue<UUID> {
     @Override
     public UUID asUuid() {
         return getValue();
+    }
+
+    @Override
+    public ClickHouseUuidValue resetToDefault() {
+        set(DEFAULT);
+        return this;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
@@ -139,10 +139,14 @@ public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> {
     }
 
     @Override
-
-    public ClickHouseByteArrayValue resetToNullOrEmpty() {
+    public ClickHouseByteArrayValue resetToDefault() {
         set(ClickHouseValues.EMPTY_BYTE_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseByteArrayValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
@@ -139,10 +139,14 @@ public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> 
     }
 
     @Override
-
-    public ClickHouseDoubleArrayValue resetToNullOrEmpty() {
+    public ClickHouseDoubleArrayValue resetToDefault() {
         set(ClickHouseValues.EMPTY_DOUBLE_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseDoubleArrayValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
@@ -139,10 +139,14 @@ public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> {
     }
 
     @Override
-
-    public ClickHouseFloatArrayValue resetToNullOrEmpty() {
+    public ClickHouseFloatArrayValue resetToDefault() {
         set(ClickHouseValues.EMPTY_FLOAT_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseFloatArrayValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
@@ -139,10 +139,14 @@ public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> {
     }
 
     @Override
-
-    public ClickHouseIntArrayValue resetToNullOrEmpty() {
+    public ClickHouseIntArrayValue resetToDefault() {
         set(ClickHouseValues.EMPTY_INT_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseIntArrayValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
@@ -139,10 +139,14 @@ public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> {
     }
 
     @Override
-
-    public ClickHouseLongArrayValue resetToNullOrEmpty() {
+    public ClickHouseLongArrayValue resetToDefault() {
         set(ClickHouseValues.EMPTY_LONG_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseLongArrayValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
@@ -139,10 +139,14 @@ public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> {
     }
 
     @Override
-
-    public ClickHouseShortArrayValue resetToNullOrEmpty() {
+    public ClickHouseShortArrayValue resetToDefault() {
         set(ClickHouseValues.EMPTY_SHORT_ARRAY);
         return this;
+    }
+
+    @Override
+    public ClickHouseShortArrayValue resetToNullOrEmpty() {
+        return resetToDefault();
     }
 
     @Override

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClientBuilderTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClientBuilderTest.java
@@ -2,6 +2,8 @@ package com.clickhouse.client;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.clickhouse.client.ClickHouseClientBuilder.Agent;
 import com.clickhouse.client.config.ClickHouseClientOption;
 
 public class ClickHouseClientBuilderTest {
@@ -9,11 +11,11 @@ public class ClickHouseClientBuilderTest {
     public void testBuildClient() {
         ClickHouseClientBuilder builder = new ClickHouseClientBuilder();
         ClickHouseClient client = builder.build();
-        Assert.assertTrue(client instanceof ClickHouseTestClient);
+        Assert.assertTrue(client instanceof Agent);
+        Assert.assertTrue(((Agent) client).getClient() instanceof ClickHouseTestClient);
         Assert.assertNotEquals(builder.build(), client);
 
-        ClickHouseTestClient testClient = (ClickHouseTestClient) client;
-        Assert.assertTrue(testClient.getConfig() == builder.getConfig());
+        Assert.assertTrue(client.getConfig() == builder.getConfig());
     }
 
     @Test(groups = { "unit" })

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseExceptionTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseExceptionTest.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client;
 
+import java.net.SocketTimeoutException;
 import java.util.concurrent.ExecutionException;
 
 import org.testng.Assert;
@@ -105,5 +106,12 @@ public class ClickHouseExceptionTest {
         Assert.assertEquals(e.getErrorCode(), 12345);
         Assert.assertEquals(e.getCause(), cause.getCause());
         Assert.assertEquals(e.getMessage(), cause.getCause().getMessage() + ", server " + server);
+    }
+
+    @Test(groups = { "unit" })
+    public void testNetworkException() {
+        Assert.assertTrue(ClickHouseException.isConnectTimedOut(new SocketTimeoutException("Connect timed out")));
+        Assert.assertTrue(ClickHouseException.isConnectTimedOut(new SocketTimeoutException("connect timed out")));
+        Assert.assertTrue(ClickHouseException.isConnectTimedOut(new SocketTimeoutException("Connect timed out ")));
     }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseLoadBalancingPolicyTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseLoadBalancingPolicyTest.java
@@ -1,0 +1,357 @@
+package com.clickhouse.client;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.clickhouse.client.ClickHouseNode.Status;
+import com.clickhouse.client.config.ClickHouseClientOption;
+
+public class ClickHouseLoadBalancingPolicyTest {
+    static class CustomPolicy extends ClickHouseLoadBalancingPolicy {
+    }
+
+    static class PrivatePolicy extends ClickHouseLoadBalancingPolicy {
+        private PrivatePolicy() {
+        }
+    }
+
+    static final int MAX_WAIT_SECONDS = 15;
+
+    private ClickHouseNodes createNodes(int size, String policy) {
+        ClickHouseNode template = ClickHouseNode.builder().host("test.host")
+                .addOption(ClickHouseClientOption.LOAD_BALANCING_POLICY.getKey(), policy).build();
+
+        ClickHouseNode[] nodes = new ClickHouseNode[size];
+        for (int i = 0; i < size; i++) {
+            nodes[i] = ClickHouseNode.builder(template).port(ClickHouseProtocol.HTTP, i + 1)
+                    .tags(String.valueOf(i % size)).build();
+        }
+
+        return new ClickHouseNodes(Arrays.asList(nodes), template);
+    }
+
+    @DataProvider(name = "nodeSelectorProvider")
+    private Object[][] getNodeSelectors() {
+        return new Object[][] { { null }, { ClickHouseNodeSelector.EMPTY },
+                { ClickHouseNodeSelector.of(Collections.emptyList(), Collections.singleton("3")) } };
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetOrCreate() {
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of(null),
+                ClickHouseLoadBalancingPolicy.of(""));
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of(""),
+                ClickHouseLoadBalancingPolicy.of(null));
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of("firstalive"),
+                ClickHouseLoadBalancingPolicy.of(ClickHouseLoadBalancingPolicy.FIRST_ALIVE));
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of("firstAlive"),
+                ClickHouseLoadBalancingPolicy.of(ClickHouseLoadBalancingPolicy.FIRST_ALIVE));
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of("RANDOM"),
+                ClickHouseLoadBalancingPolicy.of(ClickHouseLoadBalancingPolicy.RANDOM));
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of("RoundRobin"),
+                ClickHouseLoadBalancingPolicy.of(ClickHouseLoadBalancingPolicy.ROUND_ROBIN));
+        // custom policy
+        Assert.assertEquals(ClickHouseLoadBalancingPolicy.of(CustomPolicy.class.getName()),
+                ClickHouseLoadBalancingPolicy.of(CustomPolicy.class.getName()));
+        // invalid
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> ClickHouseLoadBalancingPolicy.of(getClass().getName()));
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> ClickHouseLoadBalancingPolicy.of(PrivatePolicy.class.getName()));
+    }
+
+    @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
+    public void testDummy(ClickHouseNodeSelector nodeSelector) throws Exception {
+        int size = 5;
+        int requests = 500;
+        int len = size * requests;
+        int tag = nodeSelector != null && nodeSelector.getPreferredTags().size() > 0
+                ? Integer.parseInt(nodeSelector.getPreferredTags().iterator().next())
+                : -1;
+
+        ClickHouseNodes nodes = createNodes(size, "");
+
+        // single thread
+        int[] counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            ClickHouseNode node = nodes.apply(nodeSelector);
+            counters[node.getPort() - 1] += 1;
+        }
+
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertEquals(counters[i], i == 0 ? len : 0);
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+
+        // multi-thread
+        CountDownLatch latch = new CountDownLatch(len);
+        List<ClickHouseNode> results = Collections.synchronizedList(new ArrayList<>(len));
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        for (int i = 0; i < len; i++) {
+            executor.execute(() -> {
+                ClickHouseNode node = nodes.apply(nodeSelector);
+                results.add(node);
+                latch.countDown();
+            });
+        }
+
+        if (!latch.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            Assert.fail("Failed to complete operation within " + MAX_WAIT_SECONDS
+                    + " seconds - check exception log to see what's going on");
+        }
+        counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            counters[results.get(i).getPort() - 1] += 1;
+        }
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertEquals(counters[i], i == 0 ? len : 0);
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+    }
+
+    @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
+    public void testFirstAlive(ClickHouseNodeSelector nodeSelector) throws Exception {
+        int size = 5;
+        int requests = 500;
+        int len = size * requests;
+        int tag = nodeSelector != null && nodeSelector.getPreferredTags().size() > 0
+                ? Integer.parseInt(nodeSelector.getPreferredTags().iterator().next())
+                : -1;
+
+        ClickHouseNodes nodes = createNodes(size, ClickHouseLoadBalancingPolicy.FIRST_ALIVE);
+
+        // single thread
+        int[] counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            ClickHouseNode node = nodes.apply(nodeSelector);
+            counters[node.getPort() - 1] += 1;
+        }
+
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertEquals(counters[i], i == 0 ? len : 0);
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+
+        // multi-thread
+        CountDownLatch latch = new CountDownLatch(len);
+        List<ClickHouseNode> results = Collections.synchronizedList(new ArrayList<>(len));
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        for (int i = 0; i < len; i++) {
+            executor.execute(() -> {
+                ClickHouseNode node = nodes.apply(nodeSelector);
+                results.add(node);
+                latch.countDown();
+            });
+        }
+
+        if (!latch.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            Assert.fail("Failed to complete operation within " + MAX_WAIT_SECONDS
+                    + " seconds - check exception log to see what's going on");
+        }
+        counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            counters[results.get(i).getPort() - 1] += 1;
+        }
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertEquals(counters[i], i == 0 ? len : 0);
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+    }
+
+    @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
+    public void testFirstAliveWithFailures(ClickHouseNodeSelector nodeSelector) throws Exception {
+        int size = 5;
+        int requests = 500;
+        int len = size * requests;
+        int tag = nodeSelector != null && nodeSelector.getPreferredTags().size() > 0
+                ? Integer.parseInt(nodeSelector.getPreferredTags().iterator().next())
+                : -1;
+
+        ClickHouseNodes nodes = createNodes(size, ClickHouseLoadBalancingPolicy.FIRST_ALIVE);
+
+        CountDownLatch latch = new CountDownLatch(len);
+        List<ClickHouseNode> results = Collections.synchronizedList(new ArrayList<>(len));
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        for (int i = 0; i < len; i++) {
+            executor.execute(() -> {
+                ClickHouseNode node = nodes.apply(nodeSelector);
+                results.add(node);
+                latch.countDown();
+            });
+        }
+
+        // change then first node to faulty
+        nodes.nodes.get(0).update(Status.FAULTY);
+        // remove the second
+        nodes.nodes.get(1).update(Status.STANDALONE);
+        // change the first back to healthy
+        nodes.nodes.get(0).update(Status.HEALTHY);
+
+        if (!latch.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            Assert.fail("Failed to complete operation within " + MAX_WAIT_SECONDS
+                    + " seconds - check exception log to see what's going on");
+        }
+        int[] counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            counters[results.get(i).getPort() - 1] += 1;
+        }
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertTrue(i < 3 ? counters[i] >= 0 : counters[i] == 0,
+                        "Only the first 3 nodes can be selected");
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+    }
+
+    @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
+    public void testRoundRobin(ClickHouseNodeSelector nodeSelector) throws Exception {
+        int size = 5;
+        int requests = 500;
+        int len = size * requests;
+        int tag = nodeSelector != null && nodeSelector.getPreferredTags().size() > 0
+                ? Integer.parseInt(nodeSelector.getPreferredTags().iterator().next())
+                : -1;
+
+        ClickHouseNodes nodes = createNodes(size, ClickHouseLoadBalancingPolicy.ROUND_ROBIN);
+
+        // single thread
+        int[] counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            ClickHouseNode node = nodes.apply(nodeSelector);
+            counters[node.getPort() - 1] += 1;
+        }
+
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertEquals(counters[i], requests);
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+
+        // multi-thread
+        CountDownLatch latch = new CountDownLatch(len);
+        List<ClickHouseNode> results = Collections.synchronizedList(new ArrayList<>(len));
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        for (int i = 0; i < len; i++) {
+            executor.execute(() -> {
+                ClickHouseNode node = nodes.apply(nodeSelector);
+                results.add(node);
+                latch.countDown();
+            });
+        }
+
+        if (!latch.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            Assert.fail("Failed to complete operation within " + MAX_WAIT_SECONDS
+                    + " seconds - check exception log to see what's going on");
+        }
+        counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            counters[results.get(i).getPort() - 1] += 1;
+        }
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertEquals(counters[i], requests);
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+    }
+
+    @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
+    public void testRandom(ClickHouseNodeSelector nodeSelector) throws Exception {
+        int size = 5;
+        int requests = 500;
+        int len = size * requests;
+        int tag = nodeSelector != null && nodeSelector.getPreferredTags().size() > 0
+                ? Integer.parseInt(nodeSelector.getPreferredTags().iterator().next())
+                : -1;
+
+        ClickHouseNodes nodes = createNodes(size, ClickHouseLoadBalancingPolicy.RANDOM);
+
+        // single thread
+        int[] counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            ClickHouseNode node = nodes.apply(nodeSelector);
+            counters[node.getPort() - 1] += 1;
+        }
+
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertTrue(counters[i] > 0, "All nodes should have been touched");
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+
+        // multi-thread
+        CountDownLatch latch = new CountDownLatch(len);
+        List<ClickHouseNode> results = Collections.synchronizedList(new ArrayList<>(len));
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        for (int i = 0; i < len; i++) {
+            executor.execute(() -> {
+                ClickHouseNode node = nodes.apply(nodeSelector);
+                results.add(node);
+                latch.countDown();
+            });
+        }
+
+        if (!latch.await(MAX_WAIT_SECONDS, TimeUnit.SECONDS)) {
+            Assert.fail("Failed to complete operation within " + MAX_WAIT_SECONDS
+                    + " seconds - check exception log to see what's going on");
+        }
+        counters = new int[size];
+        for (int i = 0; i < len; i++) {
+            counters[results.get(i).getPort() - 1] += 1;
+        }
+        for (int i = 0; i < size; i++) {
+            if (tag == -1) {
+                Assert.assertTrue(counters[i] > 0, "All nodes should have been touched");
+            } else if (i == tag) {
+                Assert.assertEquals(counters[i], len);
+            } else {
+                Assert.assertEquals(counters[i], 0);
+            }
+        }
+    }
+}

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodeTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodeTest.java
@@ -3,13 +3,18 @@ package com.clickhouse.client;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
 
-public class ClickHouseNodeTest {
+public class ClickHouseNodeTest extends BaseIntegrationTest {
     private void checkDefaultValues(ClickHouseNode node) {
         Assert.assertNotNull(node);
         Assert.assertEquals(node.getCluster(), ClickHouseDefaults.CLUSTER.getEffectiveDefaultValue());
@@ -19,12 +24,13 @@ public class ClickHouseNodeTest {
         Assert.assertTrue(node.getTags().isEmpty());
         Assert.assertNotNull(node.getAddress());
         Assert.assertEquals(node.getHost(), ClickHouseDefaults.HOST.getEffectiveDefaultValue());
-        Assert.assertEquals(node.getPort(), ClickHouseDefaults.PORT.getEffectiveDefaultValue());
+        Assert.assertEquals(node.getPort(), ClickHouseProtocol.ANY.getDefaultPort());
         Assert.assertEquals(node.getWeight(), ClickHouseDefaults.WEIGHT.getEffectiveDefaultValue());
     }
 
     private void checkCustomValues(ClickHouseNode node, String cluster, String host, int port, int weight,
-            ClickHouseProtocol protocol, String database, ClickHouseCredentials credentials, String[] tags) {
+            ClickHouseProtocol protocol, String database, ClickHouseCredentials credentials,
+            String[] tags) {
         Assert.assertNotNull(node);
         Assert.assertEquals(node.getCluster(), cluster);
         Assert.assertNotNull(node.getAddress());
@@ -56,7 +62,8 @@ public class ClickHouseNodeTest {
         ClickHouseCredentials credentials = ClickHouseCredentials.fromUserAndPassword("user", "passwd");
         String[] tags = new String[] { "dc1", "rack1", "server1", "id1" };
 
-        ClickHouseNode node = ClickHouseNode.builder().cluster(cluster).host(host).port(protocol, port).weight(weight)
+        ClickHouseNode node = ClickHouseNode.builder().cluster(cluster).host(host).port(protocol, port)
+                .weight(weight)
                 .database(database).credentials(credentials).tags(Arrays.asList(tags)).build();
         checkCustomValues(node, cluster, host, port, weight, protocol, database, credentials, tags);
     }
@@ -72,12 +79,14 @@ public class ClickHouseNodeTest {
         ClickHouseCredentials credentials = ClickHouseCredentials.fromUserAndPassword("user", "passwd");
         String[] tags = new String[] { "dc1", "rack1", "server1", "id1" };
 
-        ClickHouseNode base = ClickHouseNode.builder().cluster(cluster).host(host).port(protocol, port).weight(weight)
+        ClickHouseNode base = ClickHouseNode.builder().cluster(cluster).host(host).port(protocol, port)
+                .weight(weight)
                 .database(database).credentials(credentials).tags(null, tags).build();
         ClickHouseNode node = ClickHouseNode.builder(base).build();
         checkCustomValues(node, cluster, host, port, weight, protocol, database, credentials, tags);
 
-        node = ClickHouseNode.builder(base).cluster(null).host(null).port(null, null).weight(null).database(null)
+        node = ClickHouseNode.builder(base).cluster(null).host(null).port(null, null).weight(null)
+                .database(null)
                 .credentials(null).tags(null, (String[]) null).build();
         checkDefaultValues(node);
     }
@@ -90,7 +99,8 @@ public class ClickHouseNodeTest {
         int port = 19000;
         ClickHouseNode node = ClickHouseNode.of(host, protocol, port, database);
         checkCustomValues(node, (String) ClickHouseDefaults.CLUSTER.getEffectiveDefaultValue(), host, port,
-                (int) ClickHouseDefaults.WEIGHT.getEffectiveDefaultValue(), protocol, database, null, new String[0]);
+                (int) ClickHouseDefaults.WEIGHT.getEffectiveDefaultValue(), protocol, database, null,
+                new String[0]);
 
         protocol = ClickHouseProtocol.GRPC;
         node = ClickHouseNode.of(host, protocol, port, database, "read-only", "primary");
@@ -101,7 +111,8 @@ public class ClickHouseNodeTest {
 
     @Test(groups = { "unit" })
     public void testDatabase() {
-        ClickHouseConfig config = new ClickHouseConfig(Collections.singletonMap(ClickHouseClientOption.DATABASE, "ttt"),
+        ClickHouseConfig config = new ClickHouseConfig(
+                Collections.singletonMap(ClickHouseClientOption.DATABASE, "ttt"),
                 null, null, null);
         ClickHouseNode node = ClickHouseNode.builder().build();
         Assert.assertEquals(node.hasPreferredDatabase(), false);
@@ -110,7 +121,7 @@ public class ClickHouseNodeTest {
 
         node = ClickHouseNode.builder().database("").build();
         Assert.assertEquals(node.hasPreferredDatabase(), false);
-        Assert.assertEquals(node.getDatabase().orElse(null), "");
+        // Assert.assertEquals(node.getDatabase().orElse(null), "");
         Assert.assertEquals(node.getDatabase(config), config.getDatabase());
 
         node = ClickHouseNode.builder().database("123").build();
@@ -118,5 +129,260 @@ public class ClickHouseNodeTest {
         Assert.assertEquals(node.getDatabase().orElse(null), "123");
         Assert.assertEquals(node.getDatabase(config), "ttt");
         Assert.assertEquals(node.getDatabase(new ClickHouseConfig()), "123");
+    }
+
+    @Test(groups = { "unit" })
+    public void testNullOrEmptyNodes() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of((String) null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of((URI) null, null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of(""));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of(" "));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of("://"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of("://?"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of("://?&"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of("://?&#"));
+
+        Assert.assertEquals(ClickHouseNode.of("/"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("?"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("#"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("/?"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("/#"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("?#"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("/?#"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+    }
+
+    @Test(groups = { "unit" })
+    public void testInvalidNodes() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of("//a b"));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of("/ /"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testValidNodes() {
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.SSL.getKey(), "false");
+        options.put(ClickHouseClientOption.SSL_MODE.getKey(), "NONE");
+        options.put(ClickHouseClientOption.DATABASE.getKey(), "db1");
+
+        Set<String> tags = new HashSet<>();
+        tags.add("dc2");
+
+        Assert.assertEquals(ClickHouseNode.of("grpcs://node1:1919/db1?!ssl&#dc2"),
+                new ClickHouseNode("node1", ClickHouseProtocol.GRPC, 1919, null, options, tags));
+    }
+
+    @Test(groups = { "unit" })
+    public void testSecureNode() {
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.SSL.getKey(), "true");
+        options.put(ClickHouseClientOption.SSL_MODE.getKey(), "NONE");
+        options.put(ClickHouseClientOption.DATABASE.getKey(), "db1");
+
+        Assert.assertEquals(ClickHouseNode.of("https://node1:443/db1"),
+                new ClickHouseNode("node1", ClickHouseProtocol.HTTP, 443, null, options, null));
+        Assert.assertEquals(ClickHouseNode.of("tcps://node1?database=db1"),
+                new ClickHouseNode("node1", ClickHouseProtocol.TCP, 9440, null, options, null));
+    }
+
+    @Test(groups = { "unit" })
+    public void testSingleWordNode() {
+        for (String uri : new String[] {
+                "noidea",
+                "noidea/",
+                "noidea?",
+                "noidea#",
+                "noidea?&",
+                "noidea?&#",
+                "noidea/?",
+                "noidea/#",
+                "noidea/?&",
+                "noidea/?#",
+                "noidea/?&#",
+        }) {
+            Assert.assertEquals(ClickHouseNode.of(uri),
+                    new ClickHouseNode("noidea", ClickHouseProtocol.ANY, 0, null, null, null));
+        }
+
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNode.of(new URI("noidea"), null));
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeWithProtocol() {
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.SSL.getKey(), "true");
+        options.put(ClickHouseClientOption.SSL_MODE.getKey(), "NONE");
+
+        for (ClickHouseProtocol p : ClickHouseProtocol.values()) {
+            Assert.assertEquals(ClickHouseNode.of(p.name() + ":///?#"),
+                    new ClickHouseNode("localhost", p, p.getDefaultPort(), null, null, null));
+            for (String s : p.getUriSchemes()) {
+                boolean secure = p != ClickHouseProtocol.POSTGRESQL && s.endsWith("s");
+                Assert.assertEquals(ClickHouseNode.of(s + ":///?#"),
+                        new ClickHouseNode("localhost", p, secure
+                                ? p.getDefaultSecurePort()
+                                : p.getDefaultPort(),
+                                null, secure ? options : null, null));
+            }
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeWithHostAndPort() {
+        Assert.assertEquals(ClickHouseNode.of(":-1"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of(":8443"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("a:-1"),
+                new ClickHouseNode("localhost", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("a:0"),
+                new ClickHouseNode("a", ClickHouseProtocol.ANY, 0, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("a:65535"),
+                new ClickHouseNode("a", ClickHouseProtocol.ANY, 65535, null, null, null));
+        Assert.assertEquals(ClickHouseNode.of("a:65536"),
+                new ClickHouseNode("a", ClickHouseProtocol.ANY, 0, null, null, null));
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeWithDatabase() {
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.SSL.getKey(), "true");
+        options.put(ClickHouseClientOption.SSL_MODE.getKey(), "NONE");
+
+        Assert.assertEquals(ClickHouseNode.of("grpcs://node1:19100/"),
+                new ClickHouseNode("node1", ClickHouseProtocol.GRPC, 19100, null, options, null));
+
+        for (String uri : new String[] {
+                "tcp://node1:9001/test",
+                "tcp://node1:9001/test?",
+                "tcp://node1:9001/test#",
+                "tcp://node1:9001/test?#"
+        }) {
+            Assert.assertEquals(ClickHouseNode.of(uri),
+                    new ClickHouseNode("node1", ClickHouseProtocol.TCP, 9001, null,
+                            Collections.singletonMap(
+                                    ClickHouseClientOption.DATABASE.getKey(),
+                                    "test"),
+                            null));
+        }
+
+        Assert.assertEquals(ClickHouseNode.of("tcp://node1:9001/test/"),
+                new ClickHouseNode("node1", ClickHouseProtocol.TCP, 9001, null,
+                        Collections.singletonMap(ClickHouseClientOption.DATABASE.getKey(),
+                                "test/"),
+                        null));
+
+        String db = ClickHouseNode
+                .of("localhost/testdb",
+                        Collections.singletonMap(ClickHouseClientOption.DATABASE.getKey(),
+                                "system"))
+                .getDatabase().orElse(null);
+        Assert.assertEquals(db, "system");
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeWithCredentials() {
+        Assert.assertEquals(ClickHouseNode.of("grpc://letmein@master"),
+                new ClickHouseNode("master", ClickHouseProtocol.GRPC,
+                        ClickHouseProtocol.GRPC.getDefaultPort(),
+                        ClickHouseCredentials.fromUserAndPassword("letmein", ""), null, null));
+        Assert.assertEquals(ClickHouseNode.of("grpc://letmein:test@master"),
+                new ClickHouseNode("master", ClickHouseProtocol.GRPC,
+                        ClickHouseProtocol.GRPC.getDefaultPort(),
+                        ClickHouseCredentials.fromUserAndPassword("letmein", "test"), null,
+                        null));
+        Assert.assertEquals(ClickHouseNode.of("grpc://letmein:test@master/?password=secret"),
+                new ClickHouseNode("master", ClickHouseProtocol.GRPC,
+                        ClickHouseProtocol.GRPC.getDefaultPort(),
+                        ClickHouseCredentials.fromUserAndPassword("letmein", "secret"), null,
+                        null));
+        Assert.assertEquals(ClickHouseNode.of("grpc://letmein:test@master/?user=me&password=secret"),
+                new ClickHouseNode("master", ClickHouseProtocol.GRPC,
+                        ClickHouseProtocol.GRPC.getDefaultPort(),
+                        ClickHouseCredentials.fromUserAndPassword("me", "secret"), null,
+                        null));
+
+        Assert.assertEquals(
+                ClickHouseNode.of("https://:letmein@[::1]:3218/db1?user=aaa").getCredentials()
+                        .orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("aaa", "letmein"));
+        Assert.assertEquals(ClickHouseNode.of("https://:letmein@[::1]:3218/db1").getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword(
+                        (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
+                        "letmein"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeWithOptions() {
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.ASYNC.getKey(), "false");
+        options.put(ClickHouseClientOption.SSL.getKey(), "true");
+        options.put(ClickHouseClientOption.SSL_MODE.getKey(), "NONE");
+        options.put(ClickHouseClientOption.CONNECTION_TIMEOUT.getKey(), "500");
+
+        for (String uri : new String[] {
+                "https://node1?!async&ssl&connect_timeout=500",
+                "http://node1?async=false&ssl=true&sslmode=NONE&connect_timeout=500",
+                "http://node1?&&&&async=false&ssl&&&&&sslmode=NONE&connect_timeout=500&&&",
+        }) {
+            Assert.assertEquals(ClickHouseNode.of(uri),
+                    new ClickHouseNode("node1", ClickHouseProtocol.HTTP,
+                            ClickHouseProtocol.HTTP.getDefaultSecurePort(),
+                            null, options, null));
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeWithTags() {
+        Set<String> tags = new HashSet<>();
+        tags.add("dc1");
+        tags.add("r1s1");
+        tags.add("read-only");
+
+        for (String uri : new String[] {
+                "tcp://node1#dc1,r1s1,read-only",
+                "tcp://node1?#r1s1,dc1,read-only",
+                "tcp://node1/#dc1,read-only,r1s1",
+                "tcp://node1/#,,,,,,,dc1,,,,read-only,r1s1,,,,",
+        }) {
+            Assert.assertEquals(ClickHouseNode.of(uri),
+                    new ClickHouseNode("node1", ClickHouseProtocol.TCP,
+                            ClickHouseProtocol.TCP.getDefaultPort(), null,
+                            null, tags));
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testProbe() {
+        // FIXME does not support ClickHouseProtocol.POSTGRESQL for now
+        ClickHouseProtocol[] protocols = new ClickHouseProtocol[] { ClickHouseProtocol.GRPC,
+                ClickHouseProtocol.HTTP, ClickHouseProtocol.MYSQL, ClickHouseProtocol.TCP };
+        ClickHouseVersion serverVersion = ClickHouseVersion
+                .of(System.getProperty("clickhouseVersion", "latest"));
+        for (ClickHouseProtocol p : protocols) {
+            if (p == ClickHouseProtocol.GRPC && !serverVersion.check("[21.1,)")) {
+                continue;
+            }
+            ClickHouseNode node = getServer(ClickHouseProtocol.ANY, p.getDefaultPort());
+            ClickHouseNode probedNode = node.probe();
+            Assert.assertNotEquals(probedNode, node);
+            Assert.assertEquals(probedNode.getProtocol(), p);
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testToUri() {
+        Assert.assertEquals(ClickHouseNode.of("a?b=1").toUri().toString(), "any://a:0?b=1");
+        Assert.assertEquals(ClickHouseNode.of("a/b/c?d=1").toUri().toString(), "any://a:0/b/c?d=1");
+        Assert.assertEquals(
+                ClickHouseNode.of("http://test:test@server1.dc1/db1?user=default&!async&auto_discovery#apj,r1s1")
+                        .toUri().toString(),
+                "http://server1.dc1:8123/db1?async=false&auto_discovery=true#apj,r1s1");
     }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
@@ -185,6 +185,16 @@ public class ClickHouseNodesTest {
     }
 
     @Test(groups = { "unit" })
+    public void testQueryWithSlash() throws Exception {
+        ClickHouseNodes servers = ClickHouseNodes.of("https://node1?a=/b/c/d,node2/db2?/a/b/c=d,node3/db1?a=/d/c.b");
+        Assert.assertEquals(servers.nodes.get(0).getDatabase().orElse(null), "db1");
+        Assert.assertEquals(servers.nodes.get(0).getOptions().get("a"), "/b/c/d");
+        Assert.assertEquals(servers.nodes.get(1).getDatabase().orElse(null), "db2");
+        Assert.assertEquals(servers.nodes.get(1).getOptions().get("a"), "/d/c.b");
+        Assert.assertEquals(servers.nodes.get(1).getOptions().get("/a/b/c"), "d");
+    }
+
+    @Test(groups = { "unit" })
     public void testSingleNodeList() {
         String uri = "a";
         Assert.assertEquals(ClickHouseNodes.of(uri),

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
@@ -1,0 +1,488 @@
+package com.clickhouse.client;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.TreeMap;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import com.clickhouse.client.ClickHouseNode.Status;
+import com.clickhouse.client.config.ClickHouseClientOption;
+import com.clickhouse.client.config.ClickHouseDefaults;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ClickHouseNodesTest {
+    @Test(groups = { "unit" })
+    public void testNullOrEmptyList() {
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNodes.of(null));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNodes.of(""));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNodes.of(" "));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNodes.of(","));
+        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseNodes.of(",, , "));
+    }
+
+    @Test(groups = { "unit" })
+    public void testBuildKey() {
+        String baseUri = "localhost";
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, null), baseUri);
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, new TreeMap<Object, Object>()), baseUri);
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, new Properties()), baseUri);
+
+        Map<Object, Object> defaultOptions = new HashMap<>();
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions), baseUri);
+        defaultOptions.put("b", " ");
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions), baseUri + "|b= ,");
+        defaultOptions.put("a", 1);
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions), baseUri + "|a=1,b= ,");
+        defaultOptions.put(" ", false);
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions), baseUri + "| =false,a=1,b= ,");
+        defaultOptions.put(null, "null-key");
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions), baseUri + "| =false,a=1,b= ,");
+        defaultOptions.put("null-value", null);
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions),
+                baseUri + "| =false,a=1,b= ,null-value=null,");
+        defaultOptions.put(null, null);
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions),
+                baseUri + "| =false,a=1,b= ,null-value=null,");
+        defaultOptions.put(ClickHouseDefaults.USER.getKey(), "hello ");
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions),
+                baseUri + "| =false,a=1,b= ,null-value=null,user=hello ,");
+        defaultOptions.put(ClickHouseDefaults.PASSWORD.getKey(), " /?&#");
+        Assert.assertEquals(ClickHouseNodes.buildKey(baseUri, defaultOptions),
+                baseUri + "| =false,a=1,b= ,null-value=null,password= /?&#,user=hello ,");
+        Assert.assertTrue(
+                ClickHouseNodes.of(baseUri, defaultOptions) == ClickHouseNodes.of(baseUri,
+                        defaultOptions),
+                "Should be exact same node list");
+
+        ClickHouseNodes nodes = ClickHouseNodes.of(baseUri, defaultOptions);
+        String user = (String) defaultOptions.remove(ClickHouseDefaults.USER.getKey());
+        String passwd = (String) defaultOptions.remove(ClickHouseDefaults.PASSWORD.getKey());
+        Assert.assertEquals(nodes.getTemplate().getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword(user, passwd));
+        Assert.assertFalse(nodes.getTemplate().getOptions().containsKey(null), "Should not have null key");
+        Assert.assertFalse(nodes.getTemplate().getOptions().containsKey("null-value"),
+                "Should not have null value");
+        Assert.assertFalse(nodes.getTemplate().getOptions().containsKey(ClickHouseDefaults.USER.getKey()),
+                "Should not have user name");
+        Assert.assertFalse(nodes.getTemplate().getOptions().containsKey(ClickHouseDefaults.PASSWORD.getKey()),
+                "Should not have password");
+        Assert.assertEquals(nodes.getTemplate().getOptions().get("a"), "1");
+        Assert.assertEquals(nodes.getTemplate().getOptions().get(" "), "false");
+    }
+
+    @Test(groups = { "unit" })
+    public void testCache() {
+        Assert.assertTrue(ClickHouseNodes.of("a") == ClickHouseNodes.of("a"),
+                "Should be the exact same node list");
+        Assert.assertTrue(ClickHouseNodes.of("a,b,c") == ClickHouseNodes.of("a,b,c"),
+                "Should be the exact same node list");
+        Assert.assertTrue(ClickHouseNodes.of(" a") == ClickHouseNodes.of("a"),
+                "Should be the exact same node list");
+        Assert.assertTrue(ClickHouseNodes.of(" a,b,c ") == ClickHouseNodes.of("a,b,c"),
+                "Should be the exact same node list");
+
+        Assert.assertFalse(ClickHouseNodes.of("a, b,c") == ClickHouseNodes.of("a,b,c"),
+                "Should be the exact same node list");
+    }
+
+    @Test(groups = { "unit" })
+    public void testCredentials() {
+        ClickHouseNodes nodes = ClickHouseNodes
+                .of("https://dba:managed@node1,(node2),(tcp://aaa:bbb@node3)/test");
+        Assert.assertEquals(nodes.getTemplate().getCredentials().orElse(null), null);
+        Assert.assertEquals(nodes.nodes.get(0).getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("dba", "managed"));
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseDefaults.USER.getKey(), "");
+        options.put(ClickHouseDefaults.PASSWORD.getKey(), "");
+        Assert.assertEquals(ClickHouseNodes.of("https://dba:managed@node1,(node2),(tcp://aaa:bbb@node3)/test", options)
+                .getTemplate().getCredentials().orElse(null), null);
+        options.put(ClickHouseDefaults.USER.getKey(), "/u:s?e#r");
+        options.put(ClickHouseDefaults.PASSWORD.getKey(), "");
+        nodes = ClickHouseNodes.of("https://dba:managed@node1,(node2),(tcp://aaa:bbb@node3)/test", options);
+        Assert.assertEquals(nodes.getTemplate().getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("/u:s?e#r", ""));
+        Assert.assertEquals(nodes.nodes.get(0).getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("dba", "managed"));
+        Assert.assertEquals(nodes.nodes.get(1).getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("/u:s?e#r", ""));
+        Assert.assertEquals(nodes.nodes.get(2).getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("aaa", "bbb"));
+        Assert.assertEquals(
+                ClickHouseNodes.of("https://:letmein@[::1]:3218/db1?user=aaa").nodes.get(0)
+                        .getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("aaa", "letmein"));
+        Assert.assertEquals(
+                ClickHouseNodes.of("https://aaa@[::1]:3218/db1?password=ppp").nodes.get(0)
+                        .getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("aaa", "ppp"));
+        Assert.assertEquals(
+                ClickHouseNodes.of("https://[::1]:3218/db1?password=ppp").nodes.get(0)
+                        .getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword((String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
+                        "ppp"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetNodes() {
+        // without selector
+        ClickHouseNodes nodes = ClickHouseNodes.of("http://(node1#dc1),{node2#dc1},(node3#dc2)");
+        Assert.assertEquals(nodes.getNodeSelector(), ClickHouseNodeSelector.EMPTY);
+        Assert.assertEquals(nodes.getNodes(), Arrays.asList(ClickHouseNode.of("http://node1#dc1"),
+                ClickHouseNode.of("http://node2#dc1"), ClickHouseNode.of("http://node3#dc2")));
+        Assert.assertEquals(nodes.getNodes(ClickHouseNodeSelector.of("dc1"), 1),
+                Arrays.asList(ClickHouseNode.of("http://node1#dc1")));
+        Assert.assertEquals(nodes.getNodes(ClickHouseNodeSelector.of("dc1"), -1),
+                Arrays.asList(ClickHouseNode.of("http://node1#dc1"),
+                        ClickHouseNode.of("http://node2#dc1")));
+
+        // with selector
+        nodes = ClickHouseNodes
+                .of("http://(node1#dc1),{node2#dc1},(node3#dc2)/?load_balancing_tags=dc1");
+        Assert.assertEquals(nodes.getNodeSelector().getPreferredTags(), Collections.singleton("dc1"));
+        Assert.assertEquals(nodes.getNodes(),
+                Arrays.asList(ClickHouseNode.of("http://node1#dc1"),
+                        ClickHouseNode.of("http://node2#dc1")));
+        Assert.assertEquals(nodes.getNodes(ClickHouseNodeSelector.of("dc2"), 1),
+                Arrays.asList(ClickHouseNode.of("http://node3#dc2")));
+        Assert.assertEquals(nodes.getNodes(ClickHouseNodeSelector.of("dc2"), -1),
+                Arrays.asList(ClickHouseNode.of("http://node3#dc2")));
+    }
+
+    @Test(groups = { "unit" })
+    public void testNodeGrouping() throws Exception {
+        ClickHouseNodes nodes = ClickHouseNodes
+                .of("http://(a?node_group_size=1),(tcp://b?x=1)/test?x=2&node_group_size=0");
+        Assert.assertTrue(nodes.getPolicy() == ClickHouseLoadBalancingPolicy.DEFAULT,
+                "Should be the default policy");
+        Assert.assertEquals(nodes.getTemplate().config.getOption(ClickHouseClientOption.NODE_GROUP_SIZE), 0);
+        Assert.assertEquals(nodes.getNodes().size(), 2);
+        Assert.assertTrue(nodes.getFaultyNodes().isEmpty(), "Should NOT have any faulty node");
+        Assert.assertEquals(nodes.getNodes().get(0), ClickHouseNode.of("http://a/test?x=2"));
+
+        nodes = ClickHouseNodes.of(
+                "http://(a?node_group_size=2),(tcp://b?x=1), (c)/test?x=2&node_group_size=1&load_balancing_policy=firstAlive&check_all_nodes=true");
+        Assert.assertEquals(nodes.getTemplate().config.getOption(ClickHouseClientOption.CHECK_ALL_NODES), true);
+        // make sure the one-time health check completed first
+        Optional<ScheduledFuture<?>> o = nodes.scheduleHealthCheck();
+        if (o.isPresent()) {
+            o.get().get(nodes.getTemplate().config.getConnectionTimeout() * 2, TimeUnit.MILLISECONDS);
+        }
+        Assert.assertEquals(nodes.getTemplate().config.getOption(ClickHouseClientOption.NODE_GROUP_SIZE), 1);
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.getNodes().size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.size(), 1);
+        Assert.assertEquals(nodes.getFaultyNodes().size(), 1);
+        Assert.assertEquals(nodes.getFaultyNodes().get(0), ClickHouseNode.of("http://a/test?x=2"));
+        Assert.assertEquals(nodes.get(), ClickHouseNode.of("tcp://b:9000/test?x=1"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testSingleNodeList() {
+        String uri = "a";
+        Assert.assertEquals(ClickHouseNodes.of(uri),
+                new ClickHouseNodes(Arrays.asList(ClickHouseNode.of(uri))));
+        Assert.assertEquals(ClickHouseNodes.of(uri = "http://a"),
+                new ClickHouseNodes(Arrays.asList(ClickHouseNode.of(uri))));
+        Assert.assertEquals(ClickHouseNodes.of(uri).get(), ClickHouseNode.of(uri));
+        Assert.assertEquals(ClickHouseNodes.of(uri).apply(null), ClickHouseNode.of(uri));
+        Assert.assertEquals(ClickHouseNodes.of(uri).apply(ClickHouseNodeSelector.EMPTY),
+                ClickHouseNode.of(uri));
+
+        Assert.assertEquals(ClickHouseNodes.of("http://(a?a=1#b,c,d)"),
+                new ClickHouseNodes(Arrays.asList(ClickHouseNode.of("http://a?a=1#b,c,d"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://(a?a=1#b,c,d)/db?a=2&b=1"),
+                new ClickHouseNodes(Arrays.asList(ClickHouseNode.of("http://a/db?a=1&b=1#b,c,d"))));
+
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.SSL.getKey(), "true");
+        options.put(ClickHouseClientOption.SSL_MODE.getKey(), "NONE");
+        options.put(ClickHouseClientOption.DATABASE.getKey(), "db1");
+
+        Assert.assertEquals(ClickHouseNodes.of("https://node1:443/db1").nodes.get(0),
+                new ClickHouseNode("node1", ClickHouseProtocol.HTTP, 443, null, options, null));
+        Assert.assertEquals(ClickHouseNodes.of("tcps://node1?database=db1").nodes.get(0),
+                new ClickHouseNode("node1", ClickHouseProtocol.TCP, 9440, null, options, null));
+    }
+
+    @Test(groups = { "unit" })
+    public void testMultiNodeList() {
+        Assert.assertEquals(ClickHouseNodes.of("a,b,c, b"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("a"), ClickHouseNode.of("b"), ClickHouseNode.of("c"))));
+        Assert.assertEquals(ClickHouseNodes.of(" ,,,,,a,, b ,c,,a, c,,, ,"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("a"), ClickHouseNode.of("b"), ClickHouseNode.of("c"))));
+        Assert.assertEquals(ClickHouseNodes.of("(a),[::1],{c}"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("a"), ClickHouseNode.of("[::1]"),
+                        ClickHouseNode.of("c"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,b,c"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a"), ClickHouseNode.of("http://b"),
+                        ClickHouseNode.of("http://c"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://(a) , {b}, [::1]"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a"), ClickHouseNode.of("http://b"),
+                        ClickHouseNode.of("http://[::1]"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,tcp://b,grpc://c"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a"), ClickHouseNode.of("tcp://b"),
+                        ClickHouseNode.of("grpc://c"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,tcp://b,grpc://c/"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a"), ClickHouseNode.of("tcp://b"),
+                        ClickHouseNode.of("grpc://c"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,tcp://b,grpc://c/db1"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a/db1"), ClickHouseNode.of("tcp://b/db1"),
+                        ClickHouseNode.of("grpc://c/db1"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,tcp://b,grpc://c?a=1"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a?a=1"), ClickHouseNode.of("tcp://b?a=1"),
+                        ClickHouseNode.of("grpc://c?a=1"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,tcp://b,grpc://c#dc1"), new ClickHouseNodes(
+                Arrays.asList(ClickHouseNode.of("http://a#dc1"), ClickHouseNode.of("tcp://b#dc1"),
+                        ClickHouseNode.of("grpc://c#dc1"))));
+        Assert.assertEquals(ClickHouseNodes.of("http://a,tcp://b,grpc://c:1234/some/db?a=1#dc1"),
+                new ClickHouseNodes(
+                        Arrays.asList(ClickHouseNode.of("http://a/some/db?a=1#dc1"),
+                                ClickHouseNode.of("tcp://b/some/db?a=1#dc1"),
+                                ClickHouseNode.of("grpc://c:1234/some/db?a=1#dc1"))));
+    }
+
+    @Test(groups = { "unit" })
+    public void testManageAndUnmanageNewNode() {
+        ClickHouseNodes nodes = ClickHouseNodes.create("https://a,grpcs://b,mysql://c", null);
+        Assert.assertEquals(nodes.getPolicy(), ClickHouseLoadBalancingPolicy.DEFAULT);
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        ClickHouseNode node = ClickHouseNode.of("tcps://d");
+        Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+        nodes.update(node, Status.MANAGED);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 4);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        nodes.update(node, Status.STANDALONE);
+        Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+
+        // now repeat same scenario but using different method
+        node = ClickHouseNode.of("postgres://e");
+        Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 4);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        node.setManager(null);
+        Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+    }
+
+    @Test(groups = { "unit" })
+    public void testManageAndUnmanageSameNode() {
+        ClickHouseNodes nodes = ClickHouseNodes.create("grpc://(http://a), tcp://b, c", null);
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        ClickHouseNode node = ClickHouseNode.of("http://a");
+        Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+        nodes.update(node, Status.MANAGED);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        nodes.update(node, Status.STANDALONE);
+        Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+        Assert.assertEquals(nodes.nodes.size(), 2);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+
+        // now repeat same scenario but using different method
+        node = ClickHouseNode.of("tcp://b");
+        Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 2);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        node.setManager(null);
+        Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+        Assert.assertEquals(nodes.nodes.size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+    }
+
+    @Test(groups = { "unit" })
+    public void testManageAndUnmanageExistingNode() {
+        ClickHouseNode nodeA = ClickHouseNode.of("a");
+        ClickHouseNode nodeB = ClickHouseNode.of("b");
+        ClickHouseNode nodeC = ClickHouseNode.of("c");
+        ClickHouseNodes nodes = new ClickHouseNodes(Arrays.asList(nodeA, nodeB, nodeC));
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        ClickHouseNode node = nodeA;
+        Assert.assertTrue(node.isManaged(), "Existing node should be managed");
+        nodes.update(node, Status.MANAGED);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        nodes.update(node, Status.STANDALONE);
+        Assert.assertTrue(node.isStandalone(), "Unmanaged node should NOT have status manager");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 2);
+
+        // now repeat same scenario but using different method
+        node = nodeC;
+        Assert.assertTrue(node.isManaged(), "Existing node should be managed");
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 2);
+        node.setManager(null);
+        Assert.assertTrue(node.isStandalone(), "Unmanaged node should NOT have status manager");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 1);
+    }
+
+    @Test(groups = { "unit" })
+    public void testChangeStatusOfNewNode() {
+        ClickHouseNodes nodes = ClickHouseNodes.create("a,b,c", null);
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+
+        ClickHouseNode node = ClickHouseNode.of("x");
+        Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+        nodes.update(node, Status.HEALTHY);
+        Assert.assertEquals(nodes.nodes.size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        nodes.update(node, Status.FAULTY);
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 4);
+
+        // since the node is NOT managed, its update function won't work
+        for (Status s : new Status[] {
+                Status.HEALTHY,
+                Status.FAULTY,
+                Status.MANAGED,
+                Status.STANDALONE
+        }) {
+            node.update(s);
+            Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+            Assert.assertEquals(nodes.nodes.size(), 0);
+            Assert.assertEquals(nodes.faultyNodes.size(), 4);
+        }
+
+        // mark it as managed
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 4);
+        node.update(Status.STANDALONE);
+        Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 4);
+        Assert.assertEquals(nodes.faultyNodes.getLast(), node);
+        node.update(Status.HEALTHY);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        Assert.assertEquals(nodes.nodes.getFirst(), node);
+    }
+
+    @Test(groups = { "unit" })
+    public void testChangeStatusOfSameNode() {
+        ClickHouseNodes nodes = ClickHouseNodes.create("a,b,c", null);
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+
+        ClickHouseNode node = ClickHouseNode.of("c");
+        Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+        nodes.update(node, Status.HEALTHY);
+        Assert.assertEquals(nodes.nodes.size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.size(), 2);
+        nodes.update(node, Status.FAULTY);
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+
+        // since the node is NOT managed, its update function won't work
+        for (Status s : new Status[] {
+                Status.HEALTHY,
+                Status.FAULTY,
+                Status.MANAGED,
+                Status.STANDALONE
+        }) {
+            node.update(s);
+            Assert.assertTrue(node.isStandalone(), "Newly created node is always standalone");
+            Assert.assertEquals(nodes.nodes.size(), 0);
+            Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        }
+
+        // mark it as managed
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        node.update(Status.STANDALONE);
+        Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 2);
+
+        node.setManager(nodes);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.getLast(), node);
+        node.update(Status.HEALTHY);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.size(), 2);
+        Assert.assertEquals(nodes.nodes.getFirst(), node);
+    }
+
+    @Test(groups = { "unit" })
+    public void testChangeStatusOfExistingNode() {
+        ClickHouseNode nodeA = ClickHouseNode.of("http://a");
+        ClickHouseNode nodeB = ClickHouseNode.of("tcp://b");
+        ClickHouseNode nodeC = ClickHouseNode.of("grpc://c");
+        ClickHouseNodes nodes = new ClickHouseNodes(Arrays.asList(nodeA, nodeB, nodeC));
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+
+        ClickHouseNode node = nodeA;
+        Assert.assertTrue(node.isManaged(), "Existing node should be managed");
+        nodes.update(node, Status.HEALTHY);
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        nodes.update(node, Status.FAULTY);
+        Assert.assertEquals(nodes.nodes.size(), 2);
+        Assert.assertEquals(nodes.faultyNodes.size(), 1);
+
+        // since the node is managed, mark it as managed
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        node.update(Status.HEALTHY);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 3);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        Assert.assertEquals(nodes.nodes.getLast(), node);
+        node.update(Status.FAULTY);
+        Assert.assertTrue(node.isManaged(), "Node should be managed");
+        Assert.assertEquals(nodes.nodes.size(), 2);
+        Assert.assertEquals(nodes.faultyNodes.size(), 1);
+        Assert.assertEquals(nodes.faultyNodes.getLast(), node);
+
+        // remove the node from the list
+        node.setManager(null);
+        for (Status s : new Status[] {
+                Status.HEALTHY,
+                Status.FAULTY,
+                Status.MANAGED,
+                Status.STANDALONE
+        }) {
+            node.update(s);
+            Assert.assertTrue(node.isStandalone(), "Removed node is always standalone");
+            Assert.assertEquals(nodes.nodes.size(), 2);
+            Assert.assertEquals(nodes.faultyNodes.size(), 0);
+        }
+    }
+}

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseRequestTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseRequestTest.java
@@ -207,6 +207,9 @@ public class ClickHouseRequestTest {
         ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(ClickHouseNode.builder().build());
         Assert.assertEquals(request.getFormat(),
                 (ClickHouseFormat) ClickHouseDefaults.FORMAT.getEffectiveDefaultValue());
+        request.format(ClickHouseFormat.TabSeparatedRawWithNamesAndTypes);
+        Assert.assertEquals(request.getFormat(), ClickHouseFormat.TabSeparatedRawWithNamesAndTypes);
+        Assert.assertEquals(request.getInputFormat(), ClickHouseFormat.TabSeparatedRaw);
         request.format(ClickHouseFormat.ArrowStream);
         Assert.assertEquals(request.getFormat(), ClickHouseFormat.ArrowStream);
         Assert.assertEquals(request.getInputFormat(), ClickHouseFormat.ArrowStream);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import com.clickhouse.client.ClickHouseClientBuilder.Agent;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseRenameMethod;
 import com.clickhouse.client.config.ClickHouseSslMode;
@@ -163,7 +164,8 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
                 ClickHouseClient client4 = ClickHouseClient.newInstance(getProtocol());
                 ClickHouseClient client5 = getClient()) {
             for (ClickHouseClient client : new ClickHouseClient[] { client1, client2, client3, client4, client5 }) {
-                Assert.assertEquals(client.getClass(), getClientClass());
+                Assert.assertEquals(client.getClass(), Agent.class);
+                Assert.assertEquals(((Agent) client).getClient().getClass(), getClientClass());
                 Assert.assertTrue(client.accept(getProtocol()), "The client should support protocl: " + getProtocol());
             }
         }

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
@@ -1,11 +1,13 @@
 package com.clickhouse.client.grpc;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.Map.Entry;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import com.google.protobuf.ByteString;
@@ -43,8 +45,11 @@ import com.clickhouse.client.logging.LoggerFactory;
 public class ClickHouseGrpcClient extends AbstractClient<ManagedChannel> {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseGrpcClient.class);
 
-    protected static QueryInfo convert(ClickHouseNode server, ClickHouseRequest<?> request) {
+    static final List<ClickHouseProtocol> SUPPORTED = Collections.singletonList(ClickHouseProtocol.GRPC);
+
+    protected static QueryInfo convert(ClickHouseRequest<?> request) {
         ClickHouseConfig config = request.getConfig();
+        ClickHouseNode server = request.getServer();
         ClickHouseCredentials credentials = server.getCredentials(config);
 
         Builder builder = QueryInfo.newBuilder();
@@ -141,12 +146,22 @@ public class ClickHouseGrpcClient extends AbstractClient<ManagedChannel> {
     }
 
     @Override
+    protected boolean checkHealth(ClickHouseNode server, int timeout) {
+        return true;
+    }
+
+    @Override
     protected void closeConnection(ManagedChannel connection, boolean force) {
         if (!force) {
             connection.shutdown();
         } else {
             connection.shutdownNow();
         }
+    }
+
+    @Override
+    protected Collection<ClickHouseProtocol> getSupportedProtocols() {
+        return SUPPORTED;
     }
 
     @Override
@@ -161,24 +176,19 @@ public class ClickHouseGrpcClient extends AbstractClient<ManagedChannel> {
 
     protected void fill(ClickHouseRequest<?> request, StreamObserver<QueryInfo> observer) {
         try {
-            observer.onNext(convert(getServer(), request));
+            observer.onNext(convert(request));
         } finally {
             observer.onCompleted();
         }
     }
 
     @Override
-    public boolean accept(ClickHouseProtocol protocol) {
-        return ClickHouseProtocol.GRPC == protocol || super.accept(protocol);
-    }
-
-    protected CompletableFuture<ClickHouseResponse> executeAsync(ClickHouseRequest<?> sealedRequest,
-            ManagedChannel channel, ClickHouseNode server) {
+    protected Object[] getAsyncExecArguments(ClickHouseRequest<?> sealedRequest) {
         // reuse stub?
-        ClickHouseGrpc.ClickHouseStub stub = ClickHouseGrpc.newStub(channel);
+        ClickHouseGrpc.ClickHouseStub stub = ClickHouseGrpc.newStub(getConnection(sealedRequest));
 
         final ClickHouseStreamObserver responseObserver = new ClickHouseStreamObserver(sealedRequest.getConfig(),
-                server, sealedRequest.getOutputStream().orElse(null));
+                sealedRequest.getServer(), sealedRequest.getOutputStream().orElse(null));
         final StreamObserver<QueryInfo> requestObserver = stub.executeQueryWithStreamIO(responseObserver);
 
         if (sealedRequest.hasInputStream()) {
@@ -187,67 +197,61 @@ public class ClickHouseGrpcClient extends AbstractClient<ManagedChannel> {
             fill(sealedRequest, requestObserver);
         }
 
-        return CompletableFuture.supplyAsync(() -> {
-            ClickHouseConfig config = sealedRequest.getConfig();
-            int timeout = config.getConnectionTimeout() / 1000
-                    + Math.max(config.getSocketTimeout() / 1000, config.getMaxExecutionTime());
-            try {
-                if (!responseObserver.await(timeout, TimeUnit.SECONDS)) {
-                    if (!Context.current().withCancellation().cancel(new StatusException(Status.CANCELLED))) {
-                        requestObserver.onError(new StatusException(Status.CANCELLED));
-                    }
-                    throw new CompletionException(
-                            ClickHouseUtils.format("Timed out after waiting for %d %s", timeout, TimeUnit.SECONDS),
-                            null);
-                }
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new CompletionException(ClickHouseException.of(e, server));
-            }
-
-            try {
-                ClickHouseResponse response = new ClickHouseGrpcResponse(sealedRequest.getConfig(),
-                        sealedRequest.getSettings(), responseObserver);
-                Throwable cause = responseObserver.getError();
-                if (cause != null) {
-                    throw new CompletionException(ClickHouseException.of(cause, server));
-                }
-                return response;
-            } catch (IOException e) {
-                throw new CompletionException(ClickHouseException.of(e, server));
-            }
-        }, getExecutor());
-    }
-
-    protected CompletableFuture<ClickHouseResponse> executeSync(ClickHouseRequest<?> sealedRequest,
-            ManagedChannel channel, ClickHouseNode server) {
-        ClickHouseGrpc.ClickHouseBlockingStub stub = ClickHouseGrpc.newBlockingStub(channel);
-
-        // TODO not as elegant as ClickHouseImmediateFuture :<
-        try {
-            Result result = stub.executeQuery(convert(server, sealedRequest));
-
-            ClickHouseResponse response = new ClickHouseGrpcResponse(sealedRequest.getConfig(),
-                    sealedRequest.getSettings(), result);
-
-            return result.hasException()
-                    ? failedResponse(new ClickHouseException(result.getException().getCode(),
-                            result.getException().getDisplayText(), server))
-                    : CompletableFuture.completedFuture(response);
-        } catch (IOException e) {
-            throw new CompletionException(ClickHouseException.of(e, server));
-        }
+        return new Object[] { requestObserver, responseObserver };
     }
 
     @Override
-    public CompletableFuture<ClickHouseResponse> execute(ClickHouseRequest<?> request) {
-        // sealedRequest is an immutable copy of the original request
-        final ClickHouseRequest<?> sealedRequest = request.seal();
-        final ManagedChannel c = getConnection(sealedRequest);
-        final ClickHouseNode s = getServer();
+    protected ClickHouseResponse sendAsync(ClickHouseRequest<?> sealedRequest, Object... args)
+            throws ClickHouseException, IOException {
+        StreamObserver<QueryInfo> requestObserver = (StreamObserver<QueryInfo>) args[0];
+        ClickHouseStreamObserver responseObserver = (ClickHouseStreamObserver) args[1];
 
-        return sealedRequest.getConfig().isAsync() ? executeAsync(sealedRequest, c, s)
-                : executeSync(sealedRequest, c, s);
+        ClickHouseConfig config = sealedRequest.getConfig();
+        int timeout = config.getConnectionTimeout() / 1000
+                + Math.max(config.getSocketTimeout() / 1000, config.getMaxExecutionTime());
+        try {
+            if (!responseObserver.await(timeout, TimeUnit.SECONDS)) {
+                if (!Context.current().withCancellation().cancel(new StatusException(Status.CANCELLED))) {
+                    requestObserver.onError(new StatusException(Status.CANCELLED));
+                }
+                throw new SocketTimeoutException(
+                        ClickHouseUtils.format("Timed out after waiting for %d %s", timeout, TimeUnit.SECONDS));
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw ClickHouseException.of(e, sealedRequest.getServer());
+        }
+
+        ClickHouseResponse response = new ClickHouseGrpcResponse(sealedRequest.getConfig(),
+                sealedRequest.getSettings(), responseObserver);
+        Throwable cause = responseObserver.getError();
+        if (cause != null) {
+            throw ClickHouseException.of(cause, sealedRequest.getServer());
+        }
+        return response;
+    }
+
+    @Override
+    protected ClickHouseResponse send(ClickHouseRequest<?> sealedRequest) throws ClickHouseException, IOException {
+        final ManagedChannel channel = getConnection(sealedRequest);
+
+        ClickHouseGrpc.ClickHouseBlockingStub stub = ClickHouseGrpc.newBlockingStub(channel);
+
+        Result result = stub.executeQuery(convert(sealedRequest));
+
+        ClickHouseResponse response = new ClickHouseGrpcResponse(sealedRequest.getConfig(),
+                sealedRequest.getSettings(), result);
+        if (result.hasException()) {
+            throw new ClickHouseException(result.getException().getCode(), result.getException().getDisplayText(),
+                    sealedRequest.getServer());
+        }
+
+        return response;
+    }
+
+    @Override
+    public boolean accept(ClickHouseProtocol protocol) {
+        return ClickHouseProtocol.GRPC == protocol || super.accept(protocol);
     }
 
     @Override

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -125,7 +125,7 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
 
         StringBuilder builder = new StringBuilder().append(baseUrl);
         String context = (String) config.getOption(ClickHouseHttpOption.WEB_CONTEXT);
-        if (context != null && !context.isEmpty()) {
+        if (!ClickHouseChecker.isNullOrEmpty(context)) {
             char prev = '/';
             for (int i = 0, len = context.length(); i < len; i++) {
                 char ch = context.charAt(i);

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -120,25 +120,21 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
         return builder.toString();
     }
 
-    static String buildUrl(ClickHouseNode server, ClickHouseRequest<?> request) {
+    static String buildUrl(String baseUrl, ClickHouseRequest<?> request) {
         ClickHouseConfig config = request.getConfig();
 
-        StringBuilder builder = new StringBuilder();
-        builder.append(config.isSsl() ? "https" : "http").append("://").append(server.getHost()).append(':')
-                .append(server.getPort()).append('/');
+        StringBuilder builder = new StringBuilder().append(baseUrl);
         String context = (String) config.getOption(ClickHouseHttpOption.WEB_CONTEXT);
         if (context != null && !context.isEmpty()) {
             char prev = '/';
             for (int i = 0, len = context.length(); i < len; i++) {
                 char ch = context.charAt(i);
-                if (ch != '/' || ch != prev) {
+                if (ch == '?' || ch == '#') {
+                    break;
+                } else if (ch != '/' || ch != prev) {
                     builder.append(ch);
                 }
                 prev = ch;
-            }
-
-            if (prev != '/') {
-                builder.append('/');
             }
         }
 
@@ -168,7 +164,7 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
 
         this.output = request.getOutputStream().orElse(null);
 
-        this.url = buildUrl(server, request);
+        this.url = buildUrl(server.getBaseUri(), request);
 
         Map<String, String> map = new LinkedHashMap<>();
         // add customer headers
@@ -218,12 +214,14 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     }
 
     protected String getBaseUrl() {
-        String baseUrl;
         int index = url.indexOf('?');
-        if (index > 0) {
-            baseUrl = url.substring(0, index);
-        } else {
-            baseUrl = url;
+        if (index < 1) {
+            index = url.length();
+        }
+
+        String baseUrl = url.substring(0, index);
+        if (url.charAt(index - 1) != '/') {
+            baseUrl = baseUrl.concat("/");
         }
 
         return baseUrl;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -43,7 +43,7 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
     // SEND_PROGRESS_INTERVAL("http_headers_progress_interval_ms", 3000, ""),
     // WAIT_END_OF_QUERY("wait_end_of_query", false, ""),
     /**
-     * Flow control window.
+     * Web context.
      */
     WEB_CONTEXT("web_context", "/", "Web context.");
 

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseFormat;
 import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.data.ClickHouseExternalTable;
 import com.clickhouse.client.http.config.ClickHouseHttpOption;
@@ -33,12 +34,63 @@ public class ClickHouseHttpConnectionTest {
         }
 
         @Override
-        public void close() throws Exception {
+        public void close() {
         }
     }
 
     @Test(groups = { "unit" })
-    public void testDefaultHeaders() throws Exception {
+    public void testBuildUrl() {
+        // .port(ClickHouseProtocol.HTTP)
+        ClickHouseNode server = ClickHouseNode.builder().port(ClickHouseProtocol.HTTP).build();
+        ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
+        ClickHouseNode s = request.getServer();
+        Assert.assertEquals(ClickHouseHttpConnection.buildUrl(server.getBaseUri(), request),
+                "http://localhost:8123/?compress=1&extremes=0");
+
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "")),
+                "http://localhost:8123/?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "/")),
+                "http://localhost:8123/?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "./")),
+                "http://localhost:8123/./?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, ".")),
+                "http://localhost:8123/.?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "?")),
+                "http://localhost:8123/?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "#")),
+                "http://localhost:8123/?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "/a/b/c/d/")),
+                "http://localhost:8123/a/b/c/d/?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "/a?b=1#c")),
+                "http://localhost:8123/a?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "/a#c")),
+                "http://localhost:8123/a?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "///.//")),
+                "http://localhost:8123/./?compress=1&extremes=0");
+    }
+
+    @Test(groups = { "unit" })
+    public void testDefaultHeaders() {
         ClickHouseNode server = ClickHouseNode.builder().build();
         ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
         SimpleHttpConnection sc = new SimpleHttpConnection(server, request);
@@ -51,26 +103,27 @@ public class ClickHouseHttpConnectionTest {
     }
 
     @Test(groups = { "unit" })
-    public void testBuildUrl() throws Exception {
-        ClickHouseNode server = ClickHouseNode.builder().build();
+    public void testGetBaseUrl() {
+        ClickHouseNode server = ClickHouseNode.of("https://localhost/db1");
         ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
-        Assert.assertEquals(ClickHouseHttpConnection.buildUrl(server, request),
-                "http://localhost:8123/?compress=1&extremes=0");
-
+        Assert.assertEquals(ClickHouseHttpConnection.buildUrl(server.getBaseUri(), request),
+                "https://localhost:8443/?compress=1&extremes=0");
+        try (SimpleHttpConnection c = new SimpleHttpConnection(server, request)) {
+            Assert.assertEquals(c.getBaseUrl(), "https://localhost:8443/");
+        }
         Assert.assertEquals(
-                ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, "")),
-                "http://localhost:8123/?compress=1&extremes=0");
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "/a/b/c")),
+                "https://localhost:8443/a/b/c?compress=1&extremes=0");
+        try (SimpleHttpConnection c = new SimpleHttpConnection(server, request)) {
+            Assert.assertEquals(c.getBaseUrl(), "https://localhost:8443/a/b/c/");
+        }
         Assert.assertEquals(
-                ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, "/")),
-                "http://localhost:8123/?compress=1&extremes=0");
-        Assert.assertEquals(
-                ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, ".")),
-                "http://localhost:8123/./?compress=1&extremes=0");
-        Assert.assertEquals(
-                ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, "./")),
-                "http://localhost:8123/./?compress=1&extremes=0");
-        Assert.assertEquals(
-                ClickHouseHttpConnection.buildUrl(server, request.option(ClickHouseHttpOption.WEB_CONTEXT, "///.//")),
-                "http://localhost:8123/./?compress=1&extremes=0");
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "a?b=1")),
+                "https://localhost:8443/a?compress=1&extremes=0");
+        try (SimpleHttpConnection c = new SimpleHttpConnection(server, request)) {
+            Assert.assertEquals(c.getBaseUrl(), "https://localhost:8443/a/");
+        }
     }
 }

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
@@ -40,7 +40,6 @@ public class ClickHouseHttpConnectionTest {
 
     @Test(groups = { "unit" })
     public void testBuildUrl() {
-        // .port(ClickHouseProtocol.HTTP)
         ClickHouseNode server = ClickHouseNode.builder().port(ClickHouseProtocol.HTTP).build();
         ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
         ClickHouseNode s = request.getServer();
@@ -83,6 +82,10 @@ public class ClickHouseHttpConnectionTest {
                 ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
                         request.option(ClickHouseHttpOption.WEB_CONTEXT, "/a#c")),
                 "http://localhost:8123/a?compress=1&extremes=0");
+        Assert.assertEquals(
+                ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
+                        request.option(ClickHouseHttpOption.WEB_CONTEXT, "/a%20c")),
+                "http://localhost:8123/a%20c?compress=1&extremes=0");
         Assert.assertEquals(
                 ClickHouseHttpConnection.buildUrl(server.getBaseUri(),
                         request.option(ClickHouseHttpOption.WEB_CONTEXT, "///.//")),

--- a/clickhouse-jdbc/pom.xml
+++ b/clickhouse-jdbc/pom.xml
@@ -96,6 +96,10 @@
             <groupId>org.lz4</groupId>
             <artifactId>lz4-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
@@ -451,7 +455,7 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.lz4:lz4-java</artifact>
+                                    <artifact>org.apache.commons:commons-compress</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseConnection.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseConnection.java
@@ -142,6 +142,13 @@ public interface ClickHouseConnection extends Connection {
     ClickHouseConfig getConfig();
 
     /**
+     * Checks whether custom setting is allowed or not.
+     *
+     * @return true if custom setting is allowed; false otherwise
+     */
+    boolean allowCustomSetting();
+
+    /**
      * Gets current database. {@link #getSchema()} is similar but it will check if
      * connection is closed or not hence may throw {@link SQLException}.
      *

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDataSource.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDataSource.java
@@ -57,14 +57,35 @@ public class ClickHouseDataSource extends JdbcWrapper implements DataSource {
         return driver.connect(url, props);
     }
 
+    /**
+     * Gets host.
+     *
+     * @return host
+     * @deprecated will be removed in v0.3.3
+     */
+    @Deprecated
     public String getHost() {
         return connInfo.getServer().getHost();
     }
 
+    /**
+     * Gets port.
+     *
+     * @return port
+     * @deprecated will be removed in v0.3.3
+     */
+    @Deprecated
     public int getPort() {
         return connInfo.getServer().getPort();
     }
 
+    /**
+     * Gets database.
+     *
+     * @return database
+     * @deprecated will be removed in v0.3.3
+     */
+    @Deprecated
     public String getDatabase() {
         return connInfo.getServer().getDatabase()
                 .orElse((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue());

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java
@@ -58,6 +58,7 @@ public class ClickHouseResultSet extends AbstractResultSet {
     protected final List<ClickHouseColumn> columns;
     protected final Calendar defaultCalendar;
     protected final int maxRows;
+    protected final boolean nullAsDefault;
     protected final ClickHouseResultSetMetaData metaData;
 
     protected final Map<String, Class<?>> defaultTypeMap;
@@ -88,6 +89,7 @@ public class ClickHouseResultSet extends AbstractResultSet {
         this.lastReadColumn = 0;
 
         this.maxRows = 0;
+        this.nullAsDefault = false;
         this.fetchSize = 0;
     }
 
@@ -124,6 +126,7 @@ public class ClickHouseResultSet extends AbstractResultSet {
         this.lastReadColumn = 0;
 
         this.maxRows = statement.getMaxRows();
+        this.nullAsDefault = statement.getNullAsDefault() > 1;
         this.fetchSize = statement.getFetchSize();
     }
 
@@ -147,6 +150,9 @@ public class ClickHouseResultSet extends AbstractResultSet {
         ensureRead(columnIndex);
 
         ClickHouseValue v = currentRow.getValue(columnIndex - 1);
+        if (nullAsDefault && v.isNullOrEmpty()) {
+            v.resetToDefault();
+        }
         lastReadColumn = columnIndex;
         return v;
     }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseStatement.java
@@ -13,6 +13,10 @@ public interface ClickHouseStatement extends Statement {
 
     ClickHouseConfig getConfig();
 
+    int getNullAsDefault();
+
+    void setNullAsDefault(int level);
+
     ClickHouseRequest<?> getRequest();
 
     default Mutation write() {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcConfig.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcConfig.java
@@ -26,6 +26,7 @@ public class JdbcConfig {
     public static final String PROP_FETCH_SIZE = "fetchSize";
     public static final String PROP_JDBC_COMPLIANT = "jdbcCompliant";
     public static final String PROP_NAMED_PARAM = "namedParameter";
+    public static final String PROP_NULL_AS_DEFAULT = "nullAsDefault";
     public static final String PROP_TYPE_MAP = "typeMappings";
     public static final String PROP_WRAPPER_OBJ = "wrapperObject";
 
@@ -38,6 +39,7 @@ public class JdbcConfig {
     private static final String DEFAULT_FETCH_SIZE = "0";
     private static final String DEFAULT_JDBC_COMPLIANT = BOOLEAN_TRUE;
     private static final String DEFAULT_NAMED_PARAM = BOOLEAN_FALSE;
+    private static final String DEFAULT_NULL_AS_DEFAULT = "0";
     private static final String DEFAULT_TYPE_MAP = "";
     private static final String DEFAULT_WRAPPER_OBJ = BOOLEAN_FALSE;
 
@@ -120,6 +122,10 @@ public class JdbcConfig {
         info.description = "Whether to use named parameter(e.g. :ts(DateTime64(6)) or :value etc.) instead of standard JDBC question mark placeholder.";
         list.add(info);
 
+        info = new DriverPropertyInfo(PROP_NULL_AS_DEFAULT, DEFAULT_NULL_AS_DEFAULT);
+        info.description = "Default approach to handle null value, sets to 0 or negative number to throw exception when target column is not nullable, 1 to disable the null-check, and 2 or higher to replace null to default value of corresponding data type.";
+        list.add(info);
+
         info = new DriverPropertyInfo(PROP_TYPE_MAP, DEFAULT_TYPE_MAP);
         info.description = "Default type mappings between ClickHouse data type and Java class. You can define multiple mappings using comma as separator.";
         list.add(info);
@@ -138,6 +144,7 @@ public class JdbcConfig {
     private final int fetchSize;
     private final boolean jdbcCompliant;
     private final boolean namedParameter;
+    private final int nullAsDefault;
     private final Map<String, Class<?>> typeMap;
     private final boolean wrapperObject;
 
@@ -156,6 +163,7 @@ public class JdbcConfig {
         this.fetchSize = extractIntValue(props, PROP_FETCH_SIZE, DEFAULT_FETCH_SIZE);
         this.jdbcCompliant = extractBooleanValue(props, PROP_JDBC_COMPLIANT, DEFAULT_JDBC_COMPLIANT);
         this.namedParameter = extractBooleanValue(props, PROP_NAMED_PARAM, DEFAULT_NAMED_PARAM);
+        this.nullAsDefault = extractIntValue(props, PROP_NULL_AS_DEFAULT, DEFAULT_NULL_AS_DEFAULT);
         this.typeMap = extractTypeMapValue(props, PROP_TYPE_MAP, DEFAULT_TYPE_MAP);
         this.wrapperObject = extractBooleanValue(props, PROP_WRAPPER_OBJ, DEFAULT_WRAPPER_OBJ);
     }
@@ -214,6 +222,16 @@ public class JdbcConfig {
      */
     public boolean isJdbcCompliant() {
         return jdbcCompliant;
+    }
+
+    /**
+     * Gets default approach to handle null value.
+     *
+     * @return 0 or negative to throw exception, 1 to disable the null-check, and 2
+     *         to reset null to default value of corresponding data type
+     */
+    public int getNullAsDefault() {
+        return nullAsDefault;
     }
 
     /**

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParser.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParser.java
@@ -1,19 +1,14 @@
 package com.clickhouse.jdbc.internal;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
-import java.util.Locale;
 import java.util.Properties;
 
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseCredentials;
 import com.clickhouse.client.ClickHouseFormat;
 import com.clickhouse.client.ClickHouseNode;
-import com.clickhouse.client.ClickHouseProtocol;
+import com.clickhouse.client.ClickHouseNodes;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
@@ -26,26 +21,33 @@ public class ClickHouseJdbcUrlParser {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseJdbcUrlParser.class);
 
     public static class ConnectionInfo {
-        private final URI uri;
-        private final ClickHouseNode server;
+        private final ClickHouseCredentials credentials;
+        private final ClickHouseNodes nodes;
         private final JdbcConfig jdbcConf;
         private final Properties props;
 
-        protected ConnectionInfo(URI uri, ClickHouseNode server, Properties props) throws URISyntaxException {
-            this.uri = new URI("jdbc:clickhouse:" + server.getProtocol().name().toLowerCase(Locale.ROOT), null,
-                    server.getHost(), server.getPort(), "/" + server.getDatabase().orElse(""),
-                    removeCredentialsFromQuery(uri.getRawQuery()), null);
-            this.server = server;
+        protected ConnectionInfo(ClickHouseNodes nodes, Properties props) {
+            this.nodes = nodes;
             this.jdbcConf = new JdbcConfig(props);
             this.props = props;
+
+            ClickHouseCredentials c = nodes.getTemplate().getCredentials().orElse(null);
+            if (props != null && !props.isEmpty()) {
+                String user = props.getProperty(ClickHouseDefaults.USER.getKey(), "");
+                String passwd = props.getProperty(ClickHouseDefaults.PASSWORD.getKey(), "");
+                if (!ClickHouseChecker.isNullOrEmpty(user)) {
+                    c = ClickHouseCredentials.fromUserAndPassword(user, passwd);
+                }
+            }
+            this.credentials = c;
         }
 
-        public URI getUri() {
-            return uri;
+        public ClickHouseCredentials getDefaultCredentials() {
+            return this.credentials;
         }
 
         public ClickHouseNode getServer() {
-            return server;
+            return nodes.apply(nodes.getNodeSelector());
         }
 
         public JdbcConfig getJdbcConfig() {
@@ -62,122 +64,6 @@ public class ClickHouseJdbcUrlParser {
     public static final String JDBC_PREFIX = "jdbc:";
     public static final String JDBC_CLICKHOUSE_PREFIX = JDBC_PREFIX + "clickhouse:";
     public static final String JDBC_ABBREVIATION_PREFIX = JDBC_PREFIX + "ch:";
-
-    private static String decode(String str) {
-        try {
-            return URLDecoder.decode(str, StandardCharsets.UTF_8.name());
-        } catch (UnsupportedEncodingException e) {
-            // don't print the content here as it may contain password
-            log.warn("Failed to decode given string, fallback to the original string");
-            return str;
-        }
-    }
-
-    private static ClickHouseNode parseNode(URI uri, Properties defaults) {
-        ClickHouseProtocol protocol = ClickHouseProtocol.fromUriScheme(uri.getScheme());
-        if (protocol == null || protocol == ClickHouseProtocol.ANY) {
-            throw new IllegalArgumentException("Unsupported scheme: " + uri.getScheme());
-        }
-
-        String host = uri.getHost();
-        if (host == null || host.isEmpty()) {
-            throw new IllegalArgumentException("Host is missed or wrong");
-        }
-
-        int port = uri.getPort();
-        if (port == -1) {
-            port = protocol.getDefaultPort();
-        }
-
-        String userName = defaults.getProperty(ClickHouseDefaults.USER.getKey());
-        String password = defaults.getProperty(ClickHouseDefaults.PASSWORD.getKey());
-        String userInfo = uri.getRawUserInfo();
-        if (userInfo != null && !userInfo.isEmpty()) {
-            int index = userInfo.indexOf(':');
-            if (userName == null) {
-                userName = index == 0 ? userName : decode(index > 0 ? userInfo.substring(0, index) : userInfo);
-            }
-            if (password == null) {
-                password = index < 0 ? password : decode(userInfo.substring(index + 1));
-            }
-        }
-        if (userName == null || userName.isEmpty()) {
-            userName = (String) ClickHouseDefaults.USER.getEffectiveDefaultValue();
-        }
-        if (password == null) {
-            password = (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue();
-        }
-
-        final String dbKey = ClickHouseDefaults.DATABASE.getKey();
-
-        String path = uri.getPath();
-        String database;
-        if (path == null || path.isEmpty() || path.equals("/")) {
-            database = defaults.getProperty(dbKey);
-        } else if (path.charAt(0) == '/') {
-            database = defaults.getProperty(dbKey, path.substring(1));
-        } else {
-            throw new IllegalArgumentException("wrong database name path: '" + path + "'");
-        }
-        if (database == null || database.isEmpty()) {
-            database = (String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue();
-        }
-
-        defaults.setProperty(dbKey, database);
-
-        return ClickHouseNode.builder().host(host).port(protocol, port).database(database)
-                .credentials(ClickHouseCredentials.fromUserAndPassword(userName, password)).build();
-    }
-
-    private static Properties parseParams(String query, Properties props) {
-        if (query == null || query.isEmpty()) {
-            return props;
-        }
-
-        String[] queryKeyValues = query.split("&");
-        for (String keyValue : queryKeyValues) {
-            int index = keyValue.indexOf('=');
-            if (index <= 0) {
-                log.warn("don't know how to handle parameter pair: %s", keyValue);
-                continue;
-            }
-
-            props.put(decode(keyValue.substring(0, index)), decode(keyValue.substring(index + 1)));
-        }
-        return props;
-    }
-
-    static String removeCredentialsFromQuery(String query) {
-        if (query == null || query.isEmpty()) {
-            return null;
-        }
-
-        StringBuilder builder = new StringBuilder(query.length());
-        int start = 0;
-        int index = 0;
-        do {
-            index = query.indexOf('&', start);
-            String kv = query.substring(start, index < 0 ? query.length() : index);
-            start += kv.length() + 1;
-            int i = kv.indexOf('=');
-            if (i > 0) {
-                String key = kv.substring(0, i);
-                if (!ClickHouseDefaults.USER.getKey().equals(key)
-                        && !ClickHouseDefaults.PASSWORD.getKey().equals(key)) {
-                    builder.append(kv).append('&');
-                }
-            }
-        } while (index >= 0);
-
-        if (builder.length() > 0) {
-            builder.setLength(builder.length() - 1);
-            query = builder.toString();
-        } else {
-            query = null;
-        }
-
-        return query;
-    }
 
     static Properties newProperties() {
         Properties props = new Properties();
@@ -214,12 +100,11 @@ public class ClickHouseJdbcUrlParser {
         }
 
         try {
-            URI uri = new URI(jdbcUrl);
+            ClickHouseNodes nodes = ClickHouseNodes.of(jdbcUrl, defaults);
             Properties props = newProperties();
-            props.putAll(defaults);
-            parseParams(uri.getQuery(), props);
-            return new ConnectionInfo(uri, parseNode(uri, props), props);
-        } catch (URISyntaxException | IllegalArgumentException e) {
+            props.putAll(nodes.getTemplate().getOptions());
+            return new ConnectionInfo(nodes, props);
+        } catch (IllegalArgumentException e) {
             throw SqlExceptionUtils.clientError(e);
         }
     }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -384,7 +384,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
         ensureOpen();
 
         if (this.maxRows != max) {
-            if (max == 0L) {
+            if (max == 0L || !connection.allowCustomSetting()) {
                 request.removeSetting("max_result_rows");
                 request.removeSetting("result_overflow_mode");
             } else {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -60,6 +60,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
     private int fetchSize;
     private int maxFieldSize;
     private long maxRows;
+    private int nullAsDefault;
     private boolean poolable;
     private volatile String queryId;
     private int queryTimeout;
@@ -249,6 +250,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
         this.fetchSize = connection.getJdbcConfig().getFetchSize();
         this.maxFieldSize = 0;
         this.maxRows = 0L;
+        this.nullAsDefault = connection.getJdbcConfig().getNullAsDefault();
         this.poolable = false;
         this.queryId = null;
 
@@ -722,6 +724,16 @@ public class ClickHouseStatementImpl extends JdbcWrapper
     @Override
     public ClickHouseConfig getConfig() {
         return request.getConfig();
+    }
+
+    @Override
+    public int getNullAsDefault() {
+        return nullAsDefault;
+    }
+
+    @Override
+    public void setNullAsDefault(int level) {
+        this.nullAsDefault = level;
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
@@ -38,7 +38,7 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
     private final ZoneId timeZoneForDate;
     private final ZoneId timeZoneForTs;
 
-    private final List<ClickHouseColumn> columns;
+    private final ClickHouseColumn[] columns;
     private final ClickHouseValue[] values;
     private final boolean[] flags;
 
@@ -59,12 +59,14 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
         timeZoneForTs = config.getUseTimeZone().toZoneId();
         timeZoneForDate = config.isUseServerTimeZoneForDates() ? timeZoneForTs : null;
 
-        this.columns = columns;
         int size = columns.size();
+        this.columns = new ClickHouseColumn[size];
+        this.values = new ClickHouseValue[size];
         int i = 0;
-        values = new ClickHouseValue[size];
         for (ClickHouseColumn col : columns) {
-            values[i++] = ClickHouseValues.newValue(config, col);
+            this.columns[i] = col;
+            this.values[i] = ClickHouseValues.newValue(config, col);
+            i++;
         }
         flags = new boolean[size];
 
@@ -305,12 +307,23 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
         ensureOpen();
 
         ClickHouseConfig config = getConfig();
+        int nullAsDefault = getNullAsDefault();
         for (int i = 0, len = values.length; i < len; i++) {
             if (!flags[i]) {
                 throw SqlExceptionUtils.clientError(ClickHouseUtils.format("Missing value for parameter #%d", i + 1));
             }
+            ClickHouseColumn col = columns[i];
+            ClickHouseValue val = values[i];
+            if (!col.isNestedType() && !col.isNullable() && (val == null || val.isNullOrEmpty())) {
+                if (nullAsDefault > 1 && val != null) {
+                    val.resetToDefault();
+                } else if (nullAsDefault < 1) {
+                    throw SqlExceptionUtils.clientError(ClickHouseUtils.format(
+                            "Cannot set null to non-nullable column #%d [%s]", i + 1, col));
+                }
+            }
             try {
-                serializer.serialize(values[i], config, columns.get(i), stream);
+                serializer.serialize(val, config, col, stream);
             } catch (IOException e) {
                 // should not happen
                 throw SqlExceptionUtils.handle(e);

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -1154,8 +1154,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
         try (ClickHouseConnection conn = newConnection(props); Statement s = conn.createStatement()) {
             if (conn.getUri().toString().contains(":grpc:")) {
                 throw new SkipException("Skip gRPC test");
-            } else if (!conn.getServerVersion().check("[21.8,)")) {
-                throw new SkipException("Skip test when ClickHouse is older than 21.8");
+            } else if (!conn.getServerVersion().check("[22.3,)")) {
+                throw new SkipException("Skip test when ClickHouse is older than 22.3");
             }
             s.execute(String.format("drop table if exists %s; ", tableName)
                     + String.format("create table %s(id Int8, v %s)engine=Memory", tableName, columnType));

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
@@ -16,31 +16,15 @@ import org.testng.annotations.Test;
 
 public class ClickHouseJdbcUrlParserTest {
     @Test(groups = "unit")
-    public void testRemoveCredentialsFromQuery() {
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery(null), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery(""), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery(" "), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery("&"), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery(" & "), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery("a=1&b=2"), "a=1&b=2");
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery("user=a"), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery("password=a%20b"), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery("user=default&password=a%20b"), null);
-        Assert.assertEquals(ClickHouseJdbcUrlParser.removeCredentialsFromQuery("user=default&a=1&password=a%20b"),
-                "a=1");
-    }
-
-    @Test(groups = "unit")
     public void testParseInvalidUri() {
         Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse(null, null));
         Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse("", null));
         Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse("some_invalid_uri", null));
         Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse("jdbc:clickhouse:.", null));
-        Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://", null));
+        Assert.assertThrows(SQLException.class,
+                () -> ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://", null));
         Assert.assertThrows(SQLException.class,
                 () -> ClickHouseJdbcUrlParser.parse("jdbc:clickhouse:///db", null));
-        Assert.assertThrows(SQLException.class,
-                () -> ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://server/ ", null));
         Assert.assertThrows(SQLException.class,
                 () -> ClickHouseJdbcUrlParser.parse("clickhouse://a:b:c@aaa", null));
         Assert.assertThrows(SQLException.class,
@@ -50,104 +34,105 @@ public class ClickHouseJdbcUrlParserTest {
     @Test(groups = "unit")
     public void testParseIpv6() throws SQLException, URISyntaxException {
         ConnectionInfo info = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://[::1]:1234", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://[::1]:1234/default"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://[::1]:1234"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("[::1]").port(ClickHouseProtocol.HTTP, 1234)
-                        .database((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue())
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
+                ClickHouseNode.builder().host("[::1]").port(ClickHouseProtocol.HTTP, 1234).build());
+
+        info = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://[::1]/", null);
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://[::1]:8123"));
+        Assert.assertEquals(info.getServer(),
+                ClickHouseNode.builder().host("[::1]").port(ClickHouseProtocol.HTTP).build());
+
+        info = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://[::1]/dbdb", null);
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://[::1]:8123/dbdb"));
+        Assert.assertEquals(info.getServer(),
+                ClickHouseNode.builder().host("[::1]").port(ClickHouseProtocol.HTTP).database("dbdb")
                         .build());
     }
 
     @Test(groups = "unit")
     public void testParseAbbrevation() throws SQLException, URISyntaxException {
         ConnectionInfo info = ClickHouseJdbcUrlParser.parse("jdbc:ch://localhost", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://localhost:8123/default"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://localhost:8123"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP)
-                        .database((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue())
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
-                        .build());
+                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP).build());
 
         info = ClickHouseJdbcUrlParser.parse("jdbc:ch:grpc://localhost", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:grpc://localhost:9100/default"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:grpc://localhost:9100"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.GRPC)
-                        .database((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue())
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
-                        .build());
+                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.GRPC).build());
 
         info = ClickHouseJdbcUrlParser.parse("jdbc:ch:https://:letmein@[::1]:3218/db1?user=aaa", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://[::1]:3218/db1"));
-        Assert.assertEquals(info.getServer(), ClickHouseNode.builder().host("[::1]").port(ClickHouseProtocol.HTTP, 3218)
-                .database("db1").credentials(ClickHouseCredentials.fromUserAndPassword("aaa", "letmein")).build());
-        Assert.assertEquals(info.getProperties().getProperty("user"), "aaa");
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://[::1]:3218/db1?ssl=true&sslmode=NONE"));
+        Assert.assertEquals(info.getServer(), ClickHouseNode.builder().host("[::1]")
+                .port(ClickHouseProtocol.HTTP, 3218)
+                .database("db1")
+                .credentials(ClickHouseCredentials.fromUserAndPassword("aaa", "letmein"))
+                .addOption("ssl", "true").addOption("sslmode", "NONE").build());
+        Assert.assertEquals(info.getServer().getCredentials().orElse(null),
+                ClickHouseCredentials.fromUserAndPassword("aaa", "letmein"));
     }
 
     @Test(groups = "unit")
     public void testParse() throws SQLException, URISyntaxException {
         ConnectionInfo info = ClickHouseJdbcUrlParser.parse("jdbc:ch://localhost", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://localhost:8123/default"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://localhost:8123"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP)
-                        .database((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue())
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
-                        .build());
+                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP).build());
 
-        info = ClickHouseJdbcUrlParser.parse("jdbc:ch:grpc://localhost", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:grpc://localhost:9100/default"));
+        info = ClickHouseJdbcUrlParser.parse("jdbc:ch:grpc://localhost/default", null);
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:grpc://localhost:9100/default"));
         Assert.assertEquals(info.getServer(),
                 ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.GRPC)
-                        .database((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue())
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
+                        .database((String) ClickHouseDefaults.DATABASE
+                                .getEffectiveDefaultValue())
                         .build());
 
         info = ClickHouseJdbcUrlParser.parse("jdbc:ch:https://:letmein@127.0.0.1:3218/db1", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://127.0.0.1:3218/db1"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://127.0.0.1:3218/db1?ssl=true&sslmode=NONE"));
         Assert.assertEquals(info.getServer(), ClickHouseNode.builder().host("127.0.0.1")
                 .port(ClickHouseProtocol.HTTP, 3218).database("db1")
                 .credentials(ClickHouseCredentials
-                        .fromUserAndPassword((String) ClickHouseDefaults.USER.getEffectiveDefaultValue(), "letmein"))
+                        .fromUserAndPassword((String) ClickHouseDefaults.USER
+                                .getEffectiveDefaultValue(), "letmein"))
+                .addOption("ssl", "true").addOption("sslmode", "NONE")
                 .build());
     }
 
     @Test(groups = "unit")
     public void testParseWithProperties() throws SQLException, URISyntaxException {
         ConnectionInfo info = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://localhost/", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://localhost:8123/default"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://localhost:8123"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP)
-                        .database((String) ClickHouseDefaults.DATABASE.getEffectiveDefaultValue())
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
-                        .build());
+                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP).build());
 
         info = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://localhost:4321/ndb", null);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://localhost:4321/ndb"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://localhost:4321/ndb"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP, 4321).database("ndb")
-                        .credentials(ClickHouseCredentials.fromUserAndPassword(
-                                (String) ClickHouseDefaults.USER.getEffectiveDefaultValue(),
-                                (String) ClickHouseDefaults.PASSWORD.getEffectiveDefaultValue()))
-                        .build());
+                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP, 4321)
+                        .database("ndb").build());
 
         Properties props = new Properties();
         props.setProperty("database", "db1");
         info = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://me@localhost:1234/mydb?password=123", props);
-        Assert.assertEquals(info.getUri(), new URI("jdbc:clickhouse:http://localhost:1234/db1"));
+        Assert.assertEquals(info.getServer().toUri(ClickHouseJdbcUrlParser.JDBC_CLICKHOUSE_PREFIX),
+                new URI("jdbc:clickhouse:http://localhost:1234/db1"));
         Assert.assertEquals(info.getServer(),
-                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP, 1234).database("db1")
-                        .credentials(ClickHouseCredentials.fromUserAndPassword("me", "123")).build());
+                ClickHouseNode.builder().host("localhost").port(ClickHouseProtocol.HTTP, 1234)
+                        .database("db1")
+                        .credentials(ClickHouseCredentials.fromUserAndPassword("me", "123"))
+                        .build());
         Assert.assertEquals(info.getProperties().getProperty("database"), "db1");
     }
 
@@ -156,10 +141,13 @@ public class ClickHouseJdbcUrlParserTest {
         Properties props = new Properties();
         props.setProperty("user", "default1");
         props.setProperty("password", "password1");
-        ClickHouseNode server = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://user:a:passwd@foo.ch/test", props)
-                .getServer();
-        Assert.assertEquals(server.getCredentials().get().getUserName(), "default1");
-        Assert.assertEquals(server.getCredentials().get().getPassword(), "password1");
+        ConnectionInfo connInfo = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://user:a:passwd@foo.ch/test",
+                props);
+        ClickHouseNode server = connInfo.getServer();
+        Assert.assertEquals(connInfo.getDefaultCredentials().getUserName(), "default1");
+        Assert.assertEquals(connInfo.getDefaultCredentials().getPassword(), "password1");
+        Assert.assertEquals(server.getCredentials().get().getUserName(), "user");
+        Assert.assertEquals(server.getCredentials().get().getPassword(), "a:passwd");
 
         server = ClickHouseJdbcUrlParser.parse("jdbc:clickhouse://let%40me%3Ain:let%40me%3Ain@foo.ch", null)
                 .getServer();


### PR DESCRIPTION
Implements basic load-balancing and failover mentioned in #894. Key changes:
* the ability to connect to URI
* optional health-check and node-discovery(using `system.clusters` table)
* load-balancing policies: custom, firstAlive, random and roundRobin (server weight, shard num/weight, and replica are currently not considered)
* failover for connect errors(including connect timed out)

Configuration:

| Option | Description | Default Value | Remark |
| ------ | ------------ | ------------- | -------- |
| auto_discovery | Whether to enable node discovery | false | |
| node_discovery_interval | Node discovery interval in milliseconds, 0 for one-time discovery | 0 | |
| node_discovery_limit | Maximum number of nodes can be discovered at a time | 100 | |
| load_balancing_policy | Load balancing policy | '' | use 'firstAlive', 'random', 'roundRobin', or full qualified class name implementing ClickHouseLoadBlanacingPolicy |
| load_balancing_tags | Load balancing tags for filtering nodes | '' | |
| health_check_method | Health check method | SELECT_ONE | or PING which might be faster but may not work with middleware like chproxy |
| health_check_interval | Health check interval in milliseconds, 0 for one-time health check | 0 | |
| check_all_nodes | Whether all nodes should be checked or just faulty nodes | false | |
| node_check_interval | Minimum interval in milliseconds required for checking node status | 0 | |
| node_group_size | Maximum number of nodes can be used in operation at a time | 50 | |
| failover | Maximum times failover allowed | 0 | |
| retry | Maximum times retry allowed | 0 | |

Performance:

![image](https://user-images.githubusercontent.com/4270380/174685181-928e9146-4c3b-4886-86e5-34bc1abda52d.png)


Usage:
* Java client
  ```java
  try (ClickHouseClient client = ClickHouseClient.newInstance(ClickHouseProtocol.HTTP);
          ClickHouseResponse response = client.connect(
                  "http://(grpc://myoffice/mydb),localhost,{https://explorer@play.clickhouse.com:443}/system?failover=2")
                  .query("select 1").executeAndWait()) {
      Assert.assertEquals(response.firstRecord().getValue(0).asInteger(), 1);
  }
  ```
* JDBC driver
  ```java
  try (Connection conn = DriverManager.getConnection(
          "jdbc:ch://127.0.0.1:8128,(tcp://myhome?docker_cli_path=/usr/local/bin/docker),grpc://myhome/my/test/dbx1?decompress=0&failover=2", "default", "")) {
      try (Statement stmt = conn.createStatement();
          ResultSet rs = stmt.executeQuery("select 1")) {
          Assert.assertTrue(rs.next());
          Assert.assertEquals(rs.getInt(1), 1);
      }
  }
  ```
