### PR TITLE
Optimize reads for array values

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
           distribution: 'temurin'
           java-version: 8
           cache: 'maven'
-      - name: Compile and install libraries
-        run: MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError" mvn --batch-mode --show-version --strict-checksums --threads C1 -Dmaven.wagon.rto=30000 -DskipITs install
+      - name: Build and install libraries
+        run: mvn --batch-mode --show-version --strict-checksums --threads C1 -Dmaven.wagon.rto=30000 install
       - name: Compile examples
         run: for d in $(ls -d `pwd`/examples/*/); do cd $d && mvn clean compile; done
 
@@ -288,7 +288,7 @@ jobs:
         serverTz: ["Asia/Chongqing", "America/Los_Angeles", "Etc/UTC", "Europe/Berlin", "Europe/Moscow"]
         clientTz: ["Asia/Chongqing", "America/Los_Angeles", "Etc/UTC", "Europe/Berlin", "Europe/Moscow"]
       fail-fast: false
-    timeout-minutes: 10
+    timeout-minutes: 20
     name: "TimeZone(C/S): ${{ matrix.clientTz }} vs. ${{ matrix.serverTz }}"
     steps:
       - name: Check out repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           java-version: 8
           cache: 'maven'
       - name: Compile and install libraries
-        run: MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError" mvn --batch-mode --show-version --strict-checksums --threads C1 -Dmaven.wagon.rto=30000 -DskipTests install
+        run: MAVEN_OPTS="-Xmx512M -XX:+ExitOnOutOfMemoryError" mvn --batch-mode --show-version --strict-checksums --threads C1 -Dmaven.wagon.rto=30000 -DskipITs install
       - name: Compile examples
         run: for d in $(ls -d `pwd`/examples/*/); do cd $d && mvn clean compile; done
 
@@ -102,7 +102,7 @@ jobs:
         # most recent LTS releases as well as latest stable builds
         clickhouse: ["21.8", "22.3", "latest"]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 15
     name: Java client against ClickHouse ${{ matrix.clickhouse }}
     steps:
       - name: Check out repository
@@ -165,7 +165,7 @@ jobs:
           - clickhouse: "21.8"
             protocol: grpc
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 15
     name: JDBC driver against ClickHouse ${{ matrix.clickhouse }} (${{ matrix.protocol }})
     steps:
       - name: Check out repository
@@ -288,7 +288,7 @@ jobs:
         serverTz: ["Asia/Chongqing", "America/Los_Angeles", "Etc/UTC", "Europe/Berlin", "Europe/Moscow"]
         clientTz: ["Asia/Chongqing", "America/Los_Angeles", "Etc/UTC", "Europe/Berlin", "Europe/Moscow"]
       fail-fast: false
-    timeout-minutes: 30
+    timeout-minutes: 10
     name: "TimeZone(C/S): ${{ matrix.clientTz }} vs. ${{ matrix.serverTz }}"
     steps:
       - name: Check out repository

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ startsWith(github.repository, 'ClickHouse/') }}
     name: "Build and Publish Nightly Snapshot"
     runs-on: "ubuntu-latest"
-
+    timeout-minutes: 15
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,7 @@ jobs:
     if: ${{ startsWith(github.repository, 'ClickHouse/') }}
     name: "Build and Publish Nightly Snapshot"
     runs-on: "ubuntu-latest"
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseArraySequence.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseArraySequence.java
@@ -1,0 +1,76 @@
+package com.clickhouse.client;
+
+/**
+ * This interface represents a generic array value.
+ */
+public interface ClickHouseArraySequence extends ClickHouseValue {
+    /**
+     * Allocate an array according to given length. Same as
+     * {@code allocate(length, Object.class, 1)}.
+     *
+     * @param length length of the array
+     * @return this value
+     */
+    default ClickHouseArraySequence allocate(int length) {
+        return allocate(length, Object.class, 1);
+    }
+
+    /**
+     * Allocate an array according to given arguments. Same as
+     * {@code allocate(length, clazz, 1)}.
+     *
+     * @param length length of the array
+     * @param clazz  optional value type, null means {@code Object.class}
+     * @return this value
+     */
+    default ClickHouseArraySequence allocate(int length, Class<?> clazz) {
+        return allocate(length, clazz, 1);
+    }
+
+    /**
+     * Allocate an array according to given arguments.
+     *
+     * @param length length of the array
+     * @param clazz  optional value type, null means {@code Object.class}
+     * @param level  level of the array, zero or negative number is treated as
+     *               {@code 1}
+     * @return this value
+     */
+    ClickHouseArraySequence allocate(int length, Class<?> clazz, int level);
+
+    /**
+     * Gets length of this array.
+     *
+     * @return length of this array
+     */
+    int length();
+
+    /**
+     * Gets value at the specified position in this array.
+     *
+     * @param <V>   type of the value
+     * @param index index which is greater or equal to zero and always smaller
+     *              than {@link #length()}
+     * @param value non-null template object to retrieve the value
+     * @return non-null value which is same as {@code value}
+     */
+    <V extends ClickHouseValue> V getValue(int index, V value);
+
+    /**
+     * Sets value to the specified position in this array.
+     *
+     * @param index index which is greater or equal to zero and always smaller
+     *              than {@link #length()}
+     * @param value non-null container of the value
+     * @return this value
+     */
+    ClickHouseArraySequence setValue(int index, ClickHouseValue value);
+
+    @Override
+    default ClickHouseArraySequence copy() {
+        return copy(false);
+    }
+
+    @Override
+    ClickHouseArraySequence copy(boolean deep);
+}

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseByteBuffer.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseByteBuffer.java
@@ -217,7 +217,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public double[] asDoubleArray() {
-        int step = 8;
+        int step = Double.BYTES;
         int len = length / step;
         double[] values = new double[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {
@@ -231,7 +231,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public float[] asFloatArray() {
-        int step = 4;
+        int step = Float.BYTES;
         int len = length / step;
         float[] values = new float[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {
@@ -394,7 +394,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public int[] asIntegerArray() {
-        int step = 4;
+        int step = Integer.BYTES;
         int len = length / step;
         int[] values = new int[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {
@@ -404,7 +404,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public long[] asLongArray() {
-        int step = 8;
+        int step = Long.BYTES;
         int len = length / step;
         long[] values = new long[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {
@@ -414,7 +414,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public short[] asShortArray() {
-        int step = 2;
+        int step = Short.BYTES;
         int len = length / step;
         short[] values = new short[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {
@@ -436,7 +436,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public long[] asUnsignedIntegerArray() {
-        int step = 4;
+        int step = Integer.BYTES;
         int len = length / step;
         long[] values = new long[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {
@@ -446,7 +446,7 @@ public class ClickHouseByteBuffer implements Serializable {
     }
 
     public int[] asUnsignedShortArray() {
-        int step = 2;
+        int step = Short.BYTES;
         int len = length / step;
         int[] values = new int[len];
         for (int i = 0, offset = 0; i < len; i++, offset += step) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseColumn.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseColumn.java
@@ -583,7 +583,7 @@ public final class ClickHouseColumn implements Serializable {
         return nullable;
     }
 
-    boolean isLowCardinality() {
+    public boolean isLowCardinality() {
         return lowCardinality;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataProcessor.java
@@ -29,7 +29,7 @@ public abstract class ClickHouseDataProcessor {
 
         @Override
         public boolean hasNext() {
-            return processor.hasNext();
+            return processor.hasMoreToRead();
         }
 
         @Override
@@ -47,7 +47,7 @@ public abstract class ClickHouseDataProcessor {
 
         @Override
         public boolean hasNext() {
-            return processor.hasNext();
+            return processor.hasMoreToRead();
         }
 
         @Override
@@ -122,7 +122,7 @@ public abstract class ClickHouseDataProcessor {
      * @return true if there's more; false otherwise
      * @throws UncheckedIOException when failed to read data from input stream
      */
-    private boolean hasNext() throws UncheckedIOException {
+    protected boolean hasMoreToRead() throws UncheckedIOException {
         try {
             if (input.available() <= 0) {
                 input.close();

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataType.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDataType.java
@@ -76,7 +76,7 @@ public enum ClickHouseDataType {
     Enum8(String.class, true, true, false, 1, 0, 0, 0, 0, false), // "ENUM"),
     Enum16(String.class, true, true, false, 2, 0, 0, 0, 0, false),
     Float32(Float.class, false, true, true, 4, 12, 0, 0, 38, false, "FLOAT", "REAL", "SINGLE"),
-    Float64(Double.class, false, true, true, 16, 22, 0, 0, 308, false, "DOUBLE", "DOUBLE PRECISION"),
+    Float64(Double.class, false, true, true, 8, 22, 0, 0, 308, false, "DOUBLE", "DOUBLE PRECISION"),
     IPv4(Inet4Address.class, false, true, false, 4, 10, 0, 0, 0, false, "INET4"),
     IPv6(Inet6Address.class, false, true, false, 16, 39, 0, 0, 0, false, "INET6"),
     FixedString(String.class, true, true, false, 0, 0, 0, 0, 0, false, "BINARY"),

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValues.java
@@ -1016,6 +1016,42 @@ public final class ClickHouseValues {
     /**
      * Creates a value object based on given column.
      *
+     * @param column array column
+     * @return value object with empty value
+     */
+    public static ClickHouseArraySequence newArrayValue(ClickHouseColumn column) {
+        ClickHouseArraySequence value;
+        if (column == null || !column.isArray() || column.getArrayBaseColumn().isNullable()) {
+            value = ClickHouseArrayValue.ofEmpty();
+        } else if (column.getArrayNestedLevel() > 1) {
+            value = ClickHouseArrayValue.of(
+                    (Object[]) createPrimitiveArray(
+                            column.getArrayBaseColumn().getPrimitiveClass(),
+                            0, column.getArrayNestedLevel()));
+        } else {
+            Class<?> javaClass = column.getArrayBaseColumn().getPrimitiveClass();
+            if (byte.class == javaClass) {
+                value = ClickHouseByteArrayValue.ofEmpty();
+            } else if (short.class == javaClass) {
+                value = ClickHouseShortArrayValue.ofEmpty();
+            } else if (int.class == javaClass) {
+                value = ClickHouseIntArrayValue.ofEmpty();
+            } else if (long.class == javaClass) {
+                value = ClickHouseLongArrayValue.ofEmpty();
+            } else if (float.class == javaClass) {
+                value = ClickHouseFloatArrayValue.ofEmpty();
+            } else if (double.class == javaClass) {
+                value = ClickHouseDoubleArrayValue.ofEmpty();
+            } else {
+                value = ClickHouseArrayValue.ofEmpty();
+            }
+        }
+        return value;
+    }
+
+    /**
+     * Creates a value object based on given column.
+     *
      * @param config non-null configuration
      * @param column non-null column
      * @return value object with default value, either null or empty
@@ -1163,31 +1199,7 @@ public final class ClickHouseValues {
                 }
                 break;
             case Array:
-                if (column == null || column.getArrayBaseColumn().isNullable()) {
-                    value = ClickHouseArrayValue.ofEmpty();
-                } else if (column.getArrayNestedLevel() > 1) {
-                    value = ClickHouseArrayValue.of(
-                            (Object[]) createPrimitiveArray(
-                                    column.getArrayBaseColumn().getPrimitiveClass(),
-                                    0, column.getArrayNestedLevel()));
-                } else {
-                    Class<?> javaClass = column.getArrayBaseColumn().getPrimitiveClass();
-                    if (byte.class == javaClass) {
-                        value = ClickHouseByteArrayValue.ofEmpty();
-                    } else if (short.class == javaClass) {
-                        value = ClickHouseShortArrayValue.ofEmpty();
-                    } else if (int.class == javaClass) {
-                        value = ClickHouseIntArrayValue.ofEmpty();
-                    } else if (long.class == javaClass) {
-                        value = ClickHouseLongArrayValue.ofEmpty();
-                    } else if (float.class == javaClass) {
-                        value = ClickHouseFloatArrayValue.ofEmpty();
-                    } else if (double.class == javaClass) {
-                        value = ClickHouseDoubleArrayValue.ofEmpty();
-                    } else {
-                        value = ClickHouseArrayValue.ofEmpty();
-                    }
-                }
+                value = newArrayValue(column);
                 break;
             case Map:
                 if (column == null) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTabSeparatedProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTabSeparatedProcessor.java
@@ -261,10 +261,10 @@ public class ClickHouseTabSeparatedProcessor extends ClickHouseDataProcessor {
 
     @Override
     protected List<ClickHouseColumn> readColumns() throws IOException {
-        if (input == null) {
+        if (input.available() < 1) {
+            input.close();
             return Collections.emptyList();
         }
-
         ClickHouseFormat format = config.getFormat();
         if (!format.hasHeader()) {
             return DEFAULT_COLUMNS;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
@@ -29,7 +30,7 @@ import com.clickhouse.client.data.ClickHouseObjectValue;
 /**
  * Wrapper of {@code byte[]}.
  */
-public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> {
+public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "byte[]";
 
     /**
@@ -218,7 +219,7 @@ public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> {
             return resetToNullOrEmpty();
         }
 
-        return set(Arrays.copyOf(value, len));
+        return set(value);
     }
 
     @Override
@@ -522,5 +523,32 @@ public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> {
     @Override
     public int hashCode() {
         return Arrays.hashCode(getValue());
+    }
+
+    @Override
+    public ClickHouseArraySequence allocate(int length, Class<?> clazz, int level) {
+        if (length < 1) {
+            resetToDefault();
+        } else if (length() != length) {
+            set(new byte[length]);
+        }
+        return this;
+    }
+
+    @Override
+    public int length() {
+        return isNullOrEmpty() ? 0 : getValue().length;
+    }
+
+    @Override
+    public <V extends ClickHouseValue> V getValue(int index, V value) {
+        value.update(getValue()[index]);
+        return value;
+    }
+
+    @Override
+    public ClickHouseArraySequence setValue(int index, ClickHouseValue value) {
+        getValue()[index] = value.asByte();
+        return this;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
@@ -29,7 +30,7 @@ import com.clickhouse.client.data.ClickHouseObjectValue;
 /**
  * Wrapper of {@code double[]}.
  */
-public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> {
+public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "double[]";
 
     /**
@@ -305,7 +306,7 @@ public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> 
             return resetToNullOrEmpty();
         }
 
-        return set(Arrays.copyOf(value, len));
+        return set(value);
     }
 
     @Override
@@ -500,5 +501,32 @@ public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> 
     @Override
     public int hashCode() {
         return Arrays.hashCode(getValue());
+    }
+
+    @Override
+    public ClickHouseArraySequence allocate(int length, Class<?> clazz, int level) {
+        if (length < 1) {
+            resetToDefault();
+        } else if (length() != length) {
+            set(new double[length]);
+        }
+        return this;
+    }
+
+    @Override
+    public int length() {
+        return isNullOrEmpty() ? 0 : getValue().length;
+    }
+
+    @Override
+    public <V extends ClickHouseValue> V getValue(int index, V value) {
+        value.update(getValue()[index]);
+        return value;
+    }
+
+    @Override
+    public ClickHouseArraySequence setValue(int index, ClickHouseValue value) {
+        getValue()[index] = value.asDouble();
+        return this;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
@@ -29,7 +30,7 @@ import com.clickhouse.client.data.ClickHouseObjectValue;
 /**
  * Wrapper of {@code float[]}.
  */
-public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> {
+public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "float[]";
 
     /**
@@ -286,7 +287,7 @@ public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> {
             return resetToNullOrEmpty();
         }
 
-        return set(Arrays.copyOf(value, len));
+        return set(value);
     }
 
     @Override
@@ -500,5 +501,32 @@ public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> {
     @Override
     public int hashCode() {
         return Arrays.hashCode(getValue());
+    }
+
+    @Override
+    public ClickHouseArraySequence allocate(int length, Class<?> clazz, int level) {
+        if (length < 1) {
+            resetToDefault();
+        } else if (length() != length) {
+            set(new float[length]);
+        }
+        return this;
+    }
+
+    @Override
+    public int length() {
+        return isNullOrEmpty() ? 0 : getValue().length;
+    }
+
+    @Override
+    public <V extends ClickHouseValue> V getValue(int index, V value) {
+        value.update(getValue()[index]);
+        return value;
+    }
+
+    @Override
+    public ClickHouseArraySequence setValue(int index, ClickHouseValue value) {
+        getValue()[index] = value.asFloat();
+        return this;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
@@ -29,7 +30,7 @@ import com.clickhouse.client.data.ClickHouseObjectValue;
 /**
  * Wrapper of {@code int[]}.
  */
-public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> {
+public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> implements ClickHouseArraySequence {
     private final static String TYPE_NAME = "int[]";
 
     /**
@@ -248,7 +249,7 @@ public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> {
             return resetToNullOrEmpty();
         }
 
-        return set(Arrays.copyOf(value, len));
+        return set(value);
     }
 
     @Override
@@ -500,5 +501,32 @@ public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> {
     @Override
     public int hashCode() {
         return Arrays.hashCode(getValue());
+    }
+
+    @Override
+    public ClickHouseArraySequence allocate(int length, Class<?> clazz, int level) {
+        if (length < 1) {
+            resetToDefault();
+        } else if (length() != length) {
+            set(new int[length]);
+        }
+        return this;
+    }
+
+    @Override
+    public int length() {
+        return isNullOrEmpty() ? 0 : getValue().length;
+    }
+
+    @Override
+    public <V extends ClickHouseValue> V getValue(int index, V value) {
+        value.update(getValue()[index]);
+        return value;
+    }
+
+    @Override
+    public ClickHouseArraySequence setValue(int index, ClickHouseValue value) {
+        getValue()[index] = value.asInteger();
+        return this;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
@@ -30,7 +31,7 @@ import com.clickhouse.client.data.ClickHouseObjectValue;
 /**
  * Wrapper of {@code long[]}.
  */
-public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> {
+public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "long[]";
 
     /**
@@ -280,7 +281,7 @@ public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> {
             return resetToNullOrEmpty();
         }
 
-        return set(Arrays.copyOf(value, len));
+        return set(value);
     }
 
     @Override
@@ -513,5 +514,32 @@ public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> {
     @Override
     public int hashCode() {
         return Arrays.hashCode(getValue());
+    }
+
+    @Override
+    public ClickHouseArraySequence allocate(int length, Class<?> clazz, int level) {
+        if (length < 1) {
+            resetToDefault();
+        } else if (length() != length) {
+            set(new long[length]);
+        }
+        return this;
+    }
+
+    @Override
+    public int length() {
+        return isNullOrEmpty() ? 0 : getValue().length;
+    }
+
+    @Override
+    public <V extends ClickHouseValue> V getValue(int index, V value) {
+        value.update(getValue()[index]);
+        return value;
+    }
+
+    @Override
+    public ClickHouseArraySequence setValue(int index, ClickHouseValue value) {
+        getValue()[index] = value.asLong();
+        return this;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
 
+import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
 import com.clickhouse.client.ClickHouseValue;
@@ -29,7 +30,7 @@ import com.clickhouse.client.data.ClickHouseObjectValue;
 /**
  * Wrapper of {@code short[]}.
  */
-public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> {
+public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "short[]";
 
     /**
@@ -229,7 +230,7 @@ public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> {
             return resetToNullOrEmpty();
         }
 
-        return set(Arrays.copyOf(value, len));
+        return set(value);
     }
 
     @Override
@@ -500,5 +501,32 @@ public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> {
     @Override
     public int hashCode() {
         return Arrays.hashCode(getValue());
+    }
+
+    @Override
+    public ClickHouseArraySequence allocate(int length, Class<?> clazz, int level) {
+        if (length < 1) {
+            resetToDefault();
+        } else if (length() != length) {
+            set(new short[length]);
+        }
+        return this;
+    }
+
+    @Override
+    public int length() {
+        return isNullOrEmpty() ? 0 : getValue().length;
+    }
+
+    @Override
+    public <V extends ClickHouseValue> V getValue(int index, V value) {
+        value.update(getValue()[index]);
+        return value;
+    }
+
+    @Override
+    public ClickHouseArraySequence setValue(int index, ClickHouseValue value) {
+        getValue()[index] = value.asShort();
+        return this;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/AbstractByteArrayInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/AbstractByteArrayInputStream.java
@@ -80,20 +80,23 @@ public abstract class AbstractByteArrayInputStream extends ClickHouseInputStream
         }
         ensureOpen();
 
-        byte[] b = buffer;
-        int l = limit;
-        int p = position;
-        int remain = l - p;
-        if (remain > 0) {
-            output.transferBytes(b, p, remain);
-            count += remain;
-            while ((remain = updateBuffer()) > 0) {
-                b = buffer;
-                output.transferBytes(b, 0, remain);
+        try {
+            byte[] b = buffer;
+            int l = limit;
+            int p = position;
+            int remain = l - p;
+            if (remain > 0) {
+                output.transferBytes(b, p, remain);
                 count += remain;
+                while ((remain = updateBuffer()) > 0) {
+                    b = buffer;
+                    output.transferBytes(b, 0, remain);
+                    count += remain;
+                }
             }
+        } finally {
+            close();
         }
-        close();
         return count;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/AbstractByteBufferInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/AbstractByteBufferInputStream.java
@@ -82,24 +82,27 @@ public abstract class AbstractByteBufferInputStream extends ClickHouseInputStrea
         }
         ensureOpen();
 
-        ByteBuffer b = buffer;
-        int remain = b.remaining();
-        while (b != ClickHouseByteBuffer.EMPTY_BUFFER) {
-            if (remain > 0) {
-                if (b.hasArray()) {
-                    output.transferBytes(b.array(), b.position(), remain);
-                    ((Buffer) b).limit(b.position());
-                } else {
-                    byte[] bytes = new byte[remain];
-                    buffer.get(bytes);
-                    output.transferBytes(bytes, 0, remain);
+        try {
+            ByteBuffer b = buffer;
+            int remain = b.remaining();
+            while (b != ClickHouseByteBuffer.EMPTY_BUFFER) {
+                if (remain > 0) {
+                    if (b.hasArray()) {
+                        output.transferBytes(b.array(), b.position(), remain);
+                        ((Buffer) b).limit(b.position());
+                    } else {
+                        byte[] bytes = new byte[remain];
+                        buffer.get(bytes);
+                        output.transferBytes(bytes, 0, remain);
+                    }
+                    count += remain;
                 }
-                count += remain;
+                remain = updateBuffer();
+                b = buffer;
             }
-            remain = updateBuffer();
-            b = buffer;
+        } finally {
+            close();
         }
-        close();
         return count;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/IterableMultipleInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/IterableMultipleInputStream.java
@@ -153,21 +153,24 @@ public final class IterableMultipleInputStream<T> extends AbstractByteArrayInput
         }
         ensureOpen();
 
-        int remain = limit - position;
-        if (remain > 0) {
-            output.transferBytes(buffer, position, remain);
-            count += remain;
-            position = limit;
-        }
-
-        count += pipe(in, output, buffer);
-        while (it.hasNext()) {
-            InputStream i = func.apply(it.next());
-            if (i != null) {
-                count += pipe(i, output, buffer);
+        try {
+            int remain = limit - position;
+            if (remain > 0) {
+                output.transferBytes(buffer, position, remain);
+                count += remain;
+                position = limit;
             }
+
+            count += pipe(in, output, buffer);
+            while (it.hasNext()) {
+                InputStream i = func.apply(it.next());
+                if (i != null) {
+                    count += pipe(i, output, buffer);
+                }
+            }
+        } finally {
+            close();
         }
-        close();
         return count;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/NonBlockingInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/NonBlockingInputStream.java
@@ -108,20 +108,23 @@ public class NonBlockingInputStream extends ClickHouseInputStream {
         }
         ensureOpen();
 
-        byte[] b = buffer;
-        int l = b.length;
-        int p = position;
-        int remain = l - p;
-        if (remain > 0) {
-            output.transferBytes(b, p, remain);
-            count += remain;
-            while ((remain = updateBuffer()) > 0) {
-                b = buffer;
-                output.transferBytes(b, 0, remain);
+        try {
+            byte[] b = buffer;
+            int l = b.length;
+            int p = position;
+            int remain = l - p;
+            if (remain > 0) {
+                output.transferBytes(b, p, remain);
                 count += remain;
+                while ((remain = updateBuffer()) > 0) {
+                    b = buffer;
+                    output.transferBytes(b, 0, remain);
+                    count += remain;
+                }
             }
+        } finally {
+            close();
         }
-        close();
         return count;
     }
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/WrappedInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/WrappedInputStream.java
@@ -117,20 +117,23 @@ public class WrappedInputStream extends AbstractByteArrayInputStream {
         }
         ensureOpen();
 
-        int l = limit;
-        int p = position;
-        int remain = l - p;
-        if (remain > 0) {
-            output.writeBytes(buffer, p, remain);
-            count += remain;
-            position = l;
-        }
+        try {
+            int l = limit;
+            int p = position;
+            int remain = l - p;
+            if (remain > 0) {
+                output.writeBytes(buffer, p, remain);
+                count += remain;
+                position = l;
+            }
 
-        while ((remain = updateBuffer()) > 0) {
-            output.writeBytes(buffer, 0, remain);
-            count += remain;
+            while ((remain = updateBuffer()) > 0) {
+                output.writeBytes(buffer, 0, remain);
+                count += remain;
+            }
+        } finally {
+            close();
         }
-        close();
         return count;
     }
 }


### PR DESCRIPTION
Deserialization of primitive arrays is now twice faster than before, and it also benefits the upcoming Native data format.

```
Benchmark                              (client) (connection)  (statement)  (type)   Mode  Cnt  Score   Error  Units
Query.selectArrayOfUInt16  v0.3.3-SNAPSHOT             reuse     prepared  object  thrpt   20  3.066 ? 0.208  ops/s
Query.selectArrayOfUInt16  v0.3.2-patch11              reuse     prepared  object  thrpt   20  1.380 ? 0.079  ops/s
Query.selectArrayOfUInt16  clickhouse-native-jdbc      reuse     prepared  object  thrpt   20  0.720 ? 0.102  ops/s
```

```
Benchmark                          (client)    (connection)  (statement)  (type)   Mode  Cnt    Score   Error  Units
Query.selectInt8    v0.3.3-SNAPSHOT(Native)           reuse     prepared  object  thrpt   20  130.568 ? 7.936  ops/s
Query.selectUInt64  v0.3.3-SNAPSHOT(Native)           reuse     prepared  object  thrpt   20   66.351 ? 4.128  ops/s
Query.selectInt8    v0.3.3-SNAPSHOT(RowBinary)        reuse     prepared  object  thrpt   20   85.267 ? 3.679  ops/s
Query.selectUInt64  v0.3.3-SNAPSHOT(RowBinary)        reuse     prepared  object  thrpt   20   46.181 ? 3.380  ops/s
Query.selectInt8    v0.3.2-patch11(RowBinary)         reuse     prepared  object  thrpt   20   85.092 ? 6.157  ops/s
Query.selectUInt64  v0.3.2-patch11(RowBinary)         reuse     prepared  object  thrpt   20   49.179 ? 3.010  ops/s
```