### PR TITLE
Refactor JdbcTypeMapping by making it extensible

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseUtils.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseUtils.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.URLDecoder;
@@ -18,7 +17,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedHashMap;
@@ -1340,19 +1338,6 @@ public final class ClickHouseUtils {
         }
 
         return len;
-    }
-
-    @SuppressWarnings("unchecked")
-    protected static <T> T[] toArray(Class<T> clazz, Collection<T> list) {
-        int size = list == null ? 0 : list.size();
-        T[] array = (T[]) Array.newInstance(clazz, size);
-        if (size > 0) {
-            int i = 0;
-            for (T t : list) {
-                array[i++] = t;
-            }
-        }
-        return array;
     }
 
     private ClickHouseUtils() {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseArray.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseArray.java
@@ -39,8 +39,7 @@ public class ClickHouseArray implements Array {
     public int getBaseType() throws SQLException {
         ensureValid();
 
-        // don't really want to pass type mapping to Array object...
-        return JdbcTypeMapping.toJdbcType(null, getBaseColumn());
+        return resultSet.mapper.toSqlType(getBaseColumn(), resultSet.defaultTypeMap);
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseConnection.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseConnection.java
@@ -230,11 +230,20 @@ public interface ClickHouseConnection extends Connection {
     JdbcConfig getJdbcConfig();
 
     /**
-     * Gets max insert block size. Pay attention that INSERT into one partition in
-     * one table of
-     * MergeTree family up to max_insert_size rows is transactional.
+     * Gets JDBC type mapping. Same as {@code getJdbcConfig().getMapper()}.
      *
-     * @return
+     * @return non-null JDBC type mapping
+     */
+    default JdbcTypeMapping getJdbcTypeMapping() {
+        return getJdbcConfig().getDialect();
+    }
+
+    /**
+     * Gets max insert block size. Pay attention that INSERT into one partition in
+     * one table of MergeTree family up to max_insert_block_size rows is
+     * transactional.
+     *
+     * @return value of max_insert_block_size
      */
     long getMaxInsertBlockSize();
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
@@ -40,7 +40,6 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
             "REMOTE TABLE", "TABLE", "VIEW", "SYSTEM TABLE", "TEMPORARY TABLE" };
 
     private final ClickHouseConnection connection;
-    private final Map<String, Class<?>> typeMaps;
 
     protected ResultSet empty(String columns) throws SQLException {
         return fixed(columns, null);
@@ -86,7 +85,6 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
 
     public ClickHouseDatabaseMetaData(ClickHouseConnection connection) throws SQLException {
         this.connection = ClickHouseChecker.nonNull(connection, "Connection");
-        this.typeMaps = connection.getTypeMap();
     }
 
     @Override
@@ -830,7 +828,8 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
             String typeName = r.getValue("TYPE_NAME").asString();
             try {
                 ClickHouseColumn column = ClickHouseColumn.of("", typeName);
-                r.getValue("DATA_TYPE").update(JdbcTypeMapping.toJdbcType(typeMaps, column));
+                r.getValue("DATA_TYPE")
+                        .update(connection.getJdbcTypeMapping().toSqlType(column, connection.getTypeMap()));
                 r.getValue("COLUMN_SIZE").update(
                         column.getPrecision() > 0 ? column.getPrecision() : column.getDataType().getByteLength());
                 if (column.isNullable()) {
@@ -913,7 +912,7 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
                 + "DELETE_RULE Int16, FK_NAME Nullable(String), PK_NAME Nullable(String), DEFERRABILITY Int16");
     }
 
-    private Object[] toTypeRow(String typeName, String aliasTo) {
+    private Object[] toTypeRow(String typeName, String aliasTo) throws SQLException {
         ClickHouseDataType type;
         try {
             type = ClickHouseDataType.of(typeName);
@@ -976,7 +975,8 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
                 break;
         }
         return new Object[] { typeName,
-                JdbcTypeMapping.toJdbcType(typeMaps, ClickHouseColumn.of("", type, false, false, new String[0])),
+                connection.getJdbcTypeMapping().toSqlType(ClickHouseColumn.of("", type, false, false, new String[0]),
+                        connection.getTypeMap()),
                 type.getMaxPrecision(), prefix, suffix, params, nullable, type.isCaseSensitive() ? 1 : 0, searchable,
                 type.getMaxPrecision() > 0 && !type.isSigned() ? 1 : 0, money, 0,
                 aliasTo == null || aliasTo.isEmpty() ? type.name() : aliasTo, type.getMinScale(), type.getMaxScale(), 0,

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcTypeMapping.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcTypeMapping.java
@@ -3,6 +3,7 @@ package com.clickhouse.jdbc;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Date;
+import java.sql.JDBCType;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
@@ -11,13 +12,311 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import com.clickhouse.client.ClickHouseColumn;
 import com.clickhouse.client.ClickHouseDataType;
+import com.clickhouse.client.ClickHouseUtils;
 
-public final class JdbcTypeMapping {
-    static Class<?> getCustomJavaClass(Map<String, Class<?>> typeMap, ClickHouseColumn column) {
+/**
+ * This class defines mappings among {@link Types}, {@link JDBCType},
+ * {@link ClickHouseDataType}, {@link ClickHouseColumn}, and {@link Class}. It
+ * does not impact serialization and deserialization, which is handled
+ * separately by {@link com.clickhouse.client.ClickHouseDataProcessor}.
+ */
+public class JdbcTypeMapping {
+    static final class AnsiTypeMapping extends JdbcTypeMapping {
+        static String toAnsiSqlType(ClickHouseDataType dataType, int precision, int scale, TimeZone tz) {
+            final String typeName;
+            switch (dataType) {
+                case Bool:
+                    typeName = "BOOLEAN"; // or BIT(1)?
+                    break;
+                case Date:
+                case Date32:
+                    typeName = "DATE";
+                    break;
+                case DateTime:
+                case DateTime32:
+                case DateTime64:
+                    typeName = (scale <= 0 ? new StringBuilder("TIMESTAMP")
+                            : new StringBuilder("TIMESTAMP(").append(scale).append(')'))
+                            .append(tz != null ? " WITH TIMEZONE" : "").toString();
+                    break;
+                case Int8:
+                    typeName = "BYTE"; // NON-standard
+                    break;
+                case UInt8:
+                case Int16:
+                    typeName = "SMALLINT";
+                    break;
+                case UInt16:
+                case Int32:
+                    typeName = "INTEGER";
+                    break;
+                case UInt32:
+                case Int64:
+                case IntervalYear:
+                case IntervalQuarter:
+                case IntervalMonth:
+                case IntervalWeek:
+                case IntervalDay:
+                case IntervalHour:
+                case IntervalMinute:
+                case IntervalSecond:
+                    typeName = "BIGINT";
+                    break;
+                case UInt64:
+                case Int128:
+                case UInt128:
+                case Int256:
+                case UInt256:
+                case Decimal:
+                case Decimal32:
+                case Decimal64:
+                case Decimal128:
+                case Decimal256:
+                    typeName = new StringBuilder("DECIMAL(").append(precision).append(',')
+                            .append(scale).append(')').toString();
+                    break;
+                case Float32:
+                    typeName = "REAL";
+                    break;
+                case Float64:
+                    typeName = "DOUBLE PRECISION";
+                    break;
+                case Point:
+                case Ring:
+                case Polygon:
+                case MultiPolygon:
+                    typeName = "ARRAY";
+                    break;
+                case Enum:
+                case Enum8:
+                case Enum16:
+                case IPv4:
+                case IPv6:
+                case JSON:
+                case Object:
+                case FixedString:
+                case String:
+                case UUID:
+                    typeName = "VARCHAR";
+                    break;
+                default:
+                    typeName = "BINARY";
+                    break;
+            }
+            return typeName;
+        }
+
+        static String toAnsiSqlType(ClickHouseColumn column, StringBuilder builder) {
+            final ClickHouseDataType dataType = column.getDataType();
+            final String sqlType;
+
+            if (dataType == ClickHouseDataType.SimpleAggregateFunction) {
+                sqlType = column.hasNestedColumn() ? toAnsiSqlType(column.getNestedColumns().get(0), builder)
+                        : "BINARY";
+            } else if (column.isArray()) {
+                sqlType = builder.append("ARRAY").append('(')
+                        .append(toAnsiSqlType(column.getArrayBaseColumn(), builder))
+                        .append(')').toString();
+            } else if (column.isMap()) {
+                return builder.append("MAP").append('(').append(toAnsiSqlType(column.getKeyInfo(), builder)).append(',')
+                        .append(toAnsiSqlType(column.getValueInfo(), builder))
+                        .append(')').toString();
+            } else if (column.isNested() || column.isTuple()) {
+                builder.append("STRUCT").append('(');
+                for (ClickHouseColumn c : column.getNestedColumns()) {
+                    builder.append(toAnsiSqlType(c, builder)).append(',');
+                }
+                builder.setLength(builder.length() - 1);
+                sqlType = builder.append(')').toString();
+            } else {
+                sqlType = toAnsiSqlType(dataType, column.getPrecision(), column.getScale(),
+                        column.getTimeZone());
+            }
+            return sqlType;
+        }
+
+        @Override
+        protected int getSqlType(Class<?> javaClass) { // and purpose(e.g. for read or write?)
+            final int sqlType;
+            if (javaClass == boolean.class || javaClass == Boolean.class) {
+                sqlType = Types.BOOLEAN;
+            } else if (javaClass == byte.class || javaClass == Byte.class) {
+                sqlType = Types.TINYINT;
+            } else if (javaClass == short.class || javaClass == Short.class || javaClass == int.class
+                    || javaClass == Integer.class) {
+                sqlType = Types.INTEGER;
+            } else if (javaClass == long.class || javaClass == Long.class) {
+                sqlType = Types.BIGINT;
+            } else if (javaClass == float.class || javaClass == Float.class) {
+                sqlType = Types.FLOAT;
+            } else if (javaClass == double.class || javaClass == Double.class) {
+                sqlType = Types.DOUBLE;
+            } else if (javaClass == BigInteger.class || javaClass == BigDecimal.class) {
+                sqlType = Types.DECIMAL;
+            } else if (javaClass == Date.class || javaClass == LocalDate.class) {
+                sqlType = Types.DATE;
+            } else if (javaClass == Time.class || javaClass == LocalTime.class) {
+                sqlType = Types.TIME;
+            } else if (javaClass == Timestamp.class || javaClass == LocalDateTime.class
+                    || javaClass == OffsetDateTime.class || javaClass == ZonedDateTime.class) {
+                sqlType = Types.TIMESTAMP;
+            } else if (javaClass == String.class || javaClass == byte[].class
+                    || Enum.class.isAssignableFrom(javaClass)) {
+                sqlType = Types.VARCHAR;
+            } else if (javaClass.isArray()) { // could be Nested type
+                sqlType = Types.ARRAY;
+            } else if (List.class.isAssignableFrom(javaClass) || Map.class.isAssignableFrom(javaClass)) {
+                sqlType = Types.STRUCT;
+            } else {
+                sqlType = Types.OTHER;
+            }
+            return sqlType;
+        }
+
+        @Override
+        public String toNativeType(ClickHouseColumn column) {
+            return toAnsiSqlType(column, new StringBuilder());
+        }
+
+        @Override
+        public int toSqlType(ClickHouseColumn column, Map<String, Class<?>> typeMap) {
+            Class<?> javaClass = getCustomJavaClass(column, typeMap);
+            if (javaClass != null) {
+                return getSqlType(javaClass);
+            }
+
+            int sqlType = Types.OTHER;
+            switch (column.getDataType()) {
+                case Bool:
+                    sqlType = Types.BOOLEAN;
+                    break;
+                case Int8:
+                    sqlType = Types.TINYINT;
+                    break;
+                case UInt8:
+                case Int16:
+                case UInt16:
+                case Int32:
+                    sqlType = Types.INTEGER;
+                    break;
+                case UInt32:
+                case IntervalYear:
+                case IntervalQuarter:
+                case IntervalMonth:
+                case IntervalWeek:
+                case IntervalDay:
+                case IntervalHour:
+                case IntervalMinute:
+                case IntervalSecond:
+                case Int64:
+                    sqlType = Types.BIGINT;
+                    break;
+                case Float32:
+                    sqlType = Types.FLOAT;
+                    break;
+                case Float64:
+                    sqlType = Types.DOUBLE;
+                    break;
+                case UInt64:
+                case Int128:
+                case UInt128:
+                case Int256:
+                case UInt256:
+                case Decimal:
+                case Decimal32:
+                case Decimal64:
+                case Decimal128:
+                case Decimal256:
+                    sqlType = Types.DECIMAL;
+                    break;
+                case Date:
+                case Date32:
+                    sqlType = Types.DATE;
+                    break;
+                case DateTime:
+                case DateTime32:
+                case DateTime64:
+                    sqlType = Types.TIMESTAMP;
+                    break;
+                case Enum:
+                case Enum8:
+                case Enum16:
+                case IPv4:
+                case IPv6:
+                case FixedString:
+                case JSON:
+                case Object:
+                case String:
+                case UUID:
+                    sqlType = Types.VARCHAR;
+                    break;
+                case Point:
+                case Ring:
+                case Polygon:
+                case MultiPolygon:
+                case Array:
+                    sqlType = Types.ARRAY;
+                    break;
+                case Map: // Map<?,?>
+                case Nested: // Object[][]
+                case Tuple: // List<?>
+                    sqlType = Types.STRUCT;
+                    break;
+                case Nothing:
+                    sqlType = Types.NULL;
+                    break;
+                default:
+                    break;
+            }
+
+            return sqlType;
+        }
+    }
+
+    /**
+     * Inner class for static initialization.
+     */
+    static final class InstanceHolder {
+        private static final JdbcTypeMapping defaultMapping = ClickHouseUtils
+                .getService(JdbcTypeMapping.class, JdbcTypeMapping::new);
+        private static final JdbcTypeMapping ansiMapping = new AnsiTypeMapping();
+
+        private InstanceHolder() {
+        }
+    }
+
+    /**
+     * Gets default type mapping.
+     *
+     * @return non-null type mapping
+     */
+    public static JdbcTypeMapping getDefaultMapping() {
+        return InstanceHolder.defaultMapping;
+    }
+
+    /**
+     * Gets ANSI type mapping.
+     *
+     * @return non-null type mapping
+     */
+    public static JdbcTypeMapping getAnsiMapping() {
+        return InstanceHolder.ansiMapping;
+    }
+
+    /**
+     * Gets custom Java class for the given column.
+     *
+     * @param column  non-null column definition
+     * @param typeMap column type to Java class map, could be null
+     * @return custom Java class which may or may not be null
+     */
+    protected Class<?> getCustomJavaClass(ClickHouseColumn column, Map<String, Class<?>> typeMap) {
         if (typeMap != null && !typeMap.isEmpty()) {
             Class<?> javaClass = typeMap.get(column.getOriginalTypeName());
             if (javaClass == null) {
@@ -31,13 +330,97 @@ public final class JdbcTypeMapping {
     }
 
     /**
-     * Gets corresponding JDBC type for the given Java class.
+     * Gets corresponding {@link ClickHouseDataType} of the given {@link Types}.
+     *
+     * @param sqlType generic SQL types defined in JDBC
+     * @return non-null ClickHouse data type
+     */
+    protected ClickHouseDataType getDataType(int sqlType) {
+        ClickHouseDataType dataType;
+
+        switch (sqlType) {
+            case Types.BOOLEAN:
+                dataType = ClickHouseDataType.UInt8;
+                break;
+            case Types.TINYINT:
+                dataType = ClickHouseDataType.Int8;
+                break;
+            case Types.SMALLINT:
+                dataType = ClickHouseDataType.Int16;
+                break;
+            case Types.INTEGER:
+                dataType = ClickHouseDataType.Int32;
+                break;
+            case Types.BIGINT:
+                dataType = ClickHouseDataType.Int64;
+                break;
+            case Types.NUMERIC:
+                dataType = ClickHouseDataType.Int256;
+                break;
+            case Types.FLOAT:
+            case Types.REAL:
+                dataType = ClickHouseDataType.Float32;
+                break;
+            case Types.DOUBLE:
+                dataType = ClickHouseDataType.Float64;
+                break;
+            case Types.DECIMAL:
+                dataType = ClickHouseDataType.Decimal;
+                break;
+            case Types.BIT:
+            case Types.BLOB:
+            case Types.BINARY:
+            case Types.CHAR:
+            case Types.CLOB:
+            case Types.JAVA_OBJECT:
+            case Types.LONGNVARCHAR:
+            case Types.LONGVARBINARY:
+            case Types.LONGVARCHAR:
+            case Types.NCHAR:
+            case Types.NCLOB:
+            case Types.NVARCHAR:
+            case Types.OTHER:
+            case Types.SQLXML:
+            case Types.VARBINARY:
+            case Types.VARCHAR:
+                dataType = ClickHouseDataType.String;
+                break;
+            case Types.DATE:
+                dataType = ClickHouseDataType.Date;
+                break;
+            case Types.TIME:
+            case Types.TIME_WITH_TIMEZONE:
+            case Types.TIMESTAMP:
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                dataType = ClickHouseDataType.DateTime;
+                break;
+            case Types.ARRAY:
+                dataType = ClickHouseDataType.Array;
+                break;
+            case Types.STRUCT:
+                dataType = ClickHouseDataType.Tuple;
+                break;
+            case Types.DATALINK:
+            case Types.DISTINCT:
+            case Types.REF:
+            case Types.REF_CURSOR:
+            case Types.ROWID:
+            case Types.NULL:
+            default:
+                dataType = ClickHouseDataType.Nothing;
+                break;
+        }
+        return dataType;
+    }
+
+    /**
+     * Gets corresponding {@link Types} for the given Java class.
      *
      * @param javaClass non-null Java class
-     * @return JDBC type
+     * @return generic SQL type defined in JDBC
      */
-    public static int toJdbcType(Class<?> javaClass) {
-        int sqlType = Types.OTHER;
+    protected int getSqlType(Class<?> javaClass) { // and purpose(e.g. for read or write?)
+        final int sqlType;
         if (javaClass == boolean.class || javaClass == Boolean.class) {
             sqlType = Types.BOOLEAN;
         } else if (javaClass == byte.class || javaClass == Byte.class) {
@@ -66,27 +449,114 @@ public final class JdbcTypeMapping {
             sqlType = Types.TIMESTAMP_WITH_TIMEZONE;
         } else if (javaClass == String.class || javaClass == byte[].class || Enum.class.isAssignableFrom(javaClass)) {
             sqlType = Types.VARCHAR;
-        } else if (javaClass.isArray()) {
+        } else if (javaClass.isArray()) { // could be Nested type
             sqlType = Types.ARRAY;
+        } else if (List.class.isAssignableFrom(javaClass) || Map.class.isAssignableFrom(javaClass)) {
+            sqlType = Types.STRUCT;
+        } else {
+            sqlType = Types.OTHER;
         }
         return sqlType;
     }
 
     /**
-     * Gets corresponding JDBC type for the given column.
+     * Converts {@link JDBCType} to ClickHouse column.
      *
-     * @param typeMap type mappings, could be null
-     * @param column  non-null column definition
-     * @return JDBC type
+     * @param jdbcType      JDBC type
+     * @param scaleOrLength scale or length
+     * @return non-null ClickHouse column
      */
-    public static int toJdbcType(Map<String, Class<?>> typeMap, ClickHouseColumn column) {
-        Class<?> javaClass = getCustomJavaClass(typeMap, column);
+    public ClickHouseColumn toColumn(JDBCType jdbcType, int scaleOrLength) {
+        Integer type = jdbcType.getVendorTypeNumber();
+        return toColumn(type != null ? type : Types.OTHER, scaleOrLength);
+    }
+
+    /**
+     * Converts {@link Types} to ClickHouse column.
+     *
+     * @param sqlType       generic SQL types defined in JDBC
+     * @param scaleOrLength scale or length
+     * @return non-null ClickHouse column
+     */
+    public ClickHouseColumn toColumn(int sqlType, int scaleOrLength) {
+        ClickHouseDataType dataType = getDataType(sqlType);
+        ClickHouseColumn column = null;
+        if (scaleOrLength > 0) {
+            if (sqlType == Types.BIT && scaleOrLength == 1) {
+                dataType = ClickHouseDataType.UInt8;
+            } else if (sqlType == Types.NUMERIC || sqlType == Types.DECIMAL) {
+                for (ClickHouseDataType t : new ClickHouseDataType[] {}) {
+                    if (scaleOrLength <= t.getMaxScale() / 2) {
+                        column = ClickHouseColumn.of("", t, false, t.getMaxPrecision() - t.getMaxScale(),
+                                scaleOrLength);
+                        break;
+                    }
+                }
+            } else if (dataType == ClickHouseDataType.Date) {
+                if (scaleOrLength > 2) {
+                    dataType = ClickHouseDataType.Date32;
+                }
+            } else if (dataType == ClickHouseDataType.DateTime) {
+                column = ClickHouseColumn.of("", ClickHouseDataType.DateTime64, false, 0, scaleOrLength);
+            } else if (dataType == ClickHouseDataType.String) {
+                column = ClickHouseColumn.of("", ClickHouseDataType.FixedString, false, scaleOrLength, 0);
+            }
+        }
+
+        return column == null ? ClickHouseColumn.of("", dataType, false, false) : column;
+    }
+
+    /**
+     * Converts {@link ClickHouseColumn} to {@link Class}.
+     *
+     * @param column  non-null column definition
+     * @param typeMap optional custom type mapping
+     * @return non-null Java class
+     */
+    public Class<?> toJavaClass(ClickHouseColumn column, Map<String, Class<?>> typeMap) {
+        Class<?> clazz = getCustomJavaClass(column, typeMap);
+        if (clazz != null) {
+            return clazz;
+        }
+
+        ClickHouseDataType type = column.getDataType();
+        switch (type) {
+            case DateTime:
+            case DateTime32:
+            case DateTime64:
+                clazz = column.getTimeZone() != null ? OffsetDateTime.class : LocalDateTime.class;
+                break;
+            default:
+                clazz = type.getObjectClass();
+                break;
+        }
+        return clazz;
+    }
+
+    /**
+     * Converts {@link ClickHouseColumn} to native type.
+     *
+     * @param column non-null column definition
+     * @return non-null native type
+     */
+    public String toNativeType(ClickHouseColumn column) {
+        return column.getOriginalTypeName();
+    }
+
+    /**
+     * Converts {@link ClickHouseColumn} to generic SQL type defined in JDBC.
+     *
+     * @param column  non-null column definition
+     * @param typeMap optional custom mapping
+     * @return generic SQL type defined in JDBC
+     */
+    public int toSqlType(ClickHouseColumn column, Map<String, Class<?>> typeMap) {
+        Class<?> javaClass = getCustomJavaClass(column, typeMap);
         if (javaClass != null) {
-            return toJdbcType(javaClass);
+            return getSqlType(javaClass);
         }
 
         int sqlType = Types.OTHER;
-
         switch (column.getDataType()) {
             case Bool:
                 sqlType = Types.BOOLEAN;
@@ -149,6 +619,8 @@ public final class JdbcTypeMapping {
             case IPv4:
             case IPv6:
             case FixedString:
+            case JSON:
+            case Object:
             case String:
             case UUID:
                 sqlType = Types.VARCHAR;
@@ -160,152 +632,18 @@ public final class JdbcTypeMapping {
             case Array:
                 sqlType = Types.ARRAY;
                 break;
-            case Tuple:
-            case Nested:
+            case Map: // Map<?,?>
+            case Nested: // Object[][]
+            case Tuple: // List<?>
                 sqlType = Types.STRUCT;
                 break;
             case Nothing:
                 sqlType = Types.NULL;
                 break;
-            case Map:
             default:
                 break;
         }
 
         return sqlType;
-    }
-
-    /**
-     * Gets Java class for the given column.
-     *
-     * @param typeMap type mappings, could be null
-     * @param column  non-null column definition
-     * @return Java class for the column
-     */
-    public static Class<?> toJavaClass(Map<String, Class<?>> typeMap, ClickHouseColumn column) {
-        Class<?> clazz = getCustomJavaClass(typeMap, column);
-        if (clazz != null) {
-            return clazz;
-        }
-
-        ClickHouseDataType type = column.getDataType();
-        switch (type) {
-            case DateTime:
-            case DateTime32:
-            case DateTime64:
-                clazz = column.getTimeZone() != null ? OffsetDateTime.class : LocalDateTime.class;
-                break;
-            default:
-                clazz = type.getObjectClass();
-                break;
-        }
-        return clazz;
-    }
-
-    public static ClickHouseColumn fromJdbcType(int jdbcType, int scaleOrLength) {
-        ClickHouseDataType dataType = fromJdbcType(jdbcType);
-        ClickHouseColumn column = null;
-        if (scaleOrLength > 0) {
-            if (jdbcType == Types.NUMERIC || jdbcType == Types.DECIMAL) {
-                for (ClickHouseDataType t : new ClickHouseDataType[] {}) {
-                    if (scaleOrLength <= t.getMaxScale() / 2) {
-                        column = ClickHouseColumn.of("", t, false, t.getMaxPrecision() - t.getMaxScale(),
-                                scaleOrLength);
-                        break;
-                    }
-                }
-            } else if (dataType == ClickHouseDataType.Date) {
-                if (scaleOrLength > 2) {
-                    dataType = ClickHouseDataType.Date32;
-                }
-            } else if (dataType == ClickHouseDataType.DateTime) {
-                column = ClickHouseColumn.of("", ClickHouseDataType.DateTime64, false, 0, scaleOrLength);
-            } else if (dataType == ClickHouseDataType.String) {
-                column = ClickHouseColumn.of("", ClickHouseDataType.FixedString, false, scaleOrLength, 0);
-            }
-        }
-
-        return column == null ? ClickHouseColumn.of("", dataType, false, false) : column;
-    }
-
-    public static ClickHouseDataType fromJdbcType(int jdbcType) {
-        ClickHouseDataType dataType;
-
-        switch (jdbcType) {
-            case Types.BIT:
-            case Types.BOOLEAN:
-                dataType = ClickHouseDataType.UInt8;
-                break;
-            case Types.TINYINT:
-                dataType = ClickHouseDataType.Int8;
-                break;
-            case Types.SMALLINT:
-                dataType = ClickHouseDataType.Int16;
-                break;
-            case Types.INTEGER:
-                dataType = ClickHouseDataType.Int32;
-                break;
-            case Types.BIGINT:
-                dataType = ClickHouseDataType.Int64;
-                break;
-            case Types.NUMERIC:
-                dataType = ClickHouseDataType.Int256;
-                break;
-            case Types.FLOAT:
-            case Types.REAL:
-                dataType = ClickHouseDataType.Float32;
-                break;
-            case Types.DOUBLE:
-                dataType = ClickHouseDataType.Float64;
-                break;
-            case Types.DECIMAL:
-                dataType = ClickHouseDataType.Decimal;
-                break;
-            case Types.BLOB:
-            case Types.BINARY:
-            case Types.CHAR:
-            case Types.CLOB:
-            case Types.JAVA_OBJECT:
-            case Types.LONGNVARCHAR:
-            case Types.LONGVARBINARY:
-            case Types.LONGVARCHAR:
-            case Types.NCHAR:
-            case Types.NCLOB:
-            case Types.NVARCHAR:
-            case Types.OTHER:
-            case Types.SQLXML:
-            case Types.VARBINARY:
-            case Types.VARCHAR:
-                dataType = ClickHouseDataType.String;
-                break;
-            case Types.DATE:
-                dataType = ClickHouseDataType.Date;
-                break;
-            case Types.TIME:
-            case Types.TIME_WITH_TIMEZONE:
-            case Types.TIMESTAMP:
-            case Types.TIMESTAMP_WITH_TIMEZONE:
-                dataType = ClickHouseDataType.DateTime;
-                break;
-            case Types.ARRAY:
-                dataType = ClickHouseDataType.Array;
-                break;
-            case Types.STRUCT:
-                dataType = ClickHouseDataType.Nested;
-                break;
-            case Types.DATALINK:
-            case Types.DISTINCT:
-            case Types.REF:
-            case Types.REF_CURSOR:
-            case Types.ROWID:
-            case Types.NULL:
-            default:
-                dataType = ClickHouseDataType.Nothing;
-                break;
-        }
-        return dataType;
-    }
-
-    private JdbcTypeMapping() {
     }
 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
@@ -72,7 +72,8 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
             list.add(col);
             i++;
         }
-        paramMetaData = new ClickHouseParameterMetaData(Collections.unmodifiableList(list));
+        paramMetaData = new ClickHouseParameterMetaData(Collections.unmodifiableList(list), mapper,
+                connection.getTypeMap());
         flags = new boolean[size];
 
         counter = 0;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
@@ -37,7 +37,6 @@ import com.clickhouse.client.logging.Logger;
 import com.clickhouse.client.logging.LoggerFactory;
 import com.clickhouse.jdbc.ClickHousePreparedStatement;
 import com.clickhouse.jdbc.JdbcParameterizedQuery;
-import com.clickhouse.jdbc.JdbcTypeMapping;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 
@@ -103,7 +102,8 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
         for (int i = 1; i <= tlen; i++) {
             list.add(ClickHouseColumn.of("parameter" + i, ClickHouseDataType.JSON, true));
         }
-        paramMetaData = new ClickHouseParameterMetaData(Collections.unmodifiableList(list));
+        paramMetaData = new ClickHouseParameterMetaData(Collections.unmodifiableList(list), mapper,
+                connection.getTypeMap());
         batch = new LinkedList<>();
         builder = new StringBuilder();
         if ((insertValuesQuery = prefix) != null) {
@@ -148,8 +148,7 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
             long rows = 0L;
             try {
                 r = executeStatement(builder.toString(), null, null, null);
-                updateResult(parsedStmt, r);
-                if (asBatch && getResultSet() != null) {
+                if (updateResult(parsedStmt, r) != null && asBatch) {
                     throw SqlExceptionUtils.queryInBatchError(results);
                 }
                 rows = r.getSummary().getWrittenRows();
@@ -196,8 +195,7 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
                     preparedQuery.apply(builder, params);
                     try {
                         r = executeStatement(builder.toString(), null, null, null);
-                        updateResult(parsedStmt, r);
-                        if (asBatch && getResultSet() != null) {
+                        if (updateResult(parsedStmt, r) != null && asBatch) {
                             throw SqlExceptionUtils.queryInBatchError(results);
                         }
                         int count = getUpdateCount();
@@ -598,7 +596,7 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
         int idx = toArrayIndex(parameterIndex);
         ClickHouseValue value = templates[idx];
         if (value == null) {
-            value = ClickHouseValues.newValue(getConfig(), JdbcTypeMapping.fromJdbcType(targetSqlType, scaleOrLength));
+            value = ClickHouseValues.newValue(getConfig(), mapper.toColumn(targetSqlType, scaleOrLength));
             templates[idx] = value;
         }
 

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -1541,7 +1541,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                         "parameter mete data should be singleton");
                 Assert.assertEquals(ps.getParameterMetaData().getParameterCount(), 3);
                 Assert.assertEquals(ps.getParameterMetaData().getParameterMode(3), ParameterMetaData.parameterModeIn);
-                Assert.assertEquals(ps.getParameterMetaData().getParameterType(3), Types.OTHER);
+                Assert.assertEquals(ps.getParameterMetaData().getParameterType(3), Types.VARCHAR);
                 Assert.assertEquals(ps.getParameterMetaData().getPrecision(3), 0);
                 Assert.assertEquals(ps.getParameterMetaData().getScale(3), 0);
                 Assert.assertEquals(ps.getParameterMetaData().getParameterClassName(3), Object.class.getName());


### PR DESCRIPTION
* [BREAKING CHANGE] Refactor JdbcTypeMapping by making it extensible
* Add new JDBC option `dialect` and sample implementation AnsiTypeMapping (dialect=ansi)