### PR TITLE
Add custom_settings option and tidy up code

### DIFF
--- a/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
+++ b/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
@@ -87,6 +87,12 @@ public class ClickHouseCommandLineClientTest extends ClientIntegrationTest {
 
     @Test(groups = { "integration" })
     @Override
+    public void testSession() {
+        throw new SkipException("Skip due to session is not supported");
+    }
+
+    @Test(groups = { "integration" })
+    @Override
     public void testSessionLock() {
         throw new SkipException("Skip due to session is not supported");
     }

--- a/clickhouse-client/pom.xml
+++ b/clickhouse-client/pom.xml
@@ -86,6 +86,11 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <excludes>
+                        <exclude>META-INF/services</exclude>
+                    </excludes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCluster.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCluster.java
@@ -56,7 +56,7 @@ public class ClickHouseCluster extends ClickHouseNodes {
             if (n == null) {
                 continue;
             }
-            autoDiscovery = autoDiscovery || (boolean) n.config.getOption(ClickHouseClientOption.AUTO_DISCOVERY);
+            autoDiscovery = autoDiscovery || n.config.getBoolOption(ClickHouseClientOption.AUTO_DISCOVERY);
             String name = n.getCluster();
             if (!ClickHouseChecker.isNullOrEmpty(name)) {
                 if (ClickHouseChecker.isNullOrEmpty(clusterName)) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCompression.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCompression.java
@@ -1,5 +1,7 @@
 package com.clickhouse.client;
 
+import java.util.Locale;
+
 /**
  * Supported compression algoritms.
  */
@@ -90,7 +92,7 @@ public enum ClickHouseCompression {
 
         int index = 0;
         if (file != null && (index = file.lastIndexOf('.')) > 0) {
-            String ext = file.substring(index + 1).toLowerCase();
+            String ext = file.substring(index + 1).toLowerCase(Locale.ROOT);
             for (ClickHouseCompression c : values()) {
                 if (c.fileExt.equals(ext)) {
                     compression = c;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
@@ -52,6 +52,8 @@ public class ClickHouseConfig implements Serializable {
 
     private static final long serialVersionUID = 7794222888859182491L;
 
+    static final String PARAM_OPTION = "option";
+
     protected static final Map<ClickHouseOption, Serializable> mergeOptions(List<ClickHouseConfig> list) {
         if (list == null || list.isEmpty()) {
             return Collections.emptyMap();
@@ -162,6 +164,7 @@ public class ClickHouseConfig implements Serializable {
     // common options optimized for read
     private final boolean async;
     private final boolean autoDiscovery;
+    private final Map<String, String> customSettings; // serializable
     private final String clientName;
     private final boolean compressRequest;
     private final ClickHouseCompression compressAlgorithm;
@@ -253,68 +256,69 @@ public class ClickHouseConfig implements Serializable {
         }
 
         this.async = (boolean) getOption(ClickHouseClientOption.ASYNC, ClickHouseDefaults.ASYNC);
-        this.autoDiscovery = (boolean) getOption(ClickHouseClientOption.AUTO_DISCOVERY);
-        this.clientName = (String) getOption(ClickHouseClientOption.CLIENT_NAME);
-        this.compressRequest = (boolean) getOption(ClickHouseClientOption.DECOMPRESS);
-        this.compressAlgorithm = (ClickHouseCompression) getOption(ClickHouseClientOption.DECOMPRESS_ALGORITHM);
-        this.compressLevel = (int) getOption(ClickHouseClientOption.DECOMPRESS_LEVEL);
-        this.decompressResponse = (boolean) getOption(ClickHouseClientOption.COMPRESS);
-        this.decompressAlgorithm = (ClickHouseCompression) getOption(ClickHouseClientOption.COMPRESS_ALGORITHM);
-        this.decompressLevel = (int) getOption(ClickHouseClientOption.COMPRESS_LEVEL);
-        this.connectionTimeout = (int) getOption(ClickHouseClientOption.CONNECTION_TIMEOUT);
+        this.autoDiscovery = getBoolOption(ClickHouseClientOption.AUTO_DISCOVERY);
+        this.customSettings = ClickHouseOption.toKeyValuePairs(getStrOption(ClickHouseClientOption.CUSTOM_SETTINGS));
+        this.clientName = getStrOption(ClickHouseClientOption.CLIENT_NAME);
+        this.compressRequest = getBoolOption(ClickHouseClientOption.DECOMPRESS);
+        this.compressAlgorithm = getOption(ClickHouseClientOption.DECOMPRESS_ALGORITHM, ClickHouseCompression.class);
+        this.compressLevel = getIntOption(ClickHouseClientOption.DECOMPRESS_LEVEL);
+        this.decompressResponse = getBoolOption(ClickHouseClientOption.COMPRESS);
+        this.decompressAlgorithm = getOption(ClickHouseClientOption.COMPRESS_ALGORITHM, ClickHouseCompression.class);
+        this.decompressLevel = getIntOption(ClickHouseClientOption.COMPRESS_LEVEL);
+        this.connectionTimeout = getIntOption(ClickHouseClientOption.CONNECTION_TIMEOUT);
         this.database = (String) getOption(ClickHouseClientOption.DATABASE, ClickHouseDefaults.DATABASE);
         this.format = (ClickHouseFormat) getOption(ClickHouseClientOption.FORMAT, ClickHouseDefaults.FORMAT);
-        this.maxBufferSize = ClickHouseUtils.getBufferSize((int) getOption(ClickHouseClientOption.MAX_BUFFER_SIZE), -1,
+        this.maxBufferSize = ClickHouseUtils.getBufferSize(getIntOption(ClickHouseClientOption.MAX_BUFFER_SIZE), -1,
                 -1);
-        this.bufferSize = (int) getOption(ClickHouseClientOption.BUFFER_SIZE);
-        this.bufferQueueVariation = (int) getOption(ClickHouseClientOption.BUFFER_QUEUE_VARIATION);
-        this.readBufferSize = (int) getOption(ClickHouseClientOption.READ_BUFFER_SIZE);
-        this.writeBufferSize = (int) getOption(ClickHouseClientOption.WRITE_BUFFER_SIZE);
-        this.requestChunkSize = (int) getOption(ClickHouseClientOption.REQUEST_CHUNK_SIZE);
+        this.bufferSize = getIntOption(ClickHouseClientOption.BUFFER_SIZE);
+        this.bufferQueueVariation = getIntOption(ClickHouseClientOption.BUFFER_QUEUE_VARIATION);
+        this.readBufferSize = getIntOption(ClickHouseClientOption.READ_BUFFER_SIZE);
+        this.writeBufferSize = getIntOption(ClickHouseClientOption.WRITE_BUFFER_SIZE);
+        this.requestChunkSize = getIntOption(ClickHouseClientOption.REQUEST_CHUNK_SIZE);
         this.requestBuffering = (ClickHouseBufferingMode) getOption(ClickHouseClientOption.REQUEST_BUFFERING,
                 ClickHouseDefaults.BUFFERING);
         this.responseBuffering = (ClickHouseBufferingMode) getOption(ClickHouseClientOption.RESPONSE_BUFFERING,
                 ClickHouseDefaults.BUFFERING);
-        this.maxExecutionTime = (int) getOption(ClickHouseClientOption.MAX_EXECUTION_TIME);
-        this.maxQueuedBuffers = (int) getOption(ClickHouseClientOption.MAX_QUEUED_BUFFERS);
-        this.maxQueuedRequests = (int) getOption(ClickHouseClientOption.MAX_QUEUED_REQUESTS);
-        this.maxResultRows = (long) getOption(ClickHouseClientOption.MAX_RESULT_ROWS);
-        this.maxThreads = (int) getOption(ClickHouseClientOption.MAX_THREADS_PER_CLIENT);
-        this.nodeCheckInterval = (int) getOption(ClickHouseClientOption.NODE_CHECK_INTERVAL);
-        this.failover = (int) getOption(ClickHouseClientOption.FAILOVER);
-        this.retry = (int) getOption(ClickHouseClientOption.RETRY);
-        this.repeatOnSessionLock = (boolean) getOption(ClickHouseClientOption.REPEAT_ON_SESSION_LOCK);
-        this.reuseValueWrapper = (boolean) getOption(ClickHouseClientOption.REUSE_VALUE_WRAPPER);
-        this.serverInfo = !ClickHouseChecker.isNullOrBlank((String) getOption(ClickHouseClientOption.SERVER_TIME_ZONE))
-                && !ClickHouseChecker.isNullOrBlank((String) getOption(ClickHouseClientOption.SERVER_VERSION));
+        this.maxExecutionTime = getIntOption(ClickHouseClientOption.MAX_EXECUTION_TIME);
+        this.maxQueuedBuffers = getIntOption(ClickHouseClientOption.MAX_QUEUED_BUFFERS);
+        this.maxQueuedRequests = getIntOption(ClickHouseClientOption.MAX_QUEUED_REQUESTS);
+        this.maxResultRows = getLongOption(ClickHouseClientOption.MAX_RESULT_ROWS);
+        this.maxThreads = getIntOption(ClickHouseClientOption.MAX_THREADS_PER_CLIENT);
+        this.nodeCheckInterval = getIntOption(ClickHouseClientOption.NODE_CHECK_INTERVAL);
+        this.failover = getIntOption(ClickHouseClientOption.FAILOVER);
+        this.retry = getIntOption(ClickHouseClientOption.RETRY);
+        this.repeatOnSessionLock = getBoolOption(ClickHouseClientOption.REPEAT_ON_SESSION_LOCK);
+        this.reuseValueWrapper = getBoolOption(ClickHouseClientOption.REUSE_VALUE_WRAPPER);
+        this.serverInfo = !ClickHouseChecker.isNullOrBlank(getStrOption(ClickHouseClientOption.SERVER_TIME_ZONE))
+                && !ClickHouseChecker.isNullOrBlank(getStrOption(ClickHouseClientOption.SERVER_VERSION));
         this.serverTimeZone = TimeZone.getTimeZone(
                 (String) getOption(ClickHouseClientOption.SERVER_TIME_ZONE, ClickHouseDefaults.SERVER_TIME_ZONE));
         this.serverVersion = ClickHouseVersion
                 .of((String) getOption(ClickHouseClientOption.SERVER_VERSION, ClickHouseDefaults.SERVER_VERSION));
-        this.sessionTimeout = (int) getOption(ClickHouseClientOption.SESSION_TIMEOUT);
-        this.sessionCheck = (boolean) getOption(ClickHouseClientOption.SESSION_CHECK);
-        this.socketTimeout = (int) getOption(ClickHouseClientOption.SOCKET_TIMEOUT);
-        this.ssl = (boolean) getOption(ClickHouseClientOption.SSL);
-        this.sslMode = (ClickHouseSslMode) getOption(ClickHouseClientOption.SSL_MODE);
-        this.sslRootCert = (String) getOption(ClickHouseClientOption.SSL_ROOT_CERTIFICATE);
-        this.sslCert = (String) getOption(ClickHouseClientOption.SSL_CERTIFICATE);
-        this.sslKey = (String) getOption(ClickHouseClientOption.SSL_KEY);
-        this.transactionTimeout = (int) getOption(ClickHouseClientOption.TRANSACTION_TIMEOUT);
-        this.useBlockingQueue = (boolean) getOption(ClickHouseClientOption.USE_BLOCKING_QUEUE);
-        this.useObjectsInArray = (boolean) getOption(ClickHouseClientOption.USE_OBJECTS_IN_ARRAYS);
-        this.useNoProxy = (boolean) getOption(ClickHouseClientOption.USE_NO_PROXY);
-        this.useServerTimeZone = (boolean) getOption(ClickHouseClientOption.USE_SERVER_TIME_ZONE);
-        this.useServerTimeZoneForDates = (boolean) getOption(ClickHouseClientOption.USE_SERVER_TIME_ZONE_FOR_DATES);
+        this.sessionTimeout = getIntOption(ClickHouseClientOption.SESSION_TIMEOUT);
+        this.sessionCheck = getBoolOption(ClickHouseClientOption.SESSION_CHECK);
+        this.socketTimeout = getIntOption(ClickHouseClientOption.SOCKET_TIMEOUT);
+        this.ssl = getBoolOption(ClickHouseClientOption.SSL);
+        this.sslMode = getOption(ClickHouseClientOption.SSL_MODE, ClickHouseSslMode.class);
+        this.sslRootCert = getStrOption(ClickHouseClientOption.SSL_ROOT_CERTIFICATE);
+        this.sslCert = getStrOption(ClickHouseClientOption.SSL_CERTIFICATE);
+        this.sslKey = getStrOption(ClickHouseClientOption.SSL_KEY);
+        this.transactionTimeout = getIntOption(ClickHouseClientOption.TRANSACTION_TIMEOUT);
+        this.useBlockingQueue = getBoolOption(ClickHouseClientOption.USE_BLOCKING_QUEUE);
+        this.useObjectsInArray = getBoolOption(ClickHouseClientOption.USE_OBJECTS_IN_ARRAYS);
+        this.useNoProxy = getBoolOption(ClickHouseClientOption.USE_NO_PROXY);
+        this.useServerTimeZone = getBoolOption(ClickHouseClientOption.USE_SERVER_TIME_ZONE);
+        this.useServerTimeZoneForDates = getBoolOption(ClickHouseClientOption.USE_SERVER_TIME_ZONE_FOR_DATES);
 
-        String timeZone = (String) getOption(ClickHouseClientOption.USE_TIME_ZONE);
+        String timeZone = getStrOption(ClickHouseClientOption.USE_TIME_ZONE);
         TimeZone tz = ClickHouseChecker.isNullOrBlank(timeZone) ? TimeZone.getDefault()
                 : TimeZone.getTimeZone(timeZone);
         this.useTimeZone = this.useServerTimeZone ? this.serverTimeZone : tz;
         this.timeZoneForDate = this.useServerTimeZoneForDates ? this.useTimeZone : null;
 
         if (credentials == null) {
-            this.credentials = ClickHouseCredentials.fromUserAndPassword((String) getOption(ClickHouseDefaults.USER),
-                    (String) getOption(ClickHouseDefaults.PASSWORD));
+            this.credentials = ClickHouseCredentials.fromUserAndPassword(getStrOption(ClickHouseDefaults.USER),
+                    getStrOption(ClickHouseDefaults.PASSWORD));
         } else {
             this.credentials = credentials;
         }
@@ -328,6 +332,10 @@ public class ClickHouseConfig implements Serializable {
 
     public boolean isAutoDiscovery() {
         return autoDiscovery;
+    }
+
+    public Map<String, String> getCustomSettings() {
+        return customSettings;
     }
 
     public String getClientName() {
@@ -719,18 +727,99 @@ public class ClickHouseConfig implements Serializable {
         return Collections.unmodifiableMap(this.options);
     }
 
+    /**
+     * Gets typed option value. {@link ClickHouseOption#getEffectiveDefaultValue}
+     * will be called when the option is undefined.
+     *
+     * @param <T>       type of option value, must be serializable
+     * @param option    non-null option to lookup
+     * @param valueType non-null type of option value, must be serializable
+     * @return typed value
+     */
+    @SuppressWarnings("unchecked")
+    public <T extends Serializable> T getOption(ClickHouseOption option, Class<T> valueType) {
+        if (ClickHouseChecker.nonNull(option, PARAM_OPTION).getValueType() != ClickHouseChecker.nonNull(valueType,
+                "valueType")) {
+            throw new IllegalArgumentException(
+                    "Cannot convert value from type " + option.getValueType() + " to " + valueType);
+        }
+
+        T value = (T) options.get(option);
+        return value != null ? value : (T) option.getEffectiveDefaultValue();
+    }
+
+    /**
+     * Gets option value.
+     *
+     * @param option        non-null option to lookup
+     * @param defaultConfig optional default config to retrieve default value
+     * @return option value
+     */
+    public Serializable getOption(ClickHouseOption option, ClickHouseConfig defaultConfig) {
+        return this.options.getOrDefault(ClickHouseChecker.nonNull(option, PARAM_OPTION),
+                defaultConfig == null ? option.getEffectiveDefaultValue() : defaultConfig.getOption(option));
+    }
+
+    /**
+     * Gets option value.
+     *
+     * @param option       non-null option to lookup
+     * @param defaultValue optional default value
+     * @return option value
+     */
+    public Serializable getOption(ClickHouseOption option, ClickHouseDefaults defaultValue) {
+        return this.options.getOrDefault(ClickHouseChecker.nonNull(option, PARAM_OPTION),
+                defaultValue == null ? option.getEffectiveDefaultValue() : defaultValue.getEffectiveDefaultValue());
+    }
+
+    /**
+     * Shortcut of {@link #getOption(ClickHouseOption, ClickHouseDefaults)}.
+     *
+     * @param option non-null option to lookup
+     * @return option value
+     */
     public Serializable getOption(ClickHouseOption option) {
         return getOption(option, (ClickHouseDefaults) null);
     }
 
-    public Serializable getOption(ClickHouseOption option, ClickHouseConfig defaultConfig) {
-        return this.options.getOrDefault(ClickHouseChecker.nonNull(option, "option"),
-                defaultConfig == null ? option.getEffectiveDefaultValue() : defaultConfig.getOption(option));
+    /**
+     * Shortcut of {@code getOption(option, Boolean.class)}.
+     *
+     * @param option non-null option to lookup
+     * @return boolean value of the given option
+     */
+    public boolean getBoolOption(ClickHouseOption option) {
+        return getOption(option, Boolean.class);
     }
 
-    public Serializable getOption(ClickHouseOption option, ClickHouseDefaults defaultValue) {
-        return this.options.getOrDefault(ClickHouseChecker.nonNull(option, "option"),
-                defaultValue == null ? option.getEffectiveDefaultValue() : defaultValue.getEffectiveDefaultValue());
+    /**
+     * Shortcut of {@code getOption(option, Integer.class)}.
+     *
+     * @param option non-null option to lookup
+     * @return int value of the given option
+     */
+    public int getIntOption(ClickHouseOption option) {
+        return getOption(option, Integer.class);
+    }
+
+    /**
+     * Shortcut of {@code getOption(option, Long.class)}.
+     *
+     * @param option non-null option to lookup
+     * @return long value of the given option
+     */
+    public long getLongOption(ClickHouseOption option) {
+        return getOption(option, Long.class);
+    }
+
+    /**
+     * Shortcut of {@code getOption(option, String.class)}.
+     *
+     * @param option non-null option to lookup
+     * @return String value of the given option
+     */
+    public String getStrOption(ClickHouseOption option) {
+        return getOption(option, String.class);
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataProcessor.java
@@ -2,6 +2,7 @@ package com.clickhouse.client;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -279,7 +280,7 @@ public abstract class ClickHouseDataProcessor {
      * @throws IOException when failed to read columns from input stream
      */
     protected ClickHouseDataProcessor(ClickHouseConfig config, ClickHouseInputStream input,
-            ClickHouseOutputStream output, List<ClickHouseColumn> columns, Map<String, Object> settings)
+            ClickHouseOutputStream output, List<ClickHouseColumn> columns, Map<String, Serializable> settings)
             throws IOException {
         this.config = ClickHouseChecker.nonNull(config, "config");
         if (input == null && output == null) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataStreamFactory.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataStreamFactory.java
@@ -1,6 +1,7 @@
 package com.clickhouse.client;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +50,7 @@ public class ClickHouseDataStreamFactory {
      * @throws IOException when failed to read columns from input stream
      */
     public ClickHouseDataProcessor getProcessor(ClickHouseConfig config, ClickHouseInputStream input,
-            ClickHouseOutputStream output, Map<String, Object> settings, List<ClickHouseColumn> columns)
+            ClickHouseOutputStream output, Map<String, Serializable> settings, List<ClickHouseColumn> columns)
             throws IOException {
         ClickHouseFormat format = ClickHouseChecker.nonNull(config, "config").getFormat();
         ClickHouseDataProcessor processor = null;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseFormat.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseFormat.java
@@ -1,5 +1,7 @@
 package com.clickhouse.client;
 
+import java.util.Locale;
+
 /**
  * All formats supported by ClickHouse. More information at:
  * https://clickhouse.com/docs/en/interfaces/formats/.
@@ -98,7 +100,7 @@ public enum ClickHouseFormat {
 
         int index = 0;
         if (file != null && (index = file.lastIndexOf('.')) > 0) {
-            String ext = file.substring(index + 1).toLowerCase();
+            String ext = file.substring(index + 1).toLowerCase(Locale.ROOT);
             switch (ext) {
                 case "arrow":
                     format = Arrow;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
@@ -561,7 +561,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
         if (index < 0) {
             normalized = new StringBuilder()
                     .append((defaultProtocol != null ? defaultProtocol : ClickHouseProtocol.ANY).name()
-                            .toLowerCase())
+                            .toLowerCase(Locale.ROOT))
                     .append(SCHEME_DELIMITER)
                     .append(uri.trim()).toString();
         } else {
@@ -965,7 +965,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
         this.config = new ClickHouseConfig(ClickHouseConfig.toClientOptions(options), credentials, null, null);
         this.manager = new AtomicReference<>(null);
 
-        StringBuilder builder = new StringBuilder().append(protocol.name().toLowerCase());
+        StringBuilder builder = new StringBuilder().append(protocol.name().toLowerCase(Locale.ROOT));
         if (config.isSsl()) {
             builder.append('s');
         }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
@@ -368,12 +368,12 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
         this.healthCheckFuture = new AtomicReference<>(null);
 
         this.template = template;
-        this.groupSize = (int) template.config.getOption(ClickHouseClientOption.NODE_GROUP_SIZE);
+        this.groupSize = template.config.getIntOption(ClickHouseClientOption.NODE_GROUP_SIZE);
 
         Set<String> tags = new LinkedHashSet<>();
-        ClickHouseNode.parseTags((String) template.config.getOption(ClickHouseClientOption.LOAD_BALANCING_TAGS), tags);
+        ClickHouseNode.parseTags(template.config.getStrOption(ClickHouseClientOption.LOAD_BALANCING_TAGS), tags);
         this.policy = ClickHouseLoadBalancingPolicy
-                .of((String) template.config.getOption(ClickHouseClientOption.LOAD_BALANCING_POLICY));
+                .of(template.config.getStrOption(ClickHouseClientOption.LOAD_BALANCING_POLICY));
         this.selector = tags.isEmpty() ? ClickHouseNodeSelector.EMPTY : ClickHouseNodeSelector.of(null, tags);
         boolean autoDiscovery = false;
         for (ClickHouseNode n : nodes) {
@@ -383,12 +383,12 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
         if (autoDiscovery) {
             this.singleNode = false;
             this.discoveryFuture.getAndUpdate(current -> policy.schedule(current, ClickHouseNodes.this::discover,
-                    (int) template.config.getOption(ClickHouseClientOption.NODE_DISCOVERY_INTERVAL)));
+                    template.config.getIntOption(ClickHouseClientOption.NODE_DISCOVERY_INTERVAL)));
         } else {
             this.singleNode = nodes.size() == 1;
         }
         this.healthCheckFuture.getAndUpdate(current -> policy.schedule(current, ClickHouseNodes.this::check,
-                (int) template.config.getOption(ClickHouseClientOption.HEALTH_CHECK_INTERVAL)));
+                template.config.getIntOption(ClickHouseClientOption.HEALTH_CHECK_INTERVAL)));
     }
 
     protected void queryClusterNodes(Collection<ClickHouseNode> seeds, Collection<ClickHouseNode> allNodes,
@@ -461,7 +461,7 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
                 }
 
                 String query = policy.getQueryForNonLocalNodes();
-                int limit = (int) template.config.getOption(ClickHouseClientOption.NODE_DISCOVERY_LIMIT);
+                int limit = template.config.getIntOption(ClickHouseClientOption.NODE_DISCOVERY_LIMIT);
                 if (limit > 0) {
                     query = query + " limit " + limit;
                 }
@@ -551,7 +551,7 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
 
         Set<ClickHouseNode> list = new LinkedHashSet<>();
         long currentTime = System.currentTimeMillis();
-        boolean checkAll = (boolean) template.config.getOption(ClickHouseClientOption.CHECK_ALL_NODES);
+        boolean checkAll = template.config.getBoolOption(ClickHouseClientOption.CHECK_ALL_NODES);
         int healthyNodeStartIndex = -1;
         lock.readLock().lock();
         // TODO:

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseProtocol.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseProtocol.java
@@ -13,6 +13,10 @@ public enum ClickHouseProtocol {
      */
     ANY(0, "anys"),
     /**
+     * Local/File interface.
+     */
+    LOCAL(0, "local", "file"),
+    /**
      * HTTP/HTTPS interface.
      */
     HTTP(8123, 8443, "http", "https"),

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransaction.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransaction.java
@@ -166,6 +166,7 @@ public final class ClickHouseTransaction implements Serializable {
      * @param server   non-null server of the transaction
      * @param timeout  transaction timeout
      * @param implicit whether it's an implicit transaction or not
+     * @throws ClickHouseException when failed to start transaction
      */
     protected ClickHouseTransaction(ClickHouseNode server, int timeout, boolean implicit) throws ClickHouseException {
         this.server = server;
@@ -286,7 +287,7 @@ public final class ClickHouseTransaction implements Serializable {
             switch (e.getErrorCode()) {
                 case ClickHouseException.ERROR_SESSION_NOT_FOUND:
                     throw new ClickHouseTransactionException(
-                            "Invalid transaction due to session not found or timeed out", e.getCause(), this);
+                            "Invalid transaction due to session not found or timed out", e.getCause(), this);
                 case ClickHouseTransactionException.ERROR_INVALID_TRANSACTION:
                 case ClickHouseTransactionException.ERROR_UNKNOWN_STATUS_OF_TRANSACTION:
                     throw new ClickHouseTransactionException(e.getErrorCode(), e.getMessage(), e.getCause(), this);

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseUtils.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseUtils.java
@@ -42,7 +42,7 @@ public final class ClickHouseUtils {
     private static final String HOME_DIR;
 
     static {
-        HOME_DIR = System.getProperty("os.name").toLowerCase().contains("windows")
+        HOME_DIR = System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows")
                 ? Paths.get(System.getenv("APPDATA"), "clickhouse").toFile().getAbsolutePath()
                 : Paths.get(System.getProperty("user.home"), ".clickhouse").toFile().getAbsolutePath();
     }
@@ -725,7 +725,11 @@ public final class ClickHouseUtils {
      * 
      * @param str string
      * @return non-null map containing extracted key value pairs
+     * @deprecated will be removed in v0.3.3, please use
+     *             {@link com.clickhouse.client.config.ClickHouseOption#toKeyValuePairs(String)}
+     *             instead
      */
+    @Deprecated
     public static Map<String, String> getKeyValuePairs(String str) {
         if (str == null || str.isEmpty()) {
             return Collections.emptyMap();

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
@@ -1118,6 +1118,8 @@ public final class ClickHouseValues {
             case IPv6:
                 value = ClickHouseIpv6Value.ofNull();
                 break;
+            case Object:
+            case JSON:
             case FixedString:
             case String:
                 value = ClickHouseStringValue.ofNull();
@@ -1195,8 +1197,6 @@ public final class ClickHouseValues {
                 }
                 value = ClickHouseNestedValue.ofEmpty(column.getNestedColumns());
                 break;
-            case Object:
-            case JSON:
             case Tuple:
                 value = ClickHouseTupleValue.of();
                 break;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseVersion.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseVersion.java
@@ -115,7 +115,7 @@ public final class ClickHouseVersion implements Comparable<ClickHouseVersion>, S
                 }
             }
         } else {
-            version = version.trim().toLowerCase();
+            version = version.trim().toLowerCase(Locale.ROOT);
 
             int index = Math.max(version.lastIndexOf(' '), version.lastIndexOf(':'));
             latest = STR_LATEST.equals(index == -1 ? version : version.substring(index + 1));

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -26,6 +26,10 @@ public enum ClickHouseClientOption implements ClickHouseOption {
     AUTO_DISCOVERY("auto_discovery", false,
             "Whether the client should discover more nodes from system tables and/or clickhouse-keeper/zookeeper."),
     /**
+     * Custom server settings for all queries.
+     */
+    CUSTOM_SETTINGS("custom_settings", "", "Custom server settings for all queries."),
+    /**
      * Load balancing policy.
      */
     LOAD_BALANCING_POLICY("load_balancing_policy", "",

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStreamResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStreamResponse.java
@@ -1,6 +1,7 @@
 package com.clickhouse.client.data;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,7 +34,7 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
     }
 
     public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Object> settings) throws IOException {
+            Map<String, Serializable> settings) throws IOException {
         return of(config, input, settings, null, null);
     }
 
@@ -43,12 +44,12 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
     }
 
     public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Object> settings, List<ClickHouseColumn> columns) throws IOException {
+            Map<String, Serializable> settings, List<ClickHouseColumn> columns) throws IOException {
         return of(config, input, settings, columns, null);
     }
 
     public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Object> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)
+            Map<String, Serializable> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)
             throws IOException {
         return new ClickHouseStreamResponse(config, input, settings, columns, summary);
     }
@@ -62,7 +63,7 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
     private boolean closed;
 
     protected ClickHouseStreamResponse(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Object> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)
+            Map<String, Serializable> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)
             throws IOException {
         if (config == null || input == null) {
             throw new IllegalArgumentException("Non-null configuration and input stream are required");

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTabSeparatedProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTabSeparatedProcessor.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.data;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.Serializable;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -296,8 +297,8 @@ public class ClickHouseTabSeparatedProcessor extends ClickHouseDataProcessor {
             types = toStringArray(typesFragment, getTextHandler().colDelimiter);
         }
 
-        ClickHouseRenameMethod m = (ClickHouseRenameMethod) config
-                .getOption(ClickHouseClientOption.RENAME_RESPONSE_COLUMN);
+        ClickHouseRenameMethod m = config.getOption(ClickHouseClientOption.RENAME_RESPONSE_COLUMN,
+                ClickHouseRenameMethod.class);
         List<ClickHouseColumn> list = new ArrayList<>(cols.length);
         for (int i = 0; i < cols.length; i++) {
             list.add(ClickHouseColumn.of(m.rename(cols[i]), types == null ? "Nullable(String)" : types[i]));
@@ -307,7 +308,7 @@ public class ClickHouseTabSeparatedProcessor extends ClickHouseDataProcessor {
     }
 
     public ClickHouseTabSeparatedProcessor(ClickHouseConfig config, ClickHouseInputStream input,
-            ClickHouseOutputStream output, List<ClickHouseColumn> columns, Map<String, Object> settings)
+            ClickHouseOutputStream output, List<ClickHouseColumn> columns, Map<String, Serializable> settings)
             throws IOException {
         super(config, input, output, columns, settings);
     }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
@@ -13,7 +13,8 @@ public class ClickHouseConfigTest {
     @Test(groups = { "unit" })
     public void testDefaultValues() {
         ClickHouseConfig config = new ClickHouseConfig(null, null, null, null, null);
-        Assert.assertEquals(config.getClientName(), ClickHouseClientOption.CLIENT_NAME.getEffectiveDefaultValue());
+        Assert.assertEquals(config.getClientName(),
+                ClickHouseClientOption.CLIENT_NAME.getEffectiveDefaultValue());
         Assert.assertEquals(config.getDatabase(), ClickHouseDefaults.DATABASE.getEffectiveDefaultValue());
 
         Assert.assertEquals(config.getOption(ClickHouseDefaults.CLUSTER),
@@ -42,6 +43,9 @@ public class ClickHouseConfigTest {
         Integer weight = -99;
         String user = "sa";
         String password = "welcome";
+        Map<String, String> settings = new HashMap<>();
+        settings.put("session_check", "1");
+        settings.put("max_execution_time", "300");
 
         Map<ClickHouseOption, Serializable> options = new HashMap<>();
         options.put(ClickHouseClientOption.CLIENT_NAME, clientName);
@@ -52,6 +56,7 @@ public class ClickHouseConfigTest {
         options.put(ClickHouseDefaults.WEIGHT, weight);
         options.put(ClickHouseDefaults.USER, "useless");
         options.put(ClickHouseDefaults.PASSWORD, "useless");
+        options.put(ClickHouseClientOption.CUSTOM_SETTINGS, "session_check = 1, max_execution_time = 300");
 
         Object metricRegistry = new Object();
 
@@ -63,6 +68,7 @@ public class ClickHouseConfigTest {
         Assert.assertEquals(config.getOption(ClickHouseDefaults.HOST), host);
         Assert.assertEquals(config.getOption(ClickHouseDefaults.PORT), port);
         Assert.assertEquals(config.getOption(ClickHouseDefaults.WEIGHT), weight);
+        Assert.assertEquals(config.getCustomSettings(), settings);
 
         ClickHouseCredentials credentials = config.getDefaultCredentials();
         Assert.assertEquals(credentials.useAccessToken(), false);

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
@@ -78,7 +78,7 @@ public abstract class ClickHouseGrpcChannelFactory {
     }
 
     public static ClickHouseGrpcChannelFactory getFactory(ClickHouseConfig config, ClickHouseNode server) {
-        return ((boolean) config.getOption(ClickHouseGrpcOption.USE_OKHTTP))
+        return (config.getBoolOption(ClickHouseGrpcOption.USE_OKHTTP))
                 ? new OkHttpChannelFactoryImpl(config, server)
                 : new NettyChannelFactoryImpl(config, server);
     }
@@ -176,7 +176,7 @@ public abstract class ClickHouseGrpcChannelFactory {
 
     protected void setupMisc() {
         ManagedChannelBuilder<?> builder = getChannelBuilder();
-        if ((boolean) config.getOption(ClickHouseGrpcOption.USE_FULL_STREAM_DECOMPRESSION)) {
+        if (config.getBoolOption(ClickHouseGrpcOption.USE_FULL_STREAM_DECOMPRESSION)) {
             builder.enableFullStreamDecompression();
         }
 
@@ -184,8 +184,8 @@ public abstract class ClickHouseGrpcChannelFactory {
             builder.proxyDetector(NoProxyDetector.INSTANCE);
         }
         // TODO add interceptor to customize retry
-        builder.maxInboundMessageSize((int) config.getOption(ClickHouseGrpcOption.MAX_INBOUND_MESSAGE_SIZE))
-                .maxInboundMetadataSize((int) config.getOption(ClickHouseGrpcOption.MAX_INBOUND_METADATA_SIZE));
+        builder.maxInboundMessageSize(config.getIntOption(ClickHouseGrpcOption.MAX_INBOUND_MESSAGE_SIZE))
+                .maxInboundMetadataSize(config.getIntOption(ClickHouseGrpcOption.MAX_INBOUND_METADATA_SIZE));
     }
 
     public ManagedChannel create() {

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
@@ -1,6 +1,7 @@
 package com.clickhouse.client.grpc;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.net.SocketTimeoutException;
 import java.util.Collection;
 import java.util.Collections;
@@ -80,7 +81,7 @@ public class ClickHouseGrpcClient extends AbstractClient<ManagedChannel> {
         builder.setOutputCompressionType(outputCompression.encoding());
 
         // builder.setNextQueryInfo(true);
-        for (Entry<String, Object> s : request.getSettings().entrySet()) {
+        for (Entry<String, Serializable> s : request.getSettings().entrySet()) {
             builder.putSettings(s.getKey(), String.valueOf(s.getValue()));
         }
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcResponse.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcResponse.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.grpc;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.util.Map;
 
@@ -50,7 +51,7 @@ public class ClickHouseGrpcResponse extends ClickHouseStreamResponse {
         return in;
     }
 
-    protected ClickHouseGrpcResponse(ClickHouseConfig config, Map<String, Object> settings,
+    protected ClickHouseGrpcResponse(ClickHouseConfig config, Map<String, Serializable> settings,
             ClickHouseStreamObserver observer) throws IOException {
         super(config, observer.getInputStream(), settings, null, observer.getSummary());
 
@@ -58,7 +59,7 @@ public class ClickHouseGrpcResponse extends ClickHouseStreamResponse {
         this.result = null;
     }
 
-    protected ClickHouseGrpcResponse(ClickHouseConfig config, Map<String, Object> settings, Result result)
+    protected ClickHouseGrpcResponse(ClickHouseConfig config, Map<String, Serializable> settings, Result result)
             throws IOException {
         super(config,
                 result.getOutput().isEmpty()

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/NettyChannelFactoryImpl.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/NettyChannelFactoryImpl.java
@@ -26,7 +26,7 @@ final class NettyChannelFactoryImpl extends ClickHouseGrpcChannelFactory {
 
         builder = NettyChannelBuilder.forAddress(server.getHost(), server.getPort());
 
-        int flowControlWindow = (int) config.getOption(ClickHouseGrpcOption.FLOW_CONTROL_WINDOW);
+        int flowControlWindow = config.getIntOption(ClickHouseGrpcOption.FLOW_CONTROL_WINDOW);
         if (flowControlWindow > 0) {
             builder.flowControlWindow(flowControlWindow); // what about initialFlowControlWindow?
         }

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/OkHttpChannelFactoryImpl.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/OkHttpChannelFactoryImpl.java
@@ -17,7 +17,7 @@ final class OkHttpChannelFactoryImpl extends ClickHouseGrpcChannelFactory {
 
         builder = OkHttpChannelBuilder.forAddress(server.getHost(), server.getPort());
 
-        int flowControlWindow = (int) config.getOption(ClickHouseGrpcOption.FLOW_CONTROL_WINDOW);
+        int flowControlWindow = config.getIntOption(ClickHouseGrpcOption.FLOW_CONTROL_WINDOW);
         if (flowControlWindow > 0) {
             builder.flowControlWindow(flowControlWindow);
         }

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/ClickHouseHttpConnectionFactory.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/ClickHouseHttpConnectionFactory.java
@@ -11,8 +11,8 @@ import com.clickhouse.client.http.config.HttpConnectionProvider;
 public abstract class ClickHouseHttpConnectionFactory {
     public static ClickHouseHttpConnection createConnection(ClickHouseNode server, ClickHouseRequest<?> request,
             ExecutorService executor) throws IOException {
-        HttpConnectionProvider provider = (HttpConnectionProvider) request.getConfig()
-                .getOption(ClickHouseHttpOption.CONNECTION_PROVIDER);
+        HttpConnectionProvider provider = request.getConfig().getOption(ClickHouseHttpOption.CONNECTION_PROVIDER,
+                HttpConnectionProvider.class);
 
         try {
             return provider == null || provider == HttpConnectionProvider.HTTP_URL_CONNECTION

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -324,7 +324,7 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
 
     @Override
     public boolean ping(int timeout) {
-        String response = (String) config.getOption(ClickHouseHttpOption.DEFAULT_RESPONSE);
+        String response = config.getStrOption(ClickHouseHttpOption.DEFAULT_RESPONSE);
         try {
             HttpResponse<String> r = httpClient.send(pingRequest, HttpResponse.BodyHandlers.ofString());
             return r.statusCode() == HttpURLConnection.HTTP_OK && response.equals(r.body());

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -444,7 +444,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
                 log.info("Killed query [%s]: %s", qid, summaries.get(0));
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                log.warn("Interrupted for killing query [%s]", qid);
+                log.warn("Cancellation of query [%s] was interrupted", qid);
             } catch (TimeoutException e) {
                 log.warn("Timed out after waiting %d ms for killing query [%s]",
                         request.getConfig().getConnectionTimeout(), qid);


### PR DESCRIPTION
* BREAKING CHANGE: type of settings changed from `Map<String, Object>` to `Map<String, Serializable>`
* Add Local/File protocol and enhance clickhouse-cli-client accordingly
* Add convenient methods in ClickHouseOption to avoid unnecessary type conversions
* Add `custom_settings` option
* Better support of sepcial settings: `query_id`, `session_id`, `session_check` and `session_timeout` in ClickHouseRequest
