### PR TITLE
Respect custom format for mutation

### DIFF
--- a/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
+++ b/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
@@ -2,11 +2,14 @@ package com.clickhouse.client.cli;
 
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseClientBuilder;
+import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseServerForTest;
 import com.clickhouse.client.ClientIntegrationTest;
 import com.clickhouse.client.cli.config.ClickHouseCommandLineOption;
+
+import java.io.IOException;
 
 import org.testcontainers.containers.GenericContainer;
 import org.testng.Assert;
@@ -49,19 +52,19 @@ public class ClickHouseCommandLineClientTest extends ClientIntegrationTest {
 
     @Test(groups = { "integration" })
     @Override
-    public void testCustomLoad() throws Exception {
+    public void testCustomLoad() throws ClickHouseException {
         throw new SkipException("Skip due to time out error");
     }
 
     @Test(groups = { "integration" })
     @Override
-    public void testLoadRawData() throws Exception {
+    public void testLoadRawData() throws ClickHouseException, IOException {
         throw new SkipException("Skip due to response summary is always empty");
     }
 
     @Test(groups = { "integration" })
     @Override
-    public void testMultipleQueries() throws Exception {
+    public void testMultipleQueries() throws ClickHouseException {
         // FIXME not sure if the occasional "Stream closed" exception is related to
         // zeroturnaround/zt-exec#30 or not
         /*

--- a/clickhouse-client/pom.xml
+++ b/clickhouse-client/pom.xml
@@ -88,7 +88,7 @@
                 </executions>
                 <configuration>
                     <excludes>
-                        <exclude>META-INF/services</exclude>
+                        <exclude>META-INF/services/*</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
@@ -65,6 +65,11 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         protected Mutation(ClickHouseRequest<?> request, boolean sealed) {
             super(request.getClient(), request.server, request.serverRef, request.options, sealed);
 
+            // use headless format if possible
+            if (!sealed) {
+                format(request.getFormat().defaultInputFormat());
+            }
+
             this.settings.putAll(request.settings);
             this.txRef.set(request.txRef.get());
 
@@ -117,8 +122,7 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
                 }
 
                 return builder.length() > 0 && index == len ? sql
-                        : new StringBuilder().append(sql).append("\n FORMAT ").append(getInputFormat().name())
-                                .toString();
+                        : new StringBuilder().append(sql).append("\n FORMAT ").append(getFormat().name()).toString();
             }
 
             return super.getQuery();
@@ -237,6 +241,11 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
             this.input = changeProperty(PROP_DATA, this.input, input);
 
             return this;
+        }
+
+        @Override
+        public ClickHouseFormat getInputFormat() {
+            return getFormat();
         }
 
         @Override
@@ -646,7 +655,10 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
      * Gets data format used for input(e.g. writing data into server).
      *
      * @return data format for input
+     * @deprecated will be removed in v0.3.3, please use
+     *             {@code getFormat().defaultInputFormat()} instead
      */
+    @Deprecated
     public ClickHouseFormat getInputFormat() {
         return getFormat().defaultInputFormat();
     }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClientTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClientTest.java
@@ -4,12 +4,14 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 
 import com.clickhouse.client.ClickHouseRequest.Mutation;
 
 public class ClickHouseClientTest {
     @Test(groups = { "unit" })
-    public void testGetAsyncRequestOutputStream() throws Exception {
+    public void testGetAsyncRequestOutputStream() throws IOException {
         ClickHouseConfig config = new ClickHouseConfig();
         for (int i = 0; i < 256; i++) {
             ByteArrayOutputStream bas = new ByteArrayOutputStream();
@@ -21,7 +23,7 @@ public class ClickHouseClientTest {
     }
 
     @Test(groups = { "unit" })
-    public void testGetRequestOutputStream() throws Exception {
+    public void testGetRequestOutputStream() throws IOException {
         ClickHouseConfig config = new ClickHouseConfig();
         for (int i = 0; i < 256; i++) {
             ByteArrayOutputStream bas = new ByteArrayOutputStream();
@@ -33,7 +35,7 @@ public class ClickHouseClientTest {
     }
 
     @Test(groups = { "unit" })
-    public void testQuery() throws Exception {
+    public void testQuery() throws ExecutionException, InterruptedException {
         ClickHouseClient client = ClickHouseClient.builder().build();
         Assert.assertNotNull(client);
         ClickHouseRequest<?> req = client.connect(ClickHouseNode.builder().build());
@@ -48,7 +50,7 @@ public class ClickHouseClientTest {
     }
 
     @Test(groups = { "unit" })
-    public void testMutation() throws Exception {
+    public void testMutation() throws ExecutionException, InterruptedException {
         ClickHouseClient client = ClickHouseClient.builder().build();
         Assert.assertNotNull(client);
         Mutation req = client.connect(ClickHouseNode.builder().build()).write();

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClusterTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClusterTest.java
@@ -35,7 +35,7 @@ public class ClickHouseClusterTest extends BaseIntegrationTest {
     }
 
     @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
-    public void testGetNode(ClickHouseNodeSelector nodeSelector) throws Exception {
+    public void testGetNode(ClickHouseNodeSelector nodeSelector) throws InterruptedException {
         int size = 5;
         int requests = 500;
         int len = size * requests;

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseColumnTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseColumnTest.java
@@ -141,7 +141,7 @@ public class ClickHouseColumnTest {
     }
 
     @Test(groups = { "unit" })
-    public void testParse() throws Exception {
+    public void testParse() {
         ClickHouseColumn column = ClickHouseColumn.of("arr", "Nullable(Array(Nullable(UInt8))");
         Assert.assertNotNull(column);
 
@@ -156,7 +156,7 @@ public class ClickHouseColumnTest {
     }
 
     @Test(groups = { "unit" })
-    public void testAggregationFunction() throws Exception {
+    public void testAggregationFunction() {
         ClickHouseColumn column = ClickHouseColumn.of("aggFunc", "AggregateFunction(groupBitmap, UInt32)");
         Assert.assertTrue(column.isAggregateFunction());
         Assert.assertEquals(column.getDataType(), ClickHouseDataType.AggregateFunction);
@@ -178,7 +178,7 @@ public class ClickHouseColumnTest {
     }
 
     @Test(groups = { "unit" })
-    public void testArray() throws Exception {
+    public void testArray() {
         ClickHouseColumn column = ClickHouseColumn.of("arr",
                 "Array(Array(Array(Array(Array(Map(LowCardinality(String), Tuple(Array(UInt8),LowCardinality(String))))))))");
         Assert.assertTrue(column.isArray());
@@ -204,7 +204,7 @@ public class ClickHouseColumnTest {
     }
 
     @Test(dataProvider = "enumTypesProvider", groups = { "unit" })
-    public void testEnum(String typeName) throws Exception {
+    public void testEnum(String typeName) {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> ClickHouseColumn.of("e", typeName + "('Query''Start' = a)"));
         Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseColumn.of("e", typeName + "(aa,1)"));
@@ -236,7 +236,7 @@ public class ClickHouseColumnTest {
     }
 
     @Test(groups = { "unit" })
-    public void testSimpleAggregationFunction() throws Exception {
+    public void testSimpleAggregationFunction() {
         ClickHouseColumn c = ClickHouseColumn.of("a", "SimpleAggregateFunction(max, UInt64)");
         Assert.assertEquals(c.getDataType(), ClickHouseDataType.SimpleAggregateFunction);
         Assert.assertEquals(c.getNestedColumns().get(0).getDataType(), ClickHouseDataType.UInt64);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
@@ -34,7 +34,7 @@ public class ClickHouseConfigTest {
     }
 
     @Test(groups = { "unit" })
-    public void testCustomValues() throws Exception {
+    public void testCustomValues() {
         String clientName = "test client";
         String cluster = "test cluster";
         String database = "test_database";

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseDataStreamFactoryTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseDataStreamFactoryTest.java
@@ -1,18 +1,20 @@
 package com.clickhouse.client;
 
+import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class ClickHouseDataStreamFactoryTest {
     @Test(groups = { "unit" })
-    public void testGetInstance() throws Exception {
+    public void testGetInstance() {
         Assert.assertNotNull(ClickHouseDataStreamFactory.getInstance());
     }
 
     @Test(groups = { "unit" })
-    public void testCreatePipedOutputStream() throws Exception {
+    public void testCreatePipedOutputStream() throws ExecutionException, IOException, InterruptedException {
         ClickHouseConfig config = new ClickHouseConfig();
 
         // read in worker thread

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseLoadBalancingPolicyTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseLoadBalancingPolicyTest.java
@@ -71,7 +71,7 @@ public class ClickHouseLoadBalancingPolicyTest {
     }
 
     @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
-    public void testDummy(ClickHouseNodeSelector nodeSelector) throws Exception {
+    public void testDummy(ClickHouseNodeSelector nodeSelector) throws InterruptedException {
         int size = 5;
         int requests = 500;
         int len = size * requests;
@@ -130,7 +130,7 @@ public class ClickHouseLoadBalancingPolicyTest {
     }
 
     @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
-    public void testFirstAlive(ClickHouseNodeSelector nodeSelector) throws Exception {
+    public void testFirstAlive(ClickHouseNodeSelector nodeSelector) throws InterruptedException {
         int size = 5;
         int requests = 500;
         int len = size * requests;
@@ -189,7 +189,7 @@ public class ClickHouseLoadBalancingPolicyTest {
     }
 
     @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
-    public void testFirstAliveWithFailures(ClickHouseNodeSelector nodeSelector) throws Exception {
+    public void testFirstAliveWithFailures(ClickHouseNodeSelector nodeSelector) throws InterruptedException {
         int size = 5;
         int requests = 500;
         int len = size * requests;
@@ -238,7 +238,7 @@ public class ClickHouseLoadBalancingPolicyTest {
     }
 
     @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
-    public void testRoundRobin(ClickHouseNodeSelector nodeSelector) throws Exception {
+    public void testRoundRobin(ClickHouseNodeSelector nodeSelector) throws InterruptedException {
         int size = 5;
         int requests = 500;
         int len = size * requests;
@@ -297,7 +297,7 @@ public class ClickHouseLoadBalancingPolicyTest {
     }
 
     @Test(dataProvider = "nodeSelectorProvider", groups = { "unit" })
-    public void testRandom(ClickHouseNodeSelector nodeSelector) throws Exception {
+    public void testRandom(ClickHouseNodeSelector nodeSelector) throws InterruptedException {
         int size = 5;
         int requests = 500;
         int len = size * requests;

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodeTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodeTest.java
@@ -4,6 +4,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -367,7 +368,7 @@ public class ClickHouseNodeTest extends BaseIntegrationTest {
     }
 
     @Test(groups = { "unit" })
-    public void testQueryWithSlash() throws Exception {
+    public void testQueryWithSlash() throws URISyntaxException {
         ClickHouseNode server = ClickHouseNode.of("http://localhost?a=/b/c/d");
         Assert.assertEquals(server.getDatabase().orElse(null), null);
         Assert.assertEquals(server.getOptions(), Collections.singletonMap("a", "/b/c/d"));

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
@@ -7,8 +7,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import com.clickhouse.client.ClickHouseNode.Status;
 import com.clickhouse.client.config.ClickHouseClientOption;
@@ -185,7 +187,7 @@ public class ClickHouseNodesTest {
     }
 
     @Test(groups = { "unit" })
-    public void testNodeGrouping() throws Exception {
+    public void testNodeGrouping() throws ExecutionException, InterruptedException, TimeoutException {
         ClickHouseNodes nodes = ClickHouseNodes
                 .of("http://(a?node_group_size=1),(tcp://b?x=1)/test?x=2&node_group_size=0");
         Assert.assertTrue(nodes.getPolicy() == ClickHouseLoadBalancingPolicy.DEFAULT,
@@ -213,7 +215,7 @@ public class ClickHouseNodesTest {
     }
 
     @Test(groups = { "unit" })
-    public void testQueryWithSlash() throws Exception {
+    public void testQueryWithSlash() {
         ClickHouseNodes servers = ClickHouseNodes
                 .of("https://node1?a=/b/c/d,node2/db2?/a/b/c=d,node3/db1?a=/d/c.b");
         Assert.assertEquals(servers.nodes.get(0).getDatabase().orElse(null), "db1");

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseValuesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseValuesTest.java
@@ -142,7 +142,7 @@ public class ClickHouseValuesTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testConvertToIpv4() throws Exception {
+    public void testConvertToIpv4() throws UnknownHostException {
         Assert.assertEquals(ClickHouseValues.convertToIpv4((String) null), null);
         Assert.assertEquals(ClickHouseValues.convertToIpv4("127.0.0.1"), Inet4Address.getByName("127.0.0.1"));
         Assert.assertEquals(ClickHouseValues.convertToIpv4("0:0:0:0:0:ffff:7f00:1"),
@@ -150,7 +150,7 @@ public class ClickHouseValuesTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testConvertToIpv6() throws Exception {
+    public void testConvertToIpv6() throws UnknownHostException {
         Assert.assertEquals(ClickHouseValues.convertToIpv6((String) null), null);
         Assert.assertEquals(ClickHouseValues.convertToIpv6("::1"), Inet6Address.getByName("::1"));
         Assert.assertEquals(ClickHouseValues.convertToIpv6("127.0.0.1").getClass(), Inet6Address.class);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/cache/CaffeineCacheTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/cache/CaffeineCacheTest.java
@@ -11,7 +11,7 @@ import org.testng.annotations.Test;
 
 public class CaffeineCacheTest {
     @Test(groups = { "unit" })
-    public void testCache() throws Exception {
+    public void testCache() {
         int capacity = 3;
         ClickHouseCache<String, String> cache = CaffeineCache.create(capacity, 1L, (k) -> k);
         Assert.assertNotNull(cache);
@@ -32,7 +32,11 @@ public class CaffeineCacheTest {
         Assert.assertEquals(c.asMap().size(), 3);
         Assert.assertEquals(c.asMap(), m);
 
-        Thread.sleep(1500L);
+        try {
+            Thread.sleep(1500L);
+        } catch (InterruptedException e) {
+            Assert.fail("Sleep was interrupted", e);
+        }
         c.cleanUp();
 
         Assert.assertEquals(cache.get("D"), "D");

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseBoolValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseBoolValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -17,7 +18,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseBoolValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testUpdate() throws Exception {
+    public void testUpdate() {
         ClickHouseBoolValue v = ClickHouseBoolValue.of(0);
         Assert.assertEquals(v.getValue(), false);
         Assert.assertEquals(v.update(true).asByte(), (byte) 1);
@@ -87,7 +88,7 @@ public class ClickHouseBoolValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseBoolValue.ofNull());
         checkNull(ClickHouseBoolValue.of(1).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseByteValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseByteValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -17,7 +18,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseByteValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testUpdate() throws Exception {
+    public void testUpdate() {
         ClickHouseByteValue v = ClickHouseByteValue.of(-1);
         Assert.assertEquals(v.getValue(), (byte) -1);
         Assert.assertEquals(v.update(true).asByte(), (byte) 1);
@@ -54,7 +55,7 @@ public class ClickHouseByteValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseByteValue.ofNull());
         checkNull(ClickHouseByteValue.of(Byte.MIN_VALUE).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDateTimeValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDateTimeValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -40,7 +41,7 @@ public class ClickHouseDateTimeValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValueWithoutScale() throws Exception {
+    public void testValueWithoutScale() throws UnknownHostException {
         // null value
         checkNull(ClickHouseDateTimeValue.ofNull(0, ClickHouseValues.UTC_TIMEZONE));
         checkNull(
@@ -164,7 +165,7 @@ public class ClickHouseDateTimeValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValueWithScale() throws Exception {
+    public void testValueWithScale() throws UnknownHostException {
         // null value
         checkNull(ClickHouseDateTimeValue.ofNull(3, ClickHouseValues.UTC_TIMEZONE));
         checkNull(

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDateValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDateValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -15,7 +16,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseDateValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseDateValue.ofNull());
         checkNull(ClickHouseDateValue.of(LocalDate.now()).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseDoubleValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -18,7 +19,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseDoubleValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseDoubleValue.ofNull());
         checkNull(ClickHouseDoubleValue.of(Double.MAX_VALUE).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseFloatValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseFloatValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -17,7 +18,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseFloatValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseFloatValue.ofNull());
         checkNull(ClickHouseFloatValue.of(Float.MAX_VALUE).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseIntegerValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseIntegerValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -16,7 +17,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseIntegerValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseIntegerValue.ofNull());
         checkNull(ClickHouseIntegerValue.of(Integer.MAX_VALUE).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseLongValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseLongValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -18,7 +19,7 @@ import com.clickhouse.client.ClickHouseValues;
 
 public class ClickHouseLongValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testSignedValue() throws Exception {
+    public void testSignedValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseLongValue.ofNull(false));
         checkNull(ClickHouseLongValue.of(Long.MAX_VALUE, false).resetToNullOrEmpty());
@@ -159,7 +160,7 @@ public class ClickHouseLongValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testUnsignedValue() throws Exception {
+    public void testUnsignedValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseLongValue.ofNull(true));
         checkNull(ClickHouseLongValue.of(Long.MAX_VALUE, true).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseNestedValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseNestedValueTest.java
@@ -8,7 +8,7 @@ import com.clickhouse.client.ClickHouseColumn;
 
 public class ClickHouseNestedValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testMultipleValues() throws Exception {
+    public void testMultipleValues() {
         // single type
         checkValue(
                 ClickHouseNestedValue.of(ClickHouseColumn.parse("a String not null, b String null"),
@@ -96,7 +96,7 @@ public class ClickHouseNestedValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testSingleValue() throws Exception {
+    public void testSingleValue() {
         // null value
         checkNull(ClickHouseNestedValue.ofEmpty(ClickHouseColumn.parse("a Nullable(String)")), false, 3, 9);
         checkNull(ClickHouseNestedValue.ofEmpty(ClickHouseColumn.parse("a String not null")), false, 3, 9);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -42,7 +43,7 @@ public class ClickHouseOffsetDateTimeValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValueWithoutScale() throws Exception {
+    public void testValueWithoutScale() throws UnknownHostException {
         // null value
         checkNull(ClickHouseOffsetDateTimeValue.ofNull(0, null));
         checkNull(ClickHouseOffsetDateTimeValue.of(LocalDateTime.now(), 0, null).resetToNullOrEmpty());
@@ -162,7 +163,7 @@ public class ClickHouseOffsetDateTimeValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValueWithScale() throws Exception {
+    public void testValueWithScale() throws UnknownHostException {
         // null value
         checkNull(ClickHouseOffsetDateTimeValue.ofNull(3, null));
         checkNull(ClickHouseOffsetDateTimeValue.of(LocalDateTime.now(), 9, null).resetToNullOrEmpty());
@@ -207,7 +208,7 @@ public class ClickHouseOffsetDateTimeValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValueWithTimeZone() throws Exception {
+    public void testValueWithTimeZone() {
         LocalDateTime dateTime = LocalDateTime.of(2020, 2, 11, 0, 23, 33);
         TimeZone tz = null;
         ClickHouseOffsetDateTimeValue v = ClickHouseOffsetDateTimeValue.of(dateTime, 0, tz);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHousePipedStreamTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHousePipedStreamTest.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 public class ClickHousePipedStreamTest {
     @Test(groups = { "unit" })
-    public void testRead() throws Exception {
+    public void testRead() throws InterruptedException, IOException {
         ClickHousePipedStream stream = new ClickHousePipedStream(4, 3, 1);
         Assert.assertEquals(stream.queue.size(), 0);
         try (InputStream in = stream.getInput()) {
@@ -80,7 +80,7 @@ public class ClickHousePipedStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testReadBytes() throws Exception {
+    public void testReadBytes() throws InterruptedException, IOException {
         ClickHousePipedStream stream = new ClickHousePipedStream(4, 3, 1);
         Assert.assertEquals(stream.queue.size(), 0);
         byte[] bytes = new byte[3];
@@ -144,7 +144,7 @@ public class ClickHousePipedStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testWrite() throws Exception {
+    public void testWrite() throws InterruptedException, IOException {
         ClickHousePipedStream stream = new ClickHousePipedStream(2, 3, 2);
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
@@ -184,7 +184,7 @@ public class ClickHousePipedStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testWriteBytes() throws Exception {
+    public void testWriteBytes() throws InterruptedException, IOException {
         ClickHousePipedStream stream = new ClickHousePipedStream(2, 3, 2);
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
@@ -210,7 +210,7 @@ public class ClickHousePipedStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testPipedStream() throws Exception {
+    public void testPipedStream() throws InterruptedException, IOException {
         final int timeout = 10000;
         ExecutorService executor = Executors.newFixedThreadPool(2);
         for (int bufferSize = -1; bufferSize < 10; bufferSize++) {

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseShortValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseShortValueTest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -16,7 +17,7 @@ import com.clickhouse.client.ClickHouseDataType;
 
 public class ClickHouseShortValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseShortValue.ofNull());
         checkNull(ClickHouseShortValue.of(Short.MAX_VALUE).resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseStringValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseStringValueTest.java
@@ -3,6 +3,7 @@ package com.clickhouse.client.data;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
+import java.net.UnknownHostException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
@@ -78,7 +79,7 @@ public class ClickHouseStringValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testValue() throws Exception {
+    public void testValue() throws UnknownHostException {
         // null value
         checkNull(ClickHouseStringValue.ofNull());
         checkNull(ClickHouseStringValue.of("abc").resetToNullOrEmpty());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseTupleValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseTupleValueTest.java
@@ -6,7 +6,7 @@ import com.clickhouse.client.BaseClickHouseValueTest;
 
 public class ClickHouseTupleValueTest extends BaseClickHouseValueTest {
     @Test(groups = { "unit" })
-    public void testMultipleValues() throws Exception {
+    public void testMultipleValues() {
         // single type
         checkValue(ClickHouseTupleValue.of("one", "two"), UnsupportedOperationException.class, // isInfinity
                 UnsupportedOperationException.class, // isNan
@@ -78,7 +78,7 @@ public class ClickHouseTupleValueTest extends BaseClickHouseValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testSingleValue() throws Exception {
+    public void testSingleValue() {
         // null value
         checkNull(ClickHouseTupleValue.of().resetToNullOrEmpty(), false, 3, 9);
         checkNull(ClickHouseTupleValue.of(ClickHouseByteValue.of(0).asByte()).resetToNullOrEmpty(), false, 3, 9);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/array/ClickHouseByteArrayValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/array/ClickHouseByteArrayValueTest.java
@@ -5,7 +5,7 @@ import org.testng.annotations.Test;
 
 public class ClickHouseByteArrayValueTest {
     @Test(groups = { "unit" })
-    public void testConvertToBoolean() throws Exception {
+    public void testConvertToBoolean() {
         ClickHouseByteArrayValue v = ClickHouseByteArrayValue
                 .of(new byte[] { 0, 1, -1 });
         Assert.assertArrayEquals(v.getValue(), new byte[] { 0, 1, -1 });
@@ -13,7 +13,7 @@ public class ClickHouseByteArrayValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testConvertFromBoolean() throws Exception {
+    public void testConvertFromBoolean() {
         ClickHouseByteArrayValue v = ClickHouseByteArrayValue.ofEmpty();
         Assert.assertArrayEquals(v.getValue(), new byte[0]);
         v.update(new boolean[] { false, true, false });

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/array/ClickHouseLongArrayValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/array/ClickHouseLongArrayValueTest.java
@@ -7,7 +7,7 @@ import org.testng.annotations.Test;
 
 public class ClickHouseLongArrayValueTest {
     @Test(groups = { "unit" })
-    public void testConvertToBigInteger() throws Exception {
+    public void testConvertToBigInteger() {
         ClickHouseLongArrayValue v = ClickHouseLongArrayValue
                 .of(new long[] { 1L, new BigInteger("9223372036854775808").longValue() });
         Assert.assertArrayEquals(v.getValue(), new long[] { 1L, -9223372036854775808L });
@@ -16,7 +16,7 @@ public class ClickHouseLongArrayValueTest {
     }
 
     @Test(groups = { "unit" })
-    public void testConvertFromBigInteger() throws Exception {
+    public void testConvertFromBigInteger() {
         ClickHouseLongArrayValue v = ClickHouseLongArrayValue.ofEmpty();
         Assert.assertArrayEquals(v.getValue(), new long[0]);
         v.update(new BigInteger[] { BigInteger.ONE, new BigInteger("9223372036854775808") });

--- a/clickhouse-client/src/test/java/com/clickhouse/client/naming/SrvResolverTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/naming/SrvResolverTest.java
@@ -16,7 +16,7 @@ public class SrvResolverTest {
     }
 
     @Test(groups = { "integration" })
-    public void testResolv() throws Exception {
+    public void testResolv() {
         String host = "_sip._udp.sip.voice.google.com";
         int port = 5060;
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/stream/NonBlockingPipedOutputStreamTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/stream/NonBlockingPipedOutputStreamTest.java
@@ -18,7 +18,7 @@ import org.testng.annotations.Test;
 
 public class NonBlockingPipedOutputStreamTest {
     @Test(groups = { "unit" })
-    public void testRead() throws Exception {
+    public void testRead() throws IOException {
         NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 3, 1, CapacityPolicy.fixedCapacity(3),
                 null);
         Assert.assertEquals(stream.queue.size(), 0);
@@ -77,7 +77,7 @@ public class NonBlockingPipedOutputStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testReadBytes() throws Exception {
+    public void testReadBytes() throws IOException {
         NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 3, 1, CapacityPolicy.fixedCapacity(3),
                 null);
         Assert.assertEquals(stream.queue.size(), 0);
@@ -140,7 +140,7 @@ public class NonBlockingPipedOutputStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testWrite() throws Exception {
+    public void testWrite() throws IOException {
         NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(2, 3, 2, CapacityPolicy.fixedCapacity(3),
                 null);
         Assert.assertEquals(stream.queue.size(), 0);
@@ -181,7 +181,7 @@ public class NonBlockingPipedOutputStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testWriteBytes() throws Exception {
+    public void testWriteBytes() throws IOException {
         NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(2, 3, 2, CapacityPolicy.fixedCapacity(3),
                 null);
         Assert.assertEquals(stream.queue.size(), 0);
@@ -208,7 +208,7 @@ public class NonBlockingPipedOutputStreamTest {
     }
 
     @Test(groups = { "unit" })
-    public void testPipedStream() throws Exception {
+    public void testPipedStream() throws InterruptedException, IOException {
         final int timeout = 10000;
         ExecutorService executor = Executors.newFixedThreadPool(2);
         for (int bufferSize = -1; bufferSize < 10; bufferSize++) {

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactoryTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactoryTest.java
@@ -11,7 +11,7 @@ import com.clickhouse.client.grpc.config.ClickHouseGrpcOption;
 
 public class ClickHouseGrpcChannelFactoryTest extends BaseIntegrationTest {
     @Test(groups = { "integration" })
-    public void testGetFactory() throws Exception {
+    public void testGetFactory() {
         ClickHouseNode server = getServer(ClickHouseProtocol.GRPC);
         try (ClickHouseClient client = ClickHouseClient.newInstance()) {
             ClickHouseRequest<?> request = client.connect(server);

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
@@ -9,6 +9,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import com.clickhouse.client.ClickHouseClient;
+import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseRecord;
@@ -36,14 +37,14 @@ public class ClickHouseGrpcClientTest extends ClientIntegrationTest {
     }
 
     @Test(groups = "integration")
-    public void testResponseSummary() throws Exception {
+    public void testResponseSummary() throws ClickHouseException {
         ClickHouseNode server = getServer();
 
         try (ClickHouseClient client = getClient();
                 ClickHouseResponse resp = client.connect(server)
                         .option(ClickHouseClientOption.READ_BUFFER_SIZE, 8)
                         .format(ClickHouseFormat.TabSeparatedWithNamesAndTypes)
-                        .query("select number, number+1 from numbers(100)").execute().get()) {
+                        .query("select number, number+1 from numbers(100)").executeAndWait()) {
             int n = 0;
             for (ClickHouseRecord record : resp.records()) {
                 Assert.assertEquals(record.size(), 2);

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/DefaultHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/DefaultHttpConnectionTest.java
@@ -6,18 +6,21 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseRequest;
 
+import java.io.IOException;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class DefaultHttpConnectionTest extends BaseIntegrationTest {
     @Test(groups = { "integration" })
-    public void testConnectionReuse() throws Exception {
+    public void testConnectionReuse() throws IOException {
         ClickHouseNode server = getServer(ClickHouseProtocol.HTTP);
 
         try (ClickHouseClient client = ClickHouseClient.newInstance()) {
             ClickHouseRequest<?> req = client.connect(server);
 
             ClickHouseHttpConnection conn = ClickHouseHttpConnectionFactory.createConnection(server, req, null);
+            Assert.assertNotNull(conn);
         }
     }
 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
@@ -774,7 +774,7 @@ public class ClickHouseConnectionImpl extends JdbcWrapper implements ClickHouseC
             if (parsedStmt.hasTempTable()) {
                 // queries using external/temporary table
                 ps = new TableBasedPreparedStatement(this,
-                        clientRequest.write().query(parsedStmt.getSQL(), newQueryId()), parsedStmt,
+                        clientRequest.copy().query(parsedStmt.getSQL(), newQueryId()), parsedStmt,
                         resultSetType, resultSetConcurrency, resultSetHoldability);
             } else if (parsedStmt.getStatementType() == StatementType.INSERT) {
                 if (!ClickHouseChecker.isNullOrBlank(parsedStmt.getInput())) {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
@@ -30,7 +30,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test // (groups = "integration")
-    public void testAutoCommitMode() throws Exception {
+    public void testAutoCommitMode() throws SQLException {
         Properties props = new Properties();
         props.setProperty("transactionSupport", "true");
 
@@ -50,7 +50,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test(groups = "integration")
-    public void testNonExistDatabase() throws Exception {
+    public void testNonExistDatabase() throws SQLException {
         String database = UUID.randomUUID().toString();
         Properties props = new Properties();
         props.setProperty(ClickHouseClientOption.DATABASE.getKey(), database);
@@ -199,7 +199,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test // (groups = "integration")
-    public void testTransaction() throws Exception {
+    public void testTransaction() throws SQLException {
         testAutoCommit();
         testManualCommit();
         testNestedTransactions();
@@ -207,7 +207,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test // (groups = "integration")
-    public void testAutoCommit() throws Exception {
+    public void testAutoCommit() throws SQLException {
         Properties props = new Properties();
         props.setProperty("transactionSupport", "true");
         String tableName = "test_jdbc_tx_auto_commit";
@@ -294,7 +294,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test // (groups = "integration")
-    public void testManualCommit() throws Exception {
+    public void testManualCommit() throws SQLException {
         Properties props = new Properties();
         props.setProperty("autoCommit", "false");
         Properties txProps = new Properties();
@@ -397,7 +397,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test // (groups = "integration")
-    public void testNestedTransactions() throws Exception {
+    public void testNestedTransactions() throws SQLException {
         Properties props = new Properties();
         props.setProperty("autoCommit", "false");
         props.setProperty("transactionSupport", "true");
@@ -436,7 +436,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     }
 
     @Test // (groups = "integration")
-    public void testParallelTransactions() throws Exception {
+    public void testParallelTransactions() throws SQLException {
         Properties props = new Properties();
         props.setProperty("autoCommit", "false");
         props.setProperty("transactionSupport", "true");

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
@@ -297,7 +297,7 @@ public class ClickHouseResultSetTest extends JdbcIntegrationTest {
     }
 
     @Test(dataProvider = "nullableColumns", groups = "integration")
-    public void testNullValue(String columnType, String defaultValue, Class<?> clazz) throws Exception {
+    public void testNullValue(String columnType, String defaultValue, Class<?> clazz) throws SQLException {
         Properties props = new Properties();
         props.setProperty(JdbcConfig.PROP_NULL_AS_DEFAULT, "2");
         String tableName = "test_query_null_value_" + columnType.split("\\(")[0].trim().toLowerCase();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -247,7 +247,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
     }
 
     @Test(dataProvider = "connectionProperties", groups = "integration")
-    public void testCancelQuery(Properties props) throws Exception {
+    public void testCancelQuery(Properties props) throws SQLException {
         try (ClickHouseConnection conn = newConnection(props);
                 ClickHouseStatement stmt = conn.createStatement();) {
             CountDownLatch c = new CountDownLatch(1);
@@ -270,6 +270,8 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
                     });
             try {
                 c.await(5, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                Assert.fail("Failed to wait", e);
             } finally {
                 stmt.cancel();
             }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
@@ -137,7 +137,7 @@ public class ClickHouseJdbcUrlParserTest {
     }
 
     @Test(groups = "unit")
-    public void testParseCredentials() throws Exception {
+    public void testParseCredentials() throws SQLException {
         Properties props = new Properties();
         props.setProperty("user", "default1");
         props.setProperty("password", "password1");

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/parser/ClickHouseSqlParserTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/parser/ClickHouseSqlParserTest.java
@@ -768,7 +768,7 @@ public class ClickHouseSqlParserTest {
     }
 
     // TODO: add a sub-module points to ClickHouse/tests/queries?
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws IOException {
         String chTestQueryDir = "D:/Sources/Github/ch/queries";
         if (args != null && args.length > 0) {
             chTestQueryDir = args[0];


### PR DESCRIPTION
* treat custom format as is in Mutation request
* obsolete ClickHouseRequest.getInputFormat - use getFormat().defaultInputFormat() instead
* remove `throws Exception` from tests