### PR TITLE
Fix wrong setting usage for creating output stream

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataStreamFactory.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataStreamFactory.java
@@ -152,7 +152,7 @@ public class ClickHouseDataStreamFactory {
         final CapacityPolicy policy;
         final int timeout;
 
-        if (config.getResponseBuffering() == ClickHouseBufferingMode.PERFORMANCE) {
+        if (config.getRequestBuffering() == ClickHouseBufferingMode.PERFORMANCE) {
             blocking = false;
             queue = 0;
             policy = null;


### PR DESCRIPTION
Value PERFORMANCE of settings "request_buffering" is ignored during output stream creation