### PR TITLE
`isReusable` should return a constant value

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -218,7 +218,7 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
 
     @Override
     protected boolean isReusable() {
-        return !isBusy.get();
+        return true;
     }
 
     protected ClickHouseHttpResponse post(String sql, ClickHouseInputStream data, List<ClickHouseExternalTable> tables,


### PR DESCRIPTION
`isReusable` should return a constant value.
Or  `ClickHouseHttpClient` may close on flying connection when creating new connection.

[        if (connection != null && connection.isReusable()) {
            closeConnection(connection, false);
        }](https://github.com/ClickHouse/clickhouse-jdbc/blob/60b8ca8646ca981986c7263d5b19a668dcb94c5c/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java#L51-L53)