### PR TITLE
Add stream-based prepared statemenet

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseOutputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseOutputStream.java
@@ -149,7 +149,7 @@ public abstract class ClickHouseOutputStream extends OutputStream {
     protected final ClickHouseFile file;
     protected final Runnable postCloseAction;
 
-    protected boolean closed;
+    protected volatile boolean closed;
 
     protected ClickHouseOutputStream(ClickHouseFile file, Runnable postCloseAction) {
         this.file = file != null ? file : ClickHouseFile.NULL;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseSimpleResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseSimpleResponse.java
@@ -122,7 +122,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
     private final List<ClickHouseRecord> records;
     private final ClickHouseResponseSummary summary;
 
-    private boolean isClosed;
+    private volatile boolean closed;
 
     protected ClickHouseSimpleResponse(List<ClickHouseColumn> columns, List<ClickHouseRecord> records,
             ClickHouseResponseSummary summary) {
@@ -169,11 +169,11 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
     @Override
     public void close() {
         // nothing to close
-        isClosed = true;
+        closed = true;
     }
 
     @Override
     public boolean isClosed() {
-        return isClosed;
+        return closed;
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStreamResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/data/ClickHouseStreamResponse.java
@@ -60,7 +60,7 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
     protected final List<ClickHouseColumn> columns;
     protected final ClickHouseResponseSummary summary;
 
-    private boolean closed;
+    private volatile boolean closed;
 
     protected ClickHouseStreamResponse(ClickHouseConfig config, ClickHouseInputStream input,
             Map<String, Serializable> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)

--- a/clickhouse-client/src/main/java/com/clickhouse/client/stream/RestrictedInputStream.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/stream/RestrictedInputStream.java
@@ -1,0 +1,141 @@
+package com.clickhouse.client.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.LinkedList;
+
+import com.clickhouse.client.ClickHouseByteBuffer;
+import com.clickhouse.client.ClickHouseChecker;
+import com.clickhouse.client.ClickHouseDataUpdater;
+import com.clickhouse.client.ClickHouseFile;
+import com.clickhouse.client.ClickHouseOutputStream;
+import com.clickhouse.client.ClickHouseUtils;
+import com.clickhouse.client.config.ClickHouseClientOption;
+
+/**
+ * Wrapper of {@link java.io.InputStream} with length limitation. Unlike
+ * {@link WrappedInputStream}, the inner input stream remains open after calling
+ * close().
+ */
+public class RestrictedInputStream extends AbstractByteArrayInputStream {
+    private final InputStream in;
+
+    private long length;
+
+    @Override
+    protected int updateBuffer() throws IOException {
+        position = 0;
+
+        if (closed) {
+            return limit = 0;
+        }
+
+        int len = buffer.length;
+        if (this.length < len) {
+            len = (int) this.length;
+        }
+
+        int off = 0;
+        while (len > 0) {
+            int read = in.read(buffer, off, len);
+            if (read == -1) {
+                break;
+            } else {
+                off += read;
+                len -= read;
+            }
+        }
+        if (copyTo != null) {
+            copyTo.write(buffer, 0, off);
+        }
+        this.length -= off;
+        return limit = off;
+    }
+
+    public RestrictedInputStream(ClickHouseFile file, InputStream input, int bufferSize, long length,
+            Runnable postCloseAction) {
+        super(file, null, postCloseAction);
+
+        this.in = ClickHouseChecker.nonNull(input, "InputStream");
+        // fixed buffer
+        this.buffer = new byte[ClickHouseUtils.getBufferSize(bufferSize,
+                (int) ClickHouseClientOption.BUFFER_SIZE.getDefaultValue(),
+                (int) ClickHouseClientOption.MAX_BUFFER_SIZE.getDefaultValue())];
+
+        this.length = ClickHouseChecker.notLessThan(length, "Length", 0L);
+
+        this.position = 0;
+        this.limit = 0;
+    }
+
+    @Override
+    public ClickHouseByteBuffer readCustom(ClickHouseDataUpdater reader) throws IOException {
+        if (reader == null) {
+            return byteBuffer.reset();
+        }
+        ensureOpen();
+
+        LinkedList<byte[]> list = new LinkedList<>();
+        int offset = position;
+        int len = 0;
+        boolean more = true;
+        while (more) {
+            int remain = limit - position;
+            if (remain < 1) {
+                closeQuietly();
+                more = false;
+            } else {
+                int read = reader.update(buffer, position, limit);
+                if (read == -1) {
+                    byte[] bytes = new byte[limit];
+                    System.arraycopy(buffer, position, bytes, position, remain);
+                    len += remain;
+                    position = limit;
+                    list.add(bytes);
+                    if (updateBuffer() < 1) {
+                        closeQuietly();
+                        more = false;
+                    }
+                } else {
+                    len += read;
+                    position += read;
+                    list.add(buffer);
+                    more = false;
+                }
+            }
+        }
+        return byteBuffer.update(list, offset, len);
+    }
+
+    @Override
+    public long pipe(ClickHouseOutputStream output) throws IOException {
+        long count = 0L;
+        if (output == null || output.isClosed()) {
+            return count;
+        }
+        ensureOpen();
+
+        try {
+            int l = limit;
+            int p = position;
+            int remain = l - p;
+            if (remain > 0) {
+                output.writeBytes(buffer, p, remain);
+                count += remain;
+                position = l;
+            }
+
+            while ((remain = updateBuffer()) > 0) {
+                output.writeBytes(buffer, 0, remain);
+                count += remain;
+            }
+        } finally {
+            close();
+        }
+        return count;
+    }
+
+    public final long getRemaining() {
+        return length;
+    }
+}

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHousePreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHousePreparedStatement.java
@@ -20,6 +20,7 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.sql.Types;
 
+import com.clickhouse.client.ClickHouseInputStream;
 import com.clickhouse.client.data.BinaryStreamUtils;
 
 public interface ClickHousePreparedStatement extends PreparedStatement {
@@ -167,7 +168,7 @@ public interface ClickHousePreparedStatement extends PreparedStatement {
 
     @Override
     default void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
-        throw SqlExceptionUtils.unsupportedError("setBinaryStream not implemented");
+        setBinaryStream(parameterIndex, length < 0L ? x : ClickHouseInputStream.wrap(x, 0, length, null));
     }
 
     @Override
@@ -182,12 +183,12 @@ public interface ClickHousePreparedStatement extends PreparedStatement {
 
     @Override
     default void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-        setBinaryStream(parameterIndex, x, 0L);
+        throw SqlExceptionUtils.unsupportedError("setBinaryStream not implemented");
     }
 
     @Override
     default void setCharacterStream(int parameterIndex, Reader reader) throws SQLException {
-        setCharacterStream(parameterIndex, reader, 0L);
+        setCharacterStream(parameterIndex, reader, -1L);
     }
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/StreamBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/StreamBasedPreparedStatement.java
@@ -1,0 +1,338 @@
+package com.clickhouse.jdbc.internal;
+
+import java.io.File;
+import java.io.InputStream;
+import java.math.BigDecimal;
+import java.sql.Array;
+import java.sql.Date;
+import java.sql.ParameterMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+import com.clickhouse.client.ClickHouseClient;
+import com.clickhouse.client.ClickHouseColumn;
+import com.clickhouse.client.ClickHouseDataStreamFactory;
+import com.clickhouse.client.ClickHouseDataType;
+import com.clickhouse.client.ClickHouseInputStream;
+import com.clickhouse.client.ClickHouseOutputStream;
+import com.clickhouse.client.ClickHousePipedOutputStream;
+import com.clickhouse.client.ClickHouseRequest;
+import com.clickhouse.client.ClickHouseValues;
+import com.clickhouse.client.ClickHouseWriter;
+import com.clickhouse.client.logging.Logger;
+import com.clickhouse.client.logging.LoggerFactory;
+import com.clickhouse.jdbc.ClickHousePreparedStatement;
+import com.clickhouse.jdbc.SqlExceptionUtils;
+import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
+
+public class StreamBasedPreparedStatement extends AbstractPreparedStatement implements ClickHousePreparedStatement {
+    private static final Logger log = LoggerFactory.getLogger(StreamBasedPreparedStatement.class);
+
+    private static final String ERROR_SET_PARAM = "Please use setString()/setBytes()/setInputStream() or pass String/InputStream/ClickHouseInputStream to setObject() method instead";
+    private static final String DEFAULT_KEY = "pipe";
+    private static final List<ClickHouseColumn> DEFAULT_PARAMS = Collections
+            .singletonList(ClickHouseColumn.of("data", ClickHouseDataType.String, false));
+
+    private final ClickHouseSqlStatement parsedStmt;
+    private final ClickHouseParameterMetaData paramMetaData;
+
+    private final List<ClickHouseInputStream> batch;
+
+    private ClickHouseInputStream value;
+
+    protected StreamBasedPreparedStatement(ClickHouseConnectionImpl connection, ClickHouseRequest<?> request,
+            ClickHouseSqlStatement parsedStmt, int resultSetType, int resultSetConcurrency, int resultSetHoldability)
+            throws SQLException {
+        super(connection, request, resultSetType, resultSetConcurrency, resultSetHoldability);
+
+        this.parsedStmt = parsedStmt;
+        this.value = null;
+        paramMetaData = new ClickHouseParameterMetaData(DEFAULT_PARAMS, mapper, connection.getTypeMap());
+        batch = new LinkedList<>();
+    }
+
+    protected void ensureParams() throws SQLException {
+        if (value == null) {
+            throw SqlExceptionUtils.clientError("Missing input stream");
+        }
+    }
+
+    @Override
+    protected long[] executeAny(boolean asBatch) throws SQLException {
+        ensureOpen();
+        boolean continueOnError = false;
+        if (asBatch) {
+            if (batch.isEmpty()) {
+                return ClickHouseValues.EMPTY_LONG_ARRAY;
+            }
+            continueOnError = getConnection().getJdbcConfig().isContinueBatchOnError();
+        } else {
+            try {
+                if (!batch.isEmpty()) {
+                    throw SqlExceptionUtils.undeterminedExecutionError();
+                }
+                addBatch();
+            } catch (SQLException e) {
+                clearBatch();
+                throw e;
+            }
+        }
+
+        long[] results = new long[batch.size()];
+        int count = 0;
+        String sql = getRequest().getStatements(false).get(0);
+        try {
+            for (ClickHouseInputStream in : batch) {
+                @SuppressWarnings("unchecked")
+                final CompletableFuture<Boolean> future = (CompletableFuture<Boolean>) in.removeUserData(DEFAULT_KEY);
+                results[count++] = executeInsert(sql, in);
+                if (future != null) {
+                    future.get();
+                }
+            }
+        } catch (Exception e) {
+            if (!asBatch) {
+                throw SqlExceptionUtils.handle(e);
+            }
+
+            if (!continueOnError) {
+                throw SqlExceptionUtils.batchUpdateError(e, results);
+            }
+            log.error("Failed to execute batch insert of %d records", count + 1, e);
+        } finally {
+            clearBatch();
+        }
+
+        return results;
+    }
+
+    @Override
+    protected int getMaxParameterIndex() {
+        return 1;
+    }
+
+    protected String getSql() {
+        // why? because request can be modified so it might not always same as
+        // parsedStmt.getSQL()
+        return getRequest().getStatements(false).get(0);
+    }
+
+    @Override
+    public ResultSet executeQuery() throws SQLException {
+        ensureParams();
+        try {
+            executeAny(false);
+        } catch (SQLException e) {
+            if (e.getSQLState() != null) {
+                throw e;
+            } else {
+                throw new SQLException("Query failed", SqlExceptionUtils.SQL_STATE_SQL_ERROR, e.getCause());
+            }
+        }
+
+        ResultSet rs = getResultSet();
+        if (rs != null) { // should not happen
+            try {
+                rs.close();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        return newEmptyResultSet();
+    }
+
+    @Override
+    public long executeLargeUpdate() throws SQLException {
+        ensureParams();
+        try {
+            executeAny(false);
+        } catch (SQLException e) {
+            if (e.getSQLState() != null) {
+                throw e;
+            } else {
+                throw new SQLException("Update failed", SqlExceptionUtils.SQL_STATE_SQL_ERROR, e.getCause());
+            }
+        }
+        long row = getLargeUpdateCount();
+        return row > 0L ? row : 0L;
+    }
+
+    @Override
+    public void setByte(int parameterIndex, byte x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setShort(int parameterIndex, short x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setInt(int parameterIndex, int x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setLong(int parameterIndex, long x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setFloat(int parameterIndex, float x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setDouble(int parameterIndex, double x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String x) throws SQLException {
+        ensureOpen();
+
+        value = ClickHouseInputStream.of(x);
+    }
+
+    @Override
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+        ensureOpen();
+
+        value = ClickHouseInputStream.of(x);
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+        ensureOpen();
+
+        value = ClickHouseInputStream.of(x);
+    }
+
+    @Override
+    public void clearParameters() throws SQLException {
+        ensureOpen();
+
+        value = null;
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x) throws SQLException {
+        ensureOpen();
+
+        if (x instanceof ClickHouseWriter) {
+            final ClickHouseWriter writer = (ClickHouseWriter) x;
+            final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
+                    .createPipedOutputStream(getConfig(), null);
+            value = stream.getInputStream();
+
+            // always run in async mode or it will not work
+            value.setUserData(DEFAULT_KEY, ClickHouseClient.submit(() -> {
+                try (ClickHouseOutputStream out = stream) {
+                    writer.write(out);
+                }
+                return true;
+            }));
+        } else if (x instanceof InputStream) {
+            value = ClickHouseInputStream.of((InputStream) x);
+        } else if (x instanceof String) {
+            value = ClickHouseInputStream.of((String) x);
+        } else if (x instanceof byte[]) {
+            value = ClickHouseInputStream.of((byte[]) x);
+        } else if (x instanceof File) {
+            value = ClickHouseInputStream.of((File) x);
+        } else {
+            throw SqlExceptionUtils
+                    .clientError("Only byte[], String, File, InputStream and ClickHouseWriter are supported");
+        }
+    }
+
+    @Override
+    public boolean execute() throws SQLException {
+        ensureParams();
+        if (!batch.isEmpty()) {
+            throw SqlExceptionUtils.undeterminedExecutionError();
+        }
+
+        final String sql = getSql();
+        @SuppressWarnings("unchecked")
+        final CompletableFuture<Boolean> future = (CompletableFuture<Boolean>) value.removeUserData(DEFAULT_KEY);
+        executeInsert(sql, value);
+        if (future != null) {
+            try {
+                future.get();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Execution of query was interrupted: %s", sql);
+            } catch (ExecutionException e) {
+                throw SqlExceptionUtils.handle(e.getCause());
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void addBatch() throws SQLException {
+        ensureOpen();
+
+        ensureParams();
+        batch.add(value);
+        clearParameters();
+    }
+
+    @Override
+    public void clearBatch() throws SQLException {
+        ensureOpen();
+
+        this.batch.clear();
+    }
+
+    @Override
+    public void setArray(int parameterIndex, Array x) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+        throw SqlExceptionUtils.clientError(ERROR_SET_PARAM);
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+        ensureOpen();
+
+        value = ClickHouseInputStream.empty();
+    }
+
+    @Override
+    public ParameterMetaData getParameterMetaData() throws SQLException {
+        return paramMetaData;
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+        setObject(parameterIndex, x);
+    }
+}

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -1586,6 +1586,11 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     public void testInsertWithFormat() throws SQLException {
         Properties props = new Properties();
         try (ClickHouseConnection conn = newConnection(props); Statement s = conn.createStatement()) {
+            if (!conn.getServerVersion().check("[22.5,)")) {
+                throw new SkipException(
+                        "Skip due to breaking change introduced by https://github.com/ClickHouse/ClickHouse/pull/35883");
+            }
+
             s.execute("drop table if exists test_insert_with_format; "
                     + "CREATE TABLE test_insert_with_format(i Int32, s String) ENGINE=Memory");
             try (PreparedStatement ps = conn.prepareStatement("INSERT INTO test_insert_with_format format CSV")) {
@@ -1604,11 +1609,6 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                 Assert.assertEquals(rs.getInt(1), 2);
                 Assert.assertEquals(rs.getString(2), "two");
                 Assert.assertFalse(rs.next());
-            }
-
-            if (!conn.getServerVersion().check("[22.5,)")) {
-                throw new SkipException(
-                        "Skip due to breaking change introduced by https://github.com/ClickHouse/ClickHouse/pull/35883");
             }
 
             s.execute("truncate table test_insert_with_format");

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -1606,6 +1606,11 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                 Assert.assertFalse(rs.next());
             }
 
+            if (!conn.getServerVersion().check("[22.5,)")) {
+                throw new SkipException(
+                        "Skip due to breaking change introduced by https://github.com/ClickHouse/ClickHouse/pull/35883");
+            }
+
             s.execute("truncate table test_insert_with_format");
 
             try (PreparedStatement ps = conn


### PR DESCRIPTION
Take format clause as hint for stream-based insertion.

```java
try (PreparedStatement ps = conn.preparedStatement("insert into mytable(col1,col2,col3) format CSV")) {
  ps.setString(1, "1,2,3");
  ps.addBatch();
  ps.setBinaryStream(1, new ByteArrayInputStream("4,5,6".getBytes()));
  ps.addBatch();
  ps.setObject(1, new ClickHouseWriter() { // callback runs in a separate worker thread
      @Override
      public void write(ClickHouseOutputStream out) throws IOException {
          out.write("7,8,9".getBytes());
      }
  });
  ps.addBatch();
  ps.setObject(1, new File("/tmp/my.csv"));
  ps.addBatch();
  ps.executeBatch();
}
```