### PR TITLE
Fix deserialization issue in performance mode

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -180,8 +180,8 @@ public interface ClickHouseClient extends AutoCloseable {
                     .createPipedOutputStream(config, null);
             wrappedInput = getResponseInputStream(config, decompressedStream.getInputStream(), postCloseAction);
             submit(() -> {
-                try (ClickHouseInputStream in = ClickHouseInputStream.of(input, config.getReadBufferSize());
-                        ClickHouseOutputStream out = decompressedStream) {
+                try (ClickHouseInputStream in = ClickHouseInputStream.of(input, config.getReadBufferSize(),
+                        config.getResponseCompressAlgorithm(), null); ClickHouseOutputStream out = decompressedStream) {
                     in.pipe(out);
                 }
                 return null;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/AbstractByteArrayInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/AbstractByteArrayInputStream.java
@@ -264,9 +264,10 @@ public abstract class AbstractByteArrayInputStream extends ClickHouseInputStream
 
         // peforms better but this is a bit tricky
         if (n == Long.MAX_VALUE) {
+            int avail = 0;
             long counter = (long) limit - position;
-            while (updateBuffer() > 0) {
-                counter += limit;
+            while ((avail = updateBuffer()) > 0) {
+                counter += avail;
             }
 
             return counter;


### PR DESCRIPTION
Deserialization will fail when `response_buffering` is set to `PERFORMANCE` and `compress` is `true`. Regression case has been enhanced to ensure it won't happen again. 