### PR TITLE
Remove FixedString length check and relevant methods

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseChecker.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseChecker.java
@@ -2,8 +2,6 @@ package com.clickhouse.client;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
 /**
@@ -344,76 +342,6 @@ public final class ClickHouseChecker {
         if (length > maxLength) {
             throw newException("length of byte array %s is %d, which should NOT longer than %d", name, length,
                     maxLength);
-        }
-
-        return value;
-    }
-
-    /**
-     * Checks if length of the given byte array is NOT different from
-     * {@code expectedLength} and throws a customized
-     * {@link IllegalArgumentException} if it is.
-     * 
-     * @param value          the byte array to check
-     * @param expectedLength execpted length of the byte array
-     * @return the exact same byte array
-     * @throws IllegalArgumentException if length of the byte array is not same as
-     *                                  {@code expectedLength}
-     */
-    public static byte[] notWithDifferentLength(byte[] value, int expectedLength) {
-        return notWithDifferentLength(value, DEFAULT_NAME, expectedLength);
-    }
-
-    /**
-     * Checks if length of the given byte array is NOT different from
-     * {@code expectedLength} and throws a customized
-     * {@link IllegalArgumentException} if it is.
-     * 
-     * @param value          the byte array to check
-     * @param name           name of the byte array
-     * @param expectedLength execpted length of the byte array
-     * @return the exact same byte array
-     * @throws IllegalArgumentException if length of the byte array is not same as
-     *                                  {@code expectedLength}
-     */
-    public static byte[] notWithDifferentLength(byte[] value, String name, int expectedLength) {
-        int length = value == null ? 0 : value.length;
-        if (length != expectedLength) {
-            throw newException("length of byte array %s is %d, but it should be %d", name, length, expectedLength);
-        }
-
-        return value;
-    }
-
-    public static String notWithDifferentLength(String value, int expectedLength) {
-        return notWithDifferentLength(value, null, DEFAULT_NAME, expectedLength);
-    }
-
-    public static String notWithDifferentLength(String value, Charset charset, int expectedLength) {
-        return notWithDifferentLength(value, charset, DEFAULT_NAME, expectedLength);
-    }
-
-    /**
-     * Checks if byte length of the given string is NOT different from
-     * {@code expectedLength} and throws a customized
-     * {@link IllegalArgumentException} if it is.
-     * 
-     * @param value          the string to check
-     * @param charset        charset used to decode the string for byte length
-     *                       comparison, null means utf8
-     * @param name           name of the byte array
-     * @param expectedLength execpted length of the string
-     * @return the exact same string
-     * @throws IllegalArgumentException if length of the byte array is not same as
-     *                                  {@code expectedLength}
-     */
-    public static String notWithDifferentLength(String value, Charset charset, String name, int expectedLength) {
-        if (charset == null) {
-            charset = StandardCharsets.UTF_8;
-        }
-        int length = value == null ? 0 : value.getBytes(charset).length;
-        if (length != expectedLength) {
-            throw newException("length of byte array %s is %d, but it should be %d", name, length, expectedLength);
         }
 
         return value;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseValue.java
@@ -591,8 +591,8 @@ public interface ClickHouseValue extends Serializable {
         }
 
         byte[] bytes = asString().getBytes(charset == null ? StandardCharsets.UTF_8 : charset);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(bytes, length);
+        if (bytes.length < length) {
+            bytes = Arrays.copyOf(bytes, length);
         }
 
         return bytes;
@@ -604,50 +604,11 @@ public interface ClickHouseValue extends Serializable {
      * @return string value, could be null
      */
     default String asString() {
-        return asString(0, null);
-    }
-
-    /**
-     * Gets value as fixed length(in bytes) string, using default charset(usually
-     * UTF-8).
-     *
-     * @param length byte length of the string, 0 or negative number means unbounded
-     * @return string value, could be null
-     */
-    default String asString(int length) {
-        return asString(length, null);
-    }
-
-    /**
-     * Gets value as unbounded string.
-     *
-     * @param charset charset, null is same as default(UTF-8)
-     * @return string value, could be null
-     */
-    default String asString(Charset charset) {
-        return asString(0, charset);
-    }
-
-    /**
-     * Gets value as fixed length(in bytes) string.
-     *
-     * @param length  byte length of the string, 0 or negative number means
-     *                unbounded
-     * @param charset charset, null is same as default(UTF-8)
-     * @return string value, could be null
-     */
-    default String asString(int length, Charset charset) {
         if (isNullOrEmpty()) {
             return null;
         }
 
-        String str = String.valueOf(asObject());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(asObject());
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseArrayValue.java
@@ -5,8 +5,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
@@ -109,14 +106,8 @@ public class ClickHouseArrayValue<T> extends ClickHouseObjectValue<T[]> implemen
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.deepToString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.deepToString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBoolValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseBoolValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -160,18 +157,12 @@ public class ClickHouseBoolValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseByteValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseByteValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -154,18 +151,12 @@ public class ClickHouseByteValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateTimeValue.java
@@ -2,8 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -13,7 +11,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.TimeZone;
-
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
@@ -226,19 +223,13 @@ public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
         // different formatter for each scale?
-        String str = getValue().format(scale > 0 ? ClickHouseValues.DATETIME_FORMATTER : dateTimeFormatter);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return getValue().format(scale > 0 ? ClickHouseValues.DATETIME_FORMATTER : dateTimeFormatter);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDateValue.java
@@ -2,13 +2,10 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -143,18 +140,12 @@ public class ClickHouseDateValue extends ClickHouseObjectValue<LocalDate> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
-        String str = asDate().format(ClickHouseValues.DATE_FORMATTER);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return asDate().format(ClickHouseValues.DATE_FORMATTER);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseDoubleValue.java
@@ -2,10 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -167,16 +163,12 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
-        String str = String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-        return str;
+
+        return String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseEnumValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseEnumValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseEnum;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
@@ -212,18 +209,12 @@ public class ClickHouseEnumValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = type.name(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return type.name(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseFloatValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -185,18 +182,12 @@ public class ClickHouseFloatValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoMultiPolygonValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoMultiPolygonValue.java
@@ -5,7 +5,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -66,17 +65,16 @@ public class ClickHouseGeoMultiPolygonValue extends ClickHouseObjectValue<double
         return value;
     }
 
-    protected static String convert(double[][][][] value, int length) {
+    protected static String convert(double[][][][] value) {
         StringBuilder builder = new StringBuilder().append('[');
         for (int i = 0, len = value.length; i < len; i++) {
-            builder.append(ClickHouseGeoPolygonValue.convert(value[i], 0)).append(',');
+            builder.append(ClickHouseGeoPolygonValue.convert(value[i])).append(',');
         }
 
         if (builder.length() > 1) {
             builder.setLength(builder.length() - 1);
         }
-        String str = builder.append(']').toString();
-        return length > 0 ? ClickHouseChecker.notWithDifferentLength(str, length) : str;
+        return builder.append(']').toString();
     }
 
     protected ClickHouseGeoMultiPolygonValue(double[][][][] value) {
@@ -145,8 +143,8 @@ public class ClickHouseGeoMultiPolygonValue extends ClickHouseObjectValue<double
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        return convert(getValue(), length);
+    public String asString() {
+        return convert(getValue());
     }
 
     @Override
@@ -172,7 +170,7 @@ public class ClickHouseGeoMultiPolygonValue extends ClickHouseObjectValue<double
 
     @Override
     public String toSqlExpression() {
-        return convert(getValue(), 0);
+        return convert(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPointValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPointValue.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -14,7 +13,6 @@ import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -62,10 +60,9 @@ public class ClickHouseGeoPointValue extends ClickHouseObjectValue<double[]> {
         return value;
     }
 
-    protected static String convert(double[] value, int length) {
-        String str = new StringBuilder().append('(').append(value[0]).append(',').append(value[1]).append(')')
+    protected static String convert(double[] value) {
+        return new StringBuilder().append('(').append(value[0]).append(',').append(value[1]).append(')')
                 .toString();
-        return length > 0 ? ClickHouseChecker.notWithDifferentLength(str, length) : str;
     }
 
     protected ClickHouseGeoPointValue(double[] value) {
@@ -91,8 +88,8 @@ public class ClickHouseGeoPointValue extends ClickHouseObjectValue<double[]> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        return convert(getValue(), length);
+    public String asString() {
+        return convert(getValue());
     }
 
     @Override
@@ -118,7 +115,7 @@ public class ClickHouseGeoPointValue extends ClickHouseObjectValue<double[]> {
 
     @Override
     public String toSqlExpression() {
-        return convert(getValue(), 0);
+        return convert(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPolygonValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoPolygonValue.java
@@ -5,7 +5,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -66,17 +65,16 @@ public class ClickHouseGeoPolygonValue extends ClickHouseObjectValue<double[][][
         return value;
     }
 
-    protected static String convert(double[][][] value, int length) {
+    protected static String convert(double[][][] value) {
         StringBuilder builder = new StringBuilder().append('[');
         for (int i = 0, len = value.length; i < len; i++) {
-            builder.append(ClickHouseGeoRingValue.convert(value[i], 0)).append(',');
+            builder.append(ClickHouseGeoRingValue.convert(value[i])).append(',');
         }
 
         if (builder.length() > 1) {
             builder.setLength(builder.length() - 1);
         }
-        String str = builder.append(']').toString();
-        return length > 0 ? ClickHouseChecker.notWithDifferentLength(str, length) : str;
+        return builder.append(']').toString();
     }
 
     protected ClickHouseGeoPolygonValue(double[][][] value) {
@@ -140,8 +138,8 @@ public class ClickHouseGeoPolygonValue extends ClickHouseObjectValue<double[][][
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        return convert(getValue(), length);
+    public String asString() {
+        return convert(getValue());
     }
 
     @Override
@@ -167,7 +165,7 @@ public class ClickHouseGeoPolygonValue extends ClickHouseObjectValue<double[][][
 
     @Override
     public String toSqlExpression() {
-        return convert(getValue(), 0);
+        return convert(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoRingValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseGeoRingValue.java
@@ -5,7 +5,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -66,17 +65,16 @@ public class ClickHouseGeoRingValue extends ClickHouseObjectValue<double[][]> {
         return value;
     }
 
-    protected static String convert(double[][] value, int length) {
+    protected static String convert(double[][] value) {
         StringBuilder builder = new StringBuilder().append('[');
         for (int i = 0, len = value.length; i < len; i++) {
-            builder.append(ClickHouseGeoPointValue.convert(value[i], 0)).append(',');
+            builder.append(ClickHouseGeoPointValue.convert(value[i])).append(',');
         }
 
         if (builder.length() > 1) {
             builder.setLength(builder.length() - 1);
         }
-        String str = builder.append(']').toString();
-        return length > 0 ? ClickHouseChecker.notWithDifferentLength(str, length) : str;
+        return builder.append(']').toString();
     }
 
     protected ClickHouseGeoRingValue(double[][] value) {
@@ -136,8 +134,8 @@ public class ClickHouseGeoRingValue extends ClickHouseObjectValue<double[][]> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        return convert(getValue(), length);
+    public String asString() {
+        return convert(getValue());
     }
 
     @Override
@@ -164,7 +162,7 @@ public class ClickHouseGeoRingValue extends ClickHouseObjectValue<double[][]> {
 
     @Override
     public String toSqlExpression() {
-        return convert(getValue(), 0);
+        return convert(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseInstantValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseInstantValue.java
@@ -2,8 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -11,7 +9,6 @@ import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZonedDateTime;
 import java.util.TimeZone;
-
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
@@ -220,20 +217,14 @@ public class ClickHouseInstantValue extends ClickHouseObjectValue<Instant> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
         // different formatter for each scale?
-        String str = asDateTime()
+        return asDateTime()
                 .format(scale > 0 ? ClickHouseValues.DATETIME_FORMATTER : ClickHouseDateTimeValue.dateTimeFormatter);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIntegerValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIntegerValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -144,18 +141,12 @@ public class ClickHouseIntegerValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv4Value.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv4Value.java
@@ -6,14 +6,11 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -147,18 +144,12 @@ public class ClickHouseIpv4Value extends ClickHouseObjectValue<Inet4Address> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
-        String str = String.valueOf(getValue().getHostAddress());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(getValue().getHostAddress());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv6Value.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseIpv6Value.java
@@ -6,14 +6,11 @@ import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.UUID;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -147,18 +144,12 @@ public class ClickHouseIpv6Value extends ClickHouseObjectValue<Inet6Address> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
-        String str = String.valueOf(getValue().getHostAddress());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(getValue().getHostAddress());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseLongValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseLongValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -171,18 +168,12 @@ public class ClickHouseLongValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = unsigned && value < 0L ? asBigInteger().toString() : String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return unsigned && value < 0L ? asBigInteger().toString() : String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseMapValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseMapValue.java
@@ -4,7 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -138,7 +137,7 @@ public class ClickHouseMapValue extends ClickHouseObjectValue<Map<?, ?>> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         Map<?, ?> value = getValue();
         if (value == null || value.isEmpty()) {
             return "{}";
@@ -149,8 +148,7 @@ public class ClickHouseMapValue extends ClickHouseObjectValue<Map<?, ?>> {
         }
         builder.setLength(builder.length() - 1);
 
-        String str = builder.append('}').toString();
-        return length > 0 ? ClickHouseChecker.notWithDifferentLength(str, length) : str;
+        return builder.append('}').toString();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseNestedValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseNestedValue.java
@@ -5,8 +5,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -177,14 +175,8 @@ public class ClickHouseNestedValue extends ClickHouseObjectValue<Object[][]> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.deepToString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.deepToString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseObjectValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseObjectValue.java
@@ -2,10 +2,7 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -115,18 +112,12 @@ public abstract class ClickHouseObjectValue<T> implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
-        String str = value.toString();
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return value.toString();
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseOffsetDateTimeValue.java
@@ -2,8 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -12,7 +10,6 @@ import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.TimeZone;
-
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
@@ -211,20 +208,14 @@ public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetD
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNullOrEmpty()) {
             return null;
         }
 
         // different formatter for each scale?
-        String str = asDateTime(scale)
+        return asDateTime(scale)
                 .format(scale > 0 ? ClickHouseValues.DATETIME_FORMATTER : ClickHouseDateTimeValue.dateTimeFormatter);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(
-                    str.getBytes(charset == null ? StandardCharsets.US_ASCII : charset), length);
-        }
-
-        return str;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessor.java
@@ -256,7 +256,7 @@ public class ClickHouseRowBinaryProcessor extends ClickHouseDataProcessor {
             // string and uuid
             buildMappings(deserializers, serializers,
                     (r, f, c, i) -> ClickHouseStringValue.of(r, i.readBytes(c.getPrecision())),
-                    (v, f, c, o) -> o.write(v.asBinary(c.getPrecision())), ClickHouseDataType.FixedString);
+                    (v, f, c, o) -> o.writeBytes(v.asBinary(c.getPrecision())), ClickHouseDataType.FixedString);
             buildMappings(deserializers, serializers,
                     (r, f, c, i) -> ClickHouseStringValue.of(r, i.readBytes(i.readVarInt())),
                     (v, f, c, o) -> BinaryStreamUtils.writeString(o, v.asBinary()), ClickHouseDataType.String,

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseShortValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseShortValue.java
@@ -2,9 +2,6 @@ package com.clickhouse.client.data;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -154,18 +151,12 @@ public class ClickHouseShortValue implements ClickHouseValue {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
+    public String asString() {
         if (isNull) {
             return null;
         }
 
-        String str = String.valueOf(value);
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+        return String.valueOf(value);
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStringValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStringValue.java
@@ -12,7 +12,6 @@ import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.Objects;
 import java.util.UUID;
-import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseValue;
 import com.clickhouse.client.ClickHouseValues;
 
@@ -222,33 +221,21 @@ public class ClickHouseStringValue implements ClickHouseValue {
 
     @Override
     public byte[] asBinary(int length, Charset charset) {
-        if (value != null && bytes == null) {
-            bytes = value.getBytes(charset == null ? StandardCharsets.UTF_8 : charset);
+        byte[] b = bytes;
+        if (value != null && b == null) {
+            bytes = b = value.getBytes(charset == null ? StandardCharsets.UTF_8 : charset);
         }
 
-        if (bytes != null && length > 0) {
-            return ClickHouseChecker.notWithDifferentLength(bytes, length);
-        } else {
-            return bytes;
+        if (b != null && b.length < length) {
+            b = Arrays.copyOf(b, length);
         }
+        return b;
     }
 
     @Override
     public String asString() {
         if (bytes != null && value == null) {
             value = new String(bytes, StandardCharsets.UTF_8);
-        }
-
-        return value;
-    }
-
-    @Override
-    public String asString(int length, Charset charset) {
-        if (value != null && length > 0) {
-            if (bytes == null) {
-                bytes = value.getBytes(charset == null ? StandardCharsets.UTF_8 : charset);
-            }
-            ClickHouseChecker.notWithDifferentLength(bytes, length);
         }
 
         return value;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTupleValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseTupleValue.java
@@ -5,8 +5,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -137,14 +135,8 @@ public class ClickHouseTupleValue extends ClickHouseObjectValue<List<Object>> {
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.deepToString(asArray());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.deepToString(asArray());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseByteArrayValue.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
@@ -122,14 +119,8 @@ public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> impl
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.toString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.toString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseDoubleArrayValue.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
@@ -114,14 +111,8 @@ public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> 
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.toString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.toString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseFloatArrayValue.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
@@ -114,14 +111,8 @@ public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> im
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.toString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.toString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseIntArrayValue.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
@@ -114,14 +111,8 @@ public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> implem
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.toString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.toString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseLongArrayValue.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
@@ -127,14 +124,8 @@ public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> impl
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.toString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.toString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/array/ClickHouseShortArrayValue.java
@@ -4,8 +4,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -19,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.Map.Entry;
-
 import com.clickhouse.client.ClickHouseArraySequence;
 import com.clickhouse.client.ClickHouseChecker;
 import com.clickhouse.client.ClickHouseUtils;
@@ -114,14 +111,8 @@ public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> im
     }
 
     @Override
-    public String asString(int length, Charset charset) {
-        String str = Arrays.toString(getValue());
-        if (length > 0) {
-            ClickHouseChecker.notWithDifferentLength(str.getBytes(charset == null ? StandardCharsets.UTF_8 : charset),
-                    length);
-        }
-
-        return str;
+    public String asString() {
+        return Arrays.toString(getValue());
     }
 
     @Override

--- a/clickhouse-client/src/test/java/com/clickhouse/client/BaseClickHouseValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/BaseClickHouseValueTest.java
@@ -1,6 +1,5 @@
 package com.clickhouse.client;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -79,19 +78,11 @@ public abstract class BaseClickHouseValueTest {
             Assert.assertNull(v.asObject());
             Assert.assertNull(v.asObject(Object.class));
             Assert.assertNull(v.asString());
-            Assert.assertNull(v.asString(StandardCharsets.UTF_16));
-            Assert.assertNull(v.asString(1));
-            Assert.assertNull(v.asString(1, StandardCharsets.UTF_16));
             Assert.assertEquals(v.toSqlExpression(), ClickHouseValues.NULL_EXPR);
         } else {
             Assert.assertNotNull(v.asObject());
             Assert.assertNotNull(v.asObject(Object.class));
             Assert.assertNotNull(v.asString());
-            Assert.assertNotNull(v.asString(StandardCharsets.UTF_16));
-            Assert.assertNotNull(v.asString(v.asString().length()));
-            Assert.assertNotNull(
-                    v.asString(v.asString(StandardCharsets.UTF_16).getBytes(StandardCharsets.UTF_16).length,
-                            StandardCharsets.UTF_16));
             Assert.assertNotNull(v.toSqlExpression());
             Assert.assertNotEquals(v.toSqlExpression(), ClickHouseValues.NULL_EXPR);
         }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseCheckerTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseCheckerTest.java
@@ -108,19 +108,4 @@ public class ClickHouseCheckerTest {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> ClickHouseChecker.notLongerThan(new byte[2], null, 1));
     }
-
-    @Test(groups = { "unit" })
-    public void testNotWithDifferentLength() {
-        byte[] bytes;
-        Assert.assertEquals(ClickHouseChecker.notWithDifferentLength(bytes = null, "value", 0), bytes);
-        Assert.assertEquals(ClickHouseChecker.notWithDifferentLength(bytes = new byte[0], "value", 0), bytes);
-        Assert.assertEquals(ClickHouseChecker.notWithDifferentLength(bytes = new byte[1], "value", 1), bytes);
-
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> ClickHouseChecker.notWithDifferentLength((byte[]) null, null, -1));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> ClickHouseChecker.notWithDifferentLength(new byte[0], null, -1));
-        Assert.assertThrows(IllegalArgumentException.class,
-                () -> ClickHouseChecker.notWithDifferentLength(new byte[2], null, 1));
-    }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -1084,7 +1084,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
             }).executeAndWait()) {
                 Assert.fail("Should fail to insert because the string was too long");
             } catch (ClickHouseException e) {
-                Assert.assertEquals(e.getErrorCode(), 33);
+                Assert.assertTrue(e.getErrorCode() >= 33);
             }
             try (ClickHouseResponse resp = req.copy().query("select b from test_write_fixed_string order by a")
                     .executeAndWait()) {

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseStringValueTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseStringValueTest.java
@@ -68,7 +68,9 @@ public class ClickHouseStringValueTest extends BaseClickHouseValueTest {
         Assert.assertEquals(ClickHouseStringValue.of(new byte[0]).asBinary(0), new byte[0]);
         Assert.assertEquals(ClickHouseStringValue.of("").asBinary(0), new byte[0]);
 
-        Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseStringValue.of("").asBinary(1));
+        Assert.assertEquals(ClickHouseStringValue.of("").asBinary(1), new byte[] { 0 });
+        Assert.assertEquals(ClickHouseStringValue.of("ab").asBinary(1), new byte[] { 97, 98 });
+        Assert.assertEquals(ClickHouseStringValue.of("ab").asBinary(5), new byte[] { 97, 98, 0, 0, 0 });
 
         Assert.assertEquals(ClickHouseStringValue.of("a").asBinary(1), new byte[] { 97 });
         Assert.assertEquals(ClickHouseStringValue.of("a").asBinary(0), new byte[] { 97 });


### PR DESCRIPTION
Fixes #1090

BREAKING CHANGES:
* Removed `asString(int)`, `asString(Charset)`, `asString(int, Charset)` methods from all ClickHouse*Value classes
* Removed byte array check methods from ClickHouseChecker