### PR TITLE
Bug fix: inserting Array of nullable primitive

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessor.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessor.java
@@ -43,7 +43,7 @@ public class ClickHouseRowBinaryProcessor extends ClickHouseDataProcessor {
             ClickHouseColumn baseColumn = column.getArrayBaseColumn();
             int level = column.getArrayNestedLevel();
             Class<?> javaClass = baseColumn.getPrimitiveClass();
-            if (level > 1 || !javaClass.isPrimitive()) {
+            if (level > 1 || !javaClass.isPrimitive() || baseColumn.isNullable()) {
                 Object[] array = value.asArray();
                 ClickHouseValue v = ClickHouseValues.newValue(config, nestedColumn);
                 int length = array.length;

--- a/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessorTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/data/ClickHouseRowBinaryProcessorTest.java
@@ -129,6 +129,14 @@ public class ClickHouseRowBinaryProcessorTest {
         out.flush();
         Assert.assertEquals(bas.toByteArray(), BinaryStreamUtilsTest.generateBytes(2, 1, 2));
 
+        value = ClickHouseArrayValue.of(new Short[]{1, 2, null});
+        bas = new ByteArrayOutputStream();
+        out = ClickHouseOutputStream.of(bas);
+        ClickHouseRowBinaryProcessor.getMappedFunctions().serialize(value, config,
+                ClickHouseColumn.of("a", "Array(Nullable(UInt8))"), out);
+        out.flush();
+        Assert.assertEquals(bas.toByteArray(), BinaryStreamUtilsTest.generateBytes(3, 0, 1, 0, 2, 1));
+
         value = ClickHouseByteArrayValue.of(new byte[] { 1, 2 });
         bas = new ByteArrayOutputStream();
         out = ClickHouseOutputStream.of(bas);


### PR DESCRIPTION
Description:
Unable to insert the data into array of nullables

E.g.
```sql
CREATE TABLE default.t
(
    `a` Int8,
    `arr` Array(Nullable(Int8))
)
ENGINE = MergeTree
ORDER BY a
```

Trying to push an array(Scala code):
```scala
    val driver = new ClickHouseDriver()
    val connection = driver.connect("jdbc:clickhouse://localhost:8123", new Properties())
    val statement = connection.prepareStatement("insert into default.t (a, arr) values (?, ?)")

    val a = Array(1.toByte, 2.toByte, null).map(_.asInstanceOf[AnyRef])
    val arr = connection.createArrayOf("Array(Nullable(Int8))", a)

    statement.setByte(1, 1.toByte)
    statement.setArray(2, arr)
    statement.addBatch()
    statement.executeBatch()

    connection.close()
```
Error:
```
class [Ljava.lang.Object; cannot be cast to class [B ([Ljava.lang.Object; and [B are in module java.base of loader 'bootstrap')
java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [B ([Ljava.lang.Object; and [B are in module java.base of loader 'bootstrap')
	at com.clickhouse.client.data.ClickHouseRowBinaryProcessor$MappedFunctions.writeArray(ClickHouseRowBinaryProcessor.java:57)
	at com.clickhouse.client.data.ClickHouseRowBinaryProcessor$MappedFunctions.serialize(ClickHouseRowBinaryProcessor.java:486)
	at com.clickhouse.jdbc.internal.InputBasedPreparedStatement.addBatch(InputBasedPreparedStatement.java:333)
	at com.blackmorse.spark.clickhouse.types.Int8Tests.$anonfun$new$4(Int8Tests.scala:37)
...
```

Reason:
 when using (e.g) `Array(Nullable(Int8))` type, `ClickHouseArrayValue` but `ClickHouseRowBinaryProcessor` still expects `ClickHouseByteArrayValue`. 