### PR TITLE
Stop throwing exception when executing empty batch

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/SqlExceptionUtils.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/SqlExceptionUtils.java
@@ -107,10 +107,6 @@ public final class SqlExceptionUtils {
         return new BatchUpdateException("Unexpected error", SQL_STATE_SQL_ERROR, 0, updateCounts, cause);
     }
 
-    public static SQLException emptyBatchError() {
-        return clientError("Please call addBatch method at least once before batch execution");
-    }
-
     public static BatchUpdateException queryInBatchError(int[] updateCounts) {
         return new BatchUpdateException("Query is not allow in batch update", SQL_STATE_CLIENT_ERROR, updateCounts);
     }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
@@ -220,7 +220,7 @@ public class ClickHouseConnectionImpl extends JdbcWrapper implements ClickHouseC
         autoCommit = !jdbcConf.isJdbcCompliant() || jdbcConf.isAutoCommit();
 
         ClickHouseNode node = connInfo.getServer();
-        log.debug("Connecting to node: %s", node);
+        log.debug("Connecting to: %s", node);
 
         jvmTimeZone = TimeZone.getDefault();
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -25,6 +25,7 @@ import com.clickhouse.client.ClickHouseResponseSummary;
 import com.clickhouse.client.ClickHouseSerializer;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
+import com.clickhouse.client.ClickHouseValues;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseConfigChangeListener;
 import com.clickhouse.client.config.ClickHouseOption;
@@ -588,7 +589,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
     public long[] executeLargeBatch() throws SQLException {
         ensureOpen();
         if (batchStmts.isEmpty()) {
-            throw SqlExceptionUtils.emptyBatchError();
+            return ClickHouseValues.EMPTY_LONG_ARRAY;
         }
 
         boolean continueOnError = getConnection().getJdbcConfig().isContinueBatchOnError();

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
@@ -94,7 +94,7 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
         boolean continueOnError = false;
         if (asBatch) {
             if (counter < 1) {
-                throw SqlExceptionUtils.emptyBatchError();
+                return ClickHouseValues.EMPTY_LONG_ARRAY;
             }
             continueOnError = getConnection().getJdbcConfig().isContinueBatchOnError();
         } else {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
@@ -122,7 +122,7 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
         boolean continueOnError = false;
         if (asBatch) {
             if (counter < 1) {
-                throw SqlExceptionUtils.emptyBatchError();
+                return ClickHouseValues.EMPTY_LONG_ARRAY;
             }
             continueOnError = getConnection().getJdbcConfig().isContinueBatchOnError();
         } else {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
@@ -19,6 +19,7 @@ import java.util.Set;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.ClickHouseUtils;
+import com.clickhouse.client.ClickHouseValues;
 import com.clickhouse.client.data.ClickHouseExternalTable;
 import com.clickhouse.client.logging.Logger;
 import com.clickhouse.client.logging.LoggerFactory;
@@ -75,7 +76,7 @@ public class TableBasedPreparedStatement extends AbstractPreparedStatement imple
         boolean continueOnError = false;
         if (asBatch) {
             if (batch.isEmpty()) {
-                throw SqlExceptionUtils.emptyBatchError();
+                return ClickHouseValues.EMPTY_LONG_ARRAY;
             }
             continueOnError = getConnection().getJdbcConfig().isContinueBatchOnError();
         } else {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -778,15 +778,22 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     public void testBatchQuery() throws SQLException {
         try (ClickHouseConnection conn = newConnection(new Properties());
                 PreparedStatement stmt = conn.prepareStatement("select * from numbers(100) where number < ?")) {
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
             Assert.assertThrows(SQLException.class, () -> stmt.setInt(0, 5));
             Assert.assertThrows(SQLException.class, () -> stmt.setInt(2, 5));
             Assert.assertThrows(SQLException.class, () -> stmt.addBatch());
 
             stmt.setInt(1, 3);
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
             stmt.addBatch();
             stmt.setInt(1, 2);
             stmt.addBatch();
             Assert.assertThrows(BatchUpdateException.class, () -> stmt.executeBatch());
+
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
         }
     }
 

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -136,6 +136,9 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
     public void testMutation() throws SQLException {
         Properties props = new Properties();
         try (ClickHouseConnection conn = newConnection(props); ClickHouseStatement stmt = conn.createStatement()) {
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
+
             Assert.assertFalse(stmt.execute("drop table if exists test_mutation;"
                     + "create table test_mutation(a String, b UInt32) engine=MergeTree() order by tuple()"),
                     "Should not return result set");
@@ -156,6 +159,9 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             stmt.addBatch("drop table non_existing_table");
             stmt.addBatch("insert into test_mutation values('2',2)");
             Assert.assertThrows(SQLException.class, () -> stmt.executeBatch());
+
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
         }
 
         props.setProperty(JdbcConfig.PROP_CONTINUE_BATCH, "true");
@@ -269,7 +275,12 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
     public void testExecuteBatch() throws SQLException {
         Properties props = new Properties();
         try (Connection conn = newConnection(props); Statement stmt = conn.createStatement()) {
-            Assert.assertThrows(SQLException.class, () -> stmt.executeBatch());
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
+            stmt.addBatch("select 1");
+            stmt.clearBatch();
+            Assert.assertEquals(stmt.executeBatch(), new int[0]);
+            Assert.assertEquals(stmt.executeLargeBatch(), new long[0]);
             stmt.addBatch("select 1");
             // mixed usage
             Assert.assertThrows(SQLException.class, () -> stmt.execute("select 2"));


### PR DESCRIPTION
Fix #977 