### PR TITLE
clean up code and remove unnecessary dependency

### DIFF
--- a/clickhouse-benchmark/src/main/java/com/clickhouse/benchmark/misc/QueueBenchmark.java
+++ b/clickhouse-benchmark/src/main/java/com/clickhouse/benchmark/misc/QueueBenchmark.java
@@ -76,8 +76,8 @@ public class QueueBenchmark {
         // options.put(ClickHouseClientOption.SOCKET_TIMEOUT, 0);
         options.put(ClickHouseClientOption.USE_BLOCKING_QUEUE, false);
         final ClickHouseConfig config = new ClickHouseConfig(options);
-        final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance().createPipedOutputStream(
-                config, null);
+        final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
+                .createPipedOutputStream(config);
         CompletableFuture<Long> future = ClickHouseClient.submit(() -> {
             long range = state.samples;
             try (ClickHouseOutputStream out = stream) {
@@ -99,8 +99,8 @@ public class QueueBenchmark {
     public void nonBlocking(CompareState state, Blackhole consumer) throws Exception {
         final ClickHouseConfig config = new ClickHouseConfig(Collections
                 .singletonMap(ClickHouseClientOption.RESPONSE_BUFFERING, ClickHouseBufferingMode.PERFORMANCE));
-        final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance().createPipedOutputStream(
-                config, null);
+        final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
+                .createPipedOutputStream(config);
         CompletableFuture<Long> future = ClickHouseClient.submit(() -> {
             long range = state.samples;
             try (ClickHouseOutputStream out = stream) {

--- a/clickhouse-client/pom.xml
+++ b/clickhouse-client/pom.xml
@@ -43,11 +43,12 @@
             <groupId>dnsjava</groupId>
             <artifactId>dnsjava</artifactId>
             <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/clickhouse-client/src/main/java/com/clickhouse/client/AbstractSocketClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/AbstractSocketClient.java
@@ -432,7 +432,7 @@ public class AbstractSocketClient implements AutoCloseable {
         }
 
         ClickHousePipedOutputStream responeStream = ClickHouseDataStreamFactory.getInstance()
-                .createPipedOutputStream(ClickHouseChecker.nonNull(config, ClickHouseConfig.TYPE_NAME), null);
+                .createPipedOutputStream(ClickHouseChecker.nonNull(config, ClickHouseConfig.TYPE_NAME));
         processRequest(config, rawRequest, responeStream);
         return responeStream.getInputStream();
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -90,7 +90,7 @@ public interface ClickHouseClient extends AutoCloseable {
             Runnable postCloseAction) {
         if (config == null) {
             return ClickHouseOutputStream.of(output, (int) ClickHouseClientOption.BUFFER_SIZE.getDefaultValue(),
-                    ClickHouseCompression.NONE, -1, postCloseAction);
+                    ClickHouseCompression.NONE, ClickHouseConfig.DEFAULT_READ_COMPRESS_LEVEL, postCloseAction);
         }
 
         return ClickHouseOutputStream.of(output, config.getWriteBufferSize(), config.getRequestCompressAlgorithm(),

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -515,9 +515,8 @@ public interface ClickHouseClient extends AutoCloseable {
 
         return submit(() -> {
             try (ClickHouseClient client = newInstance(theServer.getProtocol());
-                    ClickHouseResponse response = client.connect(theServer).write().table(table)
-                            .decompressClientRequest(compression).format(format).data(writer)
-                            .executeAndWait()) {
+                    ClickHouseResponse response = client.connect(theServer).write().table(table).data(writer)
+                            .decompressClientRequest(compression).format(format).executeAndWait()) {
                 return response.getSummary();
             }
         });
@@ -611,8 +610,8 @@ public interface ClickHouseClient extends AutoCloseable {
 
         return submit(() -> {
             try (ClickHouseClient client = newInstance(theServer.getProtocol());
-                    ClickHouseResponse response = client.connect(theServer).write().table(table)
-                            .decompressClientRequest(compression).format(format).data(input).executeAndWait()) {
+                    ClickHouseResponse response = client.connect(theServer).write().table(table).data(input)
+                            .decompressClientRequest(compression).format(format).executeAndWait()) {
                 return response.getSummary();
             } finally {
                 try {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.clickhouse.client.ClickHouseNode.Status;
 import com.clickhouse.data.ClickHouseChecker;
+import com.clickhouse.data.ClickHouseDataStreamFactory;
 import com.clickhouse.data.ClickHouseUtils;
 
 /**
@@ -336,7 +337,7 @@ public abstract class ClickHouseLoadBalancingPolicy implements Serializable {
      *         health check
      */
     protected ScheduledExecutorService getScheduler() {
-        return ClickHouseClientBuilder.defaultScheduler;
+        return ClickHouseDataStreamFactory.getInstance().getScheduler();
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
@@ -157,8 +157,9 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Sets custom writer for streaming. This will remove input stream set by other
-         * {@code data()} methods.
+         * Sets custom writer for writing uncompressed data, use
+         * {@link #data(ClickHousePassThruStream)} when the data is compressed. This
+         * will remove input stream set by other {@code data(...)} methods.
          *
          * @param writer writer
          * @return mutation request
@@ -173,7 +174,9 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Loads data from given pass-thru stream which may or may not be compressed.
+         * Loads data from the given pass-thru stream which may or may not be
+         * compressed. This will not only remove custom writer set by
+         * {@link #data(ClickHouseWriter)}, but may also update compression and format.
          *
          * @param stream pass-thru stream, could be a file and may or may not be
          *               compressed
@@ -204,22 +207,28 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Loads data from given file which may or may not be compressed.
+         * Loads data from the given file. It's same as
+         * {@code data(ClickHouseFile.of(file))} if the file name implies compression
+         * algorithm and/or format(e.g. {@code some_file.csv.gz}). It fall back to
+         * {@link #data(InputStream)} if no clue. This will remove custom writer set by
+         * {@link #data(ClickHouseWriter)}.
          *
          * @param file absolute or relative path of the file, file extension will be
          *             used to determine if it's compressed or not
          * @return mutation request
          */
         public Mutation data(String file) {
-            return data(ClickHouseFile.of(file));
+            ClickHouseFile f = ClickHouseFile.of(file);
+            return f.isRecognized() ? data(f) : data(f.getInputStream());
         }
 
         /**
-         * Loads compressed data from given file.
+         * Loads compressed data from the given file. This will remove custom writer set
+         * by {@link #data(ClickHouseWriter)}.
          *
          * @param file        absolute or relative path of the file
-         * @param compression compression algorithm, {@link ClickHouseCompression#NONE}
-         *                    means no compression
+         * @param compression compression algorithm, null or
+         *                    {@link ClickHouseCompression#NONE} means no compression
          * @return mutation request
          */
         public Mutation data(String file, ClickHouseCompression compression) {
@@ -228,13 +237,16 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Loads compressed data from given file.
+         * Loads compressed data from the given file. This will remove custom writer set
+         * by {@link #data(ClickHouseWriter)}.
          *
          * @param file             absolute or relative path of the file
-         * @param compression      compression algorithm,
-         *                         {@link ClickHouseCompression#NONE}
-         *                         means no compression
-         * @param compressionLevel compression level
+         * @param compression      compression algorithm, null or
+         *                         {@link ClickHouseCompression#NONE} means no
+         *                         compression
+         * @param compressionLevel compression level, use
+         *                         {@code com.clickhouse.data.ClickHouseDataConfig#DEFAULT_READ_COMPRESS_LEVEL}
+         *                         to use recommended level for the algorithm
          * @return mutation request
          */
         public Mutation data(String file, ClickHouseCompression compression, int compressionLevel) {
@@ -242,7 +254,8 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Loads data from input stream.
+         * Loads data from input stream. This will remove custom writer set by
+         * {@link #data(ClickHouseWriter)}.
          *
          * @param input input stream
          * @return mutation request
@@ -252,7 +265,8 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Loads data from input stream.
+         * Loads data from input stream. This will remove custom writer set by
+         * {@link #data(ClickHouseWriter)}.
          *
          * @param input input stream
          * @return mutation request
@@ -273,7 +287,8 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
         }
 
         /**
-         * Loads data from input stream.
+         * Loads data from deferred input stream. This will remove custom writer set by
+         * {@link #data(ClickHouseWriter)}.
          *
          * @param input input stream
          * @return mutation request
@@ -1804,7 +1819,7 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
     @SuppressWarnings("unchecked")
     public SelfT transaction(int timeout) throws ClickHouseException {
         ClickHouseTransaction tx = txRef.get();
-        if (tx != null && tx.getTimeout() == (timeout > 0 ? timeout : 0)) {
+        if (tx != null && tx.getTimeout() == (timeout < 0 ? 0 : timeout)) {
             return (SelfT) this;
         }
         return transaction(getManager().getOrStartTransaction(this, timeout));

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseStreamResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseStreamResponse.java
@@ -111,6 +111,7 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
             // ignore
             log.debug("Failed to skip reading input stream due to: %s", e.getMessage());
         } finally {
+            // close forcibly without skipping won't help much when network is slow/unstable
             try {
                 input.close();
             } catch (IOException e) {

--- a/clickhouse-client/src/main/java9/module-info.java
+++ b/clickhouse-client/src/main/java9/module-info.java
@@ -5,8 +5,7 @@ module com.clickhouse.client {
     exports com.clickhouse.client;
     exports com.clickhouse.client.config;
 
-    requires static java.logging;
-    requires static org.slf4j;
+    requires static org.dnsjava;
 
     requires transitive com.clickhouse.data;
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -1532,10 +1532,9 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
             throw new SkipException("Skip as only http implementation works well");
         }
 
-        File file = Files.createTempFile("chc", ".data").toFile();
+        File file = ClickHouseUtils.createTempFile("chc", ".data", false);
         ClickHouseFile wrappedFile = ClickHouseFile.of(file,
-                gzipCompressed ? ClickHouseCompression.GZIP : ClickHouseCompression.NONE, 0,
-                ClickHouseFormat.CSV);
+                gzipCompressed ? ClickHouseCompression.GZIP : ClickHouseCompression.NONE, ClickHouseFormat.CSV);
         String query = "select number, if(number % 2 = 0, null, toString(number)) str from numbers(10)";
         if (useOneLiner) {
             ClickHouseClient.dump(server, query, wrappedFile).get();
@@ -1683,7 +1682,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
         sendAndWait(server, "drop table if exists test_load_file",
                 "create table test_load_file(a Int32, b Nullable(String))engine=Memory");
         ClickHouseFile wrappedFile = ClickHouseFile.of(file,
-                gzipCompressed ? ClickHouseCompression.GZIP : ClickHouseCompression.NONE, -1, ClickHouseFormat.CSV);
+                gzipCompressed ? ClickHouseCompression.GZIP : ClickHouseCompression.NONE, ClickHouseFormat.CSV);
         if (useOneLiner) {
             try {
                 ClickHouseClient.load(server, "test_load_file", wrappedFile).get();
@@ -1735,7 +1734,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
             // single producer → single consumer
             // important to close the stream *before* retrieving response
             try (ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
-                    .createPipedOutputStream(config, null)) {
+                    .createPipedOutputStream(config)) {
                 // start the worker thread which transfer data from the input into ClickHouse
                 future = request.data(stream.getInputStream()).execute();
                 // write bytes into the piped stream

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -1528,7 +1528,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
     public void testDumpFile(boolean gzipCompressed, boolean useOneLiner)
             throws ExecutionException, InterruptedException, IOException {
         ClickHouseNode server = getServer();
-        if (server.getProtocol() != ClickHouseProtocol.GRPC && server.getProtocol() != ClickHouseProtocol.HTTP) {
+        if (server.getProtocol() != ClickHouseProtocol.HTTP) {
             throw new SkipException("Skip as only http implementation works well");
         }
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -1528,7 +1528,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
     public void testDumpFile(boolean gzipCompressed, boolean useOneLiner)
             throws ExecutionException, InterruptedException, IOException {
         ClickHouseNode server = getServer();
-        if (server.getProtocol() != ClickHouseProtocol.HTTP) {
+        if (server.getProtocol() != ClickHouseProtocol.GRPC && server.getProtocol() != ClickHouseProtocol.HTTP) {
             throw new SkipException("Skip as only http implementation works well");
         }
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
@@ -18,6 +18,11 @@ public interface ClickHouseDataConfig extends Serializable {
         }
 
         @Override
+        public boolean isAsync() {
+            return config.isAsync();
+        }
+
+        @Override
         public ClickHouseFormat getFormat() {
             return config.getFormat();
         }
@@ -136,8 +141,9 @@ public interface ClickHouseDataConfig extends Serializable {
     static final boolean DEFAULT_USE_OBJECT_IN_ARRAY = false;
     static final boolean DEFAULT_WIDEN_UNSIGNED_TYPE = false;
 
-    static final int DEFAULT_READ_COMPRESS_LEVEL = -1;
-    static final int DEFAULT_WRITE_COMPRESS_LEVEL = -1;
+    static final int DEFAULT_COMPRESS_LEVEL = -1;
+    static final int DEFAULT_READ_COMPRESS_LEVEL = DEFAULT_COMPRESS_LEVEL;
+    static final int DEFAULT_WRITE_COMPRESS_LEVEL = DEFAULT_COMPRESS_LEVEL;
 
     static final int DEFAULT_TIMEOUT = 30 * 1000; // 30 seconds
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataStreamFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataStreamFactory.java
@@ -2,8 +2,16 @@ package com.clickhouse.data;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import com.clickhouse.config.ClickHouseBufferingMode;
 import com.clickhouse.data.format.ClickHouseRowBinaryProcessor;
@@ -16,6 +24,25 @@ import com.clickhouse.data.stream.NonBlockingPipedOutputStream;
  * Factory class for creating objects to handle data stream.
  */
 public class ClickHouseDataStreamFactory {
+    protected static final class DefaultExecutors {
+        protected static final ExecutorService executor;
+        protected static final ScheduledExecutorService scheduler;
+
+        static {
+            int coreThreads = Runtime.getRuntime().availableProcessors();
+            if (coreThreads < ClickHouseUtils.MIN_CORE_THREADS) {
+                coreThreads = ClickHouseUtils.MIN_CORE_THREADS;
+            }
+
+            executor = ClickHouseUtils.newThreadPool("ClickHouseWorker-", coreThreads,
+                    coreThreads * 2 + 1, 0, 0, false);
+            scheduler = Executors.newSingleThreadScheduledExecutor(new ClickHouseThreadFactory("ClickHouseScheduler-"));
+        }
+
+        private DefaultExecutors() {
+        }
+    }
+
     private static final ClickHouseDataStreamFactory instance = ClickHouseUtils
             .getService(ClickHouseDataStreamFactory.class, new ClickHouseDataStreamFactory());
 
@@ -24,12 +51,70 @@ public class ClickHouseDataStreamFactory {
     protected static final String ERROR_UNSUPPORTED_FORMAT = "Unsupported format: ";
 
     /**
+     * Handles custom action.
+     *
+     * @param postCloseAction post close action, could be null
+     * @throws IOException when failed to execute post close action
+     */
+    public static void handleCustomAction(Runnable postCloseAction) throws IOException {
+        if (postCloseAction == null) {
+            return;
+        }
+
+        try {
+            postCloseAction.run();
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    /**
      * Gets instance of the factory class.
      *
      * @return instance of the factory class
      */
     public static ClickHouseDataStreamFactory getInstance() {
         return instance;
+    }
+
+    /**
+     * Gets default executor service for running blocking tasks.
+     *
+     * @return non-null executor service
+     */
+    public ExecutorService getExecutor() {
+        return DefaultExecutors.executor;
+    }
+
+    /**
+     * Gets default scheduled executor service for scheduled tasks.
+     *
+     * @return non-null scheduled executor service
+     */
+    public ScheduledExecutorService getScheduler() {
+        return DefaultExecutors.scheduler;
+    }
+
+    /**
+     * Executes a blocking task using
+     * {@link CompletableFuture#supplyAsync(Supplier)} and custom
+     * {@link ExecutorService}.
+     *
+     * @return non-null future to get result
+     */
+    public <T> CompletableFuture<T> runBlockingTask(Supplier<T> supplier) {
+        return CompletableFuture.supplyAsync(supplier, DefaultExecutors.executor);
+    }
+
+    /**
+     * Schedules a task using
+     * {@link ScheduledExecutorService#schedule(Runnable, long, TimeUnit)} and
+     * custom {@link ScheduledExecutorService}.
+     *
+     * @return non-null future to get result
+     */
+    public ScheduledFuture<?> scheduleTask(Runnable task, long delay, TimeUnit unit) {
+        return DefaultExecutors.scheduler.schedule(task, delay, unit);
     }
 
     /**
@@ -58,6 +143,16 @@ public class ClickHouseDataStreamFactory {
             processor = new ClickHouseTabSeparatedProcessor(config, input, output, columns, settings);
         }
         return processor;
+    }
+
+    /**
+     * Creates a piped output stream.
+     *
+     * @param config non-null configuration
+     * @return piped output stream
+     */
+    public final ClickHousePipedOutputStream createPipedOutputStream(ClickHouseDataConfig config) {
+        return createPipedOutputStream(config, (Runnable) null);
     }
 
     /**
@@ -92,9 +187,55 @@ public class ClickHouseDataStreamFactory {
                 : new NonBlockingPipedOutputStream(bufferSize, queue, timeout, policy, postCloseAction);
     }
 
+    /**
+     * Creates a piped output stream.
+     *
+     * @param config non-null configuration
+     * @param writer non-null custom writer
+     * @return piped output stream
+     */
+    public ClickHousePipedOutputStream createPipedOutputStream(ClickHouseDataConfig config, ClickHouseWriter writer) {
+        if (config == null || writer == null) {
+            throw new IllegalArgumentException("Non-null config and writer are required");
+        }
+
+        final int bufferSize = config.getWriteBufferSize();
+        final boolean blocking;
+        final int queue;
+        final CapacityPolicy policy;
+        final int timeout;
+
+        if (config.getReadBufferingMode() == ClickHouseBufferingMode.PERFORMANCE) {
+            blocking = false;
+            queue = 0;
+            policy = null;
+            timeout = 0; // questionable
+        } else {
+            blocking = config.isUseBlockingQueue();
+            queue = config.getMaxQueuedBuffers();
+            policy = config.getBufferQueueVariation() < 1 ? CapacityPolicy.fixedCapacity(queue)
+                    : CapacityPolicy.linearDynamicCapacity(1, queue, config.getBufferQueueVariation());
+            timeout = config.getReadTimeout();
+        }
+
+        return blocking
+                ? new BlockingPipedOutputStream(bufferSize, queue, timeout, writer)
+                : new NonBlockingPipedOutputStream(bufferSize, queue, timeout, policy, writer);
+    }
+
+    public final ClickHousePipedOutputStream createPipedOutputStream(int bufferSize, int queueSize, int timeout) {
+        return createPipedOutputStream(bufferSize, queueSize, timeout, (Runnable) null);
+    }
+
     public ClickHousePipedOutputStream createPipedOutputStream(int bufferSize, int queueSize, int timeout,
             Runnable postCloseAction) {
         return new BlockingPipedOutputStream(ClickHouseDataConfig.getBufferSize(bufferSize), queueSize, timeout,
                 postCloseAction);
+    }
+
+    public ClickHousePipedOutputStream createPipedOutputStream(int bufferSize, int queueSize, int timeout,
+            ClickHouseWriter writer) {
+        return new BlockingPipedOutputStream(ClickHouseDataConfig.getBufferSize(bufferSize), queueSize, timeout,
+                writer);
     }
 }

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataStreamFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataStreamFactory.java
@@ -29,13 +29,12 @@ public class ClickHouseDataStreamFactory {
         protected static final ScheduledExecutorService scheduler;
 
         static {
-            int coreThreads = Runtime.getRuntime().availableProcessors();
+            int coreThreads = 2 * Runtime.getRuntime().availableProcessors() + 1;
             if (coreThreads < ClickHouseUtils.MIN_CORE_THREADS) {
                 coreThreads = ClickHouseUtils.MIN_CORE_THREADS;
             }
 
-            executor = ClickHouseUtils.newThreadPool("ClickHouseWorker-", coreThreads,
-                    coreThreads * 2 + 1, 0, 0, false);
+            executor = ClickHouseUtils.newThreadPool("ClickHouseWorker-", coreThreads, coreThreads, 0, 0, false);
             scheduler = Executors.newSingleThreadScheduledExecutor(new ClickHouseThreadFactory("ClickHouseScheduler-"));
         }
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDeferredValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDeferredValue.java
@@ -24,7 +24,7 @@ public final class ClickHouseDeferredValue<T> implements Supplier<T> {
      * @return deferred value of a future object
      */
     public static <T> ClickHouseDeferredValue<T> of(CompletableFuture<T> future) {
-        return of(future, 0);
+        return of(future, 0L);
     }
 
     /**
@@ -36,13 +36,14 @@ public final class ClickHouseDeferredValue<T> implements Supplier<T> {
      *                timeout
      * @return deferred vaue of a future object
      */
-    public static <T> ClickHouseDeferredValue<T> of(CompletableFuture<T> future, int timeout) {
-        final CompletableFuture<T> f = future != null ? future : CompletableFuture.completedFuture(null);
-        final int t = timeout < 0 ? 0 : timeout;
+    @SuppressWarnings("unchecked")
+    public static <T> ClickHouseDeferredValue<T> of(CompletableFuture<T> future, long timeout) {
+        final CompletableFuture<T> f = future != null ? future : (CompletableFuture<T>) ClickHouseUtils.NULL_FUTURE;
+        final long t = timeout < 0L ? 0L : timeout;
 
         Supplier<T> supplier = () -> {
             try {
-                return f.get(t, TimeUnit.MILLISECONDS);
+                return t > 0L ? f.get(t, TimeUnit.MILLISECONDS) : f.get();
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 f.cancel(false);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseExternalTable.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseExternalTable.java
@@ -68,9 +68,8 @@ public class ClickHouseExternalTable implements Serializable {
         }
 
         public Builder content(ClickHouseInputStream input) {
-            ClickHousePassThruStream stream = ClickHouseChecker.nonNull(input, ClickHouseInputStream.TYPE_NAME)
-                    .getUnderlyingStream();
-            if (stream.hasInput()) {
+            if (ClickHouseChecker.nonNull(input, ClickHouseInputStream.TYPE_NAME).hasUnderlyingStream()) {
+                ClickHousePassThruStream stream = input.getUnderlyingStream();
                 this.compression = ClickHouseCompression.NONE;
                 this.compressionLevel = ClickHouseDataConfig.DEFAULT_WRITE_COMPRESS_LEVEL;
                 this.content = ClickHouseDeferredValue.of(stream.getInputStream(), InputStream.class);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFile.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFile.java
@@ -25,22 +25,30 @@ public class ClickHouseFile extends ClickHousePassThruStream {
             ClickHouseDataConfig.DEFAULT_READ_COMPRESS_LEVEL, null);
 
     public static ClickHouseFile of(File file) {
-        return of(file, null, 0, null);
+        return of(file, null, ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL, null);
     }
 
     public static ClickHouseFile of(Path path) {
         return of(ClickHouseChecker.nonNull(path, "Path").toFile(), null,
-                ClickHouseDataConfig.DEFAULT_READ_COMPRESS_LEVEL, null);
+                ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL, null);
     }
 
     public static ClickHouseFile of(String file) {
         return of(new File(ClickHouseChecker.nonEmpty(file, FILE_TYPE_NAME)), null,
-                ClickHouseDataConfig.DEFAULT_READ_COMPRESS_LEVEL, null);
+                ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL, null);
+    }
+
+    public static ClickHouseFile of(String file, ClickHouseCompression compression, ClickHouseFormat format) {
+        return of(file, compression, ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL, format);
     }
 
     public static ClickHouseFile of(String file, ClickHouseCompression compression, int compressionLevel,
             ClickHouseFormat format) {
         return of(new File(ClickHouseChecker.nonEmpty(file, FILE_TYPE_NAME)), compression, compressionLevel, format);
+    }
+
+    public static ClickHouseFile of(File file, ClickHouseCompression compression, ClickHouseFormat format) {
+        return of(file, compression, ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL, format);
     }
 
     public static ClickHouseFile of(File file, ClickHouseCompression compression, int compressionLevel,
@@ -166,6 +174,16 @@ public class ClickHouseFile extends ClickHousePassThruStream {
      */
     public File getFile() {
         return file;
+    }
+
+    /**
+     * Checks if the given file is recogonized or not. Same as
+     * {@code hasCompression() || hasFormat()}.
+     *
+     * @return true if the file is recogonized
+     */
+    public boolean isRecognized() {
+        return hasCompression() || hasFormat();
     }
 
     @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseOutputStream.java
@@ -173,6 +173,16 @@ public abstract class ClickHouseOutputStream extends OutputStream {
     }
 
     /**
+     * Checks if there's underlying output stream. Same as
+     * {@code getUnderlyingStream().hasOutput()}.
+     *
+     * @return true if there's underlying output stream; false otherwise
+     */
+    public boolean hasUnderlyingStream() {
+        return stream.hasOutput();
+    }
+
+    /**
      * Transfers bytes into output stream without creating a copy.
      *
      * @param bytes non-null byte array
@@ -255,9 +265,7 @@ public abstract class ClickHouseOutputStream extends OutputStream {
             flush();
         } finally {
             closed = true;
-            if (postCloseAction != null) {
-                postCloseAction.run();
-            }
+            ClickHouseDataStreamFactory.handleCustomAction(postCloseAction);
         }
     }
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHousePipedOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHousePipedOutputStream.java
@@ -1,9 +1,72 @@
 package com.clickhouse.data;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 /**
  * SPSC(Single-producer single-consumer) channel for streaming.
  */
 public abstract class ClickHousePipedOutputStream extends ClickHouseOutputStream {
+    /**
+     * Handles async write result.
+     * 
+     * @param future          async write result
+     * @param timeout         timeout in milliseconds
+     * @param postCloseAction post close aciton, could be null
+     * @throws UncheckedIOException when writing failed
+     */
+    protected static void handleWriteResult(CompletableFuture<?> future, long timeout, Runnable postCloseAction)
+            throws UncheckedIOException {
+        try {
+            if (future != null) {
+                future.get(timeout, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new UncheckedIOException(new IOException("Writing was interrupted", e));
+        } catch (TimeoutException e) {
+            throw new UncheckedIOException(
+                    new IOException(ClickHouseUtils.format("Writing timed out after %d milliseconds", timeout), e));
+        } catch (ExecutionException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof IOException) {
+                throw new UncheckedIOException((IOException) cause);
+            } else if (cause instanceof UncheckedIOException) {
+                throw (UncheckedIOException) cause;
+            } else {
+                throw new UncheckedIOException(new IOException("Writing failed", cause));
+            }
+        } finally {
+            if (postCloseAction != null) {
+                postCloseAction.run();
+            }
+        }
+    }
+
+    /**
+     * Writes data to the piped output stream in a separate thread. The given piped
+     * output stream will be closed automatically at the end of writing.
+     *
+     * @param writer non-null custom writer
+     * @param output non-null piped output stream
+     * @return non-null future
+     */
+    protected static CompletableFuture<Void> writeAsync(ClickHouseWriter writer, ClickHousePipedOutputStream output) {
+        return ClickHouseDataStreamFactory.getInstance().runBlockingTask(() -> {
+            try (ClickHouseOutputStream out = output) {
+                writer.write(out);
+            } catch (Exception e) {
+                throw new CompletionException(e);
+            }
+            return null;
+        });
+    }
+
     protected ClickHousePipedOutputStream(Runnable postCloseAction) {
         super(null, postCloseAction);
     }

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
@@ -69,7 +69,9 @@ public final class ClickHouseUtils {
     public static final String DEFAULT_CHARSET = StandardCharsets.UTF_8.name();
 
     public static final int MIN_CORE_THREADS = 3;
+
     public static final CompletableFuture<Void> NULL_FUTURE = CompletableFuture.completedFuture(null);
+    public static final Supplier<?> NULL_SUPPLIER = () -> null;
 
     public static final String VARIABLE_PREFIX = "{{";
     public static final String VARIABLE_SUFFIX = "}}";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseWriter.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseWriter.java
@@ -4,8 +4,10 @@ import java.io.IOException;
 
 @FunctionalInterface
 public interface ClickHouseWriter {
+    static final String TYPE_NAME = "Writer";
+
     /**
-     * Writes value to output stream.
+     * Writes data to output stream.
      *
      * @param output non-null output stream
      * @throws IOException when failed to write data to output stream

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/BlockingInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/BlockingInputStream.java
@@ -8,31 +8,27 @@ import java.util.concurrent.TimeUnit;
 
 import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseUtils;
-import com.clickhouse.logging.Logger;
-import com.clickhouse.logging.LoggerFactory;
 
 /**
  * {@link java.nio.ByteBuffer} backed input stream with
  * {@link java.util.concurrent.BlockingQueue}.
  */
 public class BlockingInputStream extends AbstractByteBufferInputStream {
-    private static final Logger log = LoggerFactory.getLogger(BlockingInputStream.class);
-
     private final BlockingQueue<ByteBuffer> queue;
-    private final int timeout;
+    private final long timeout;
 
-    public BlockingInputStream(BlockingQueue<ByteBuffer> queue, int timeout, Runnable postCloseAction) {
+    public BlockingInputStream(BlockingQueue<ByteBuffer> queue, long timeout, Runnable postCloseAction) {
         super(null, null, postCloseAction);
 
         this.queue = ClickHouseChecker.nonNull(queue, "Queue");
-        this.timeout = timeout > 0 ? timeout : 0;
+        this.timeout = timeout < 0L ? 0L : timeout;
     }
 
     @Override
     protected int updateBuffer() throws IOException {
         ByteBuffer b;
         try {
-            if (timeout > 0) {
+            if (timeout > 0L) {
                 b = queue.poll(timeout, TimeUnit.MILLISECONDS);
                 if (b == null) {
                     throw new IOException(ClickHouseUtils.format("Read timed out after %d ms", timeout));

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingInputStream.java
@@ -13,16 +13,16 @@ import com.clickhouse.data.ClickHouseUtils;
 
 public class NonBlockingInputStream extends ClickHouseInputStream {
     private final AdaptiveQueue<byte[]> queue;
-    private final int timeout;
+    private final long timeout;
 
     private byte[] buffer;
     private int position;
 
-    public NonBlockingInputStream(AdaptiveQueue<byte[]> queue, int timeout, Runnable postCloseAction) {
+    public NonBlockingInputStream(AdaptiveQueue<byte[]> queue, long timeout, Runnable postCloseAction) {
         super(null, null, postCloseAction);
 
         this.queue = ClickHouseChecker.nonNull(queue, "Queue");
-        this.timeout = timeout > 0 ? timeout : 0;
+        this.timeout = timeout < 0L ? 0L : timeout;
 
         this.buffer = null;
         this.position = 0;

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseDeferredValueTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseDeferredValueTest.java
@@ -1,0 +1,58 @@
+package com.clickhouse.data;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ClickHouseDeferredValueTest {
+    @Test(groups = { "unit" })
+    public void testDeferredValues() throws Exception {
+        final List<Integer> list = new ArrayList<>(2);
+        ClickHouseDeferredValue<?> v = ClickHouseDeferredValue.of(list, List.class);
+        Assert.assertEquals(v.get(), list);
+        list.add(3);
+        Assert.assertEquals(v.get(), list);
+
+        v = ClickHouseDeferredValue.of(() -> {
+            list.add(5);
+            return list;
+        });
+        Assert.assertEquals(list, Arrays.asList(3));
+        Assert.assertEquals(v.get(), list);
+        Assert.assertEquals(list, Arrays.asList(3, 5));
+
+        CountDownLatch latch = new CountDownLatch(1);
+        v = ClickHouseDeferredValue.of(CompletableFuture.supplyAsync(() -> {
+            try {
+                latch.await(3000L, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            list.remove(0);
+            return list;
+        }), 500L);
+        Assert.assertEquals(list, Arrays.asList(3, 5));
+        latch.countDown();
+        Thread.sleep(1000L);
+        Assert.assertEquals(v.get(), list);
+        Assert.assertEquals(list, Arrays.asList(5));
+    }
+
+    @Test(groups = { "unit" })
+    public void testNullValues() {
+        Assert.assertNull(ClickHouseDeferredValue.of((CompletableFuture<?>) null).get());
+        Assert.assertNull(ClickHouseDeferredValue.of((CompletableFuture<?>) null, 50L).get());
+
+        Assert.assertNull(ClickHouseDeferredValue.of((Supplier<?>) null).get());
+
+        Assert.assertNull(ClickHouseDeferredValue.of(null, Object.class).get());
+        Assert.assertNull(ClickHouseDeferredValue.of(null, null).get());
+    }
+}

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseFileTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseFileTest.java
@@ -18,7 +18,7 @@ public class ClickHouseFileTest {
         Assert.assertTrue(file.hasOutput());
         Assert.assertTrue(file.hasCompression());
         Assert.assertEquals(file.getCompressionAlgorithm(), ClickHouseCompression.LZ4);
-        Assert.assertEquals(file.getCompressionLevel(), -1);
+        Assert.assertEquals(file.getCompressionLevel(), ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL);
         Assert.assertTrue(file.hasFormat());
         Assert.assertEquals(file.getFormat(), ClickHouseFormat.CSV);
         Assert.assertEquals(file.getFile().getAbsolutePath(), nonExistingFile);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseInputStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseInputStreamTest.java
@@ -5,7 +5,9 @@ import java.io.ByteArrayInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ArrayBlockingQueue;
@@ -181,6 +183,16 @@ public class ClickHouseInputStreamTest {
         in.close();
         Assert.assertTrue(in.available() == 0, "Should have all bytes read");
         Assert.assertTrue(in.isClosed(), "Should have been closed");
+    }
+
+    @Test(groups = { "unit" })
+    public void testPostCloseAction() throws IOException {
+        try (ClickHouseInputStream in = ClickHouseInputStream
+                .of(generateInputStream("abc".getBytes(StandardCharsets.US_ASCII)), 0, () -> {
+                    throw new UncheckedIOException(new IOException("fake exception"));
+                })) {
+            Assert.assertThrows(IOException.class, () -> in.close());
+        }
     }
 
     @Test(groups = { "unit" })

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseOutputStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseOutputStreamTest.java
@@ -4,6 +4,7 @@ import java.io.BufferedOutputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 
 import org.testng.Assert;
@@ -61,5 +62,16 @@ public class ClickHouseOutputStreamTest {
         empty.close();
         Assert.assertEquals(empty.isClosed(), true);
         Assert.assertThrows(IOException.class, () -> empty.write(1));
+    }
+
+    @Test(groups = { "unit" })
+    public void testPostCloseAction() throws IOException {
+        try (ClickHouseOutputStream out = ClickHouseOutputStream.of(new ByteArrayOutputStream(), 0,
+                ClickHouseCompression.NONE,
+                ClickHouseTestDataConfig.DEFAULT_COMPRESS_LEVEL, () -> {
+                    throw new UncheckedIOException(new IOException("fake exception"));
+                })) {
+            Assert.assertThrows(IOException.class, () -> out.close());
+        }
     }
 }

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHousePassThruStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHousePassThruStreamTest.java
@@ -14,8 +14,7 @@ public class ClickHousePassThruStreamTest {
         final InputStream in = new ByteArrayInputStream(new byte[0]);
         final OutputStream out = new ByteArrayOutputStream();
 
-        ClickHousePassThruStream stream = ClickHousePassThruStream.of(in, null, -1,
-                null);
+        ClickHousePassThruStream stream = ClickHousePassThruStream.of(in, null, null);
         Assert.assertNotEquals(stream.getInputStream(), ClickHouseInputStream.empty());
         Assert.assertEquals(stream.getOutputStream(), ClickHouseOutputStream.empty());
         Assert.assertFalse(stream.hasCompression());
@@ -24,7 +23,7 @@ public class ClickHousePassThruStreamTest {
         Assert.assertFalse(stream.isCompressed());
         Assert.assertFalse(stream.hasFormat());
         Assert.assertNull(stream.getCompressionAlgorithm());
-        Assert.assertEquals(stream.getCompressionLevel(), -1);
+        Assert.assertEquals(stream.getCompressionLevel(), ClickHouseDataConfig.DEFAULT_COMPRESS_LEVEL);
         Assert.assertNull(stream.getFormat());
 
         stream = ClickHousePassThruStream.of(out, null, -1, null);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
@@ -20,8 +20,8 @@ public class ClickHouseUtilsTest {
         File f = ClickHouseUtils.createTempFile(null, null);
         Assert.assertNotNull(f);
         Assert.assertTrue(f.exists(), f.getAbsolutePath() + " should exist");
-        Assert.assertTrue(f.getName().endsWith(".tmp"),
-                "By default temporary file should end with .tmp, but it's " + f.getName());
+        Assert.assertTrue(f.getName().endsWith(".data"),
+                "By default temporary file should end with .data, but it's " + f.getName());
 
         f = ClickHouseUtils.createTempFile("prefix__", "__suffix", true);
         Assert.assertNotNull(f);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/stream/BlockingPipedOutputStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/stream/BlockingPipedOutputStreamTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 public class BlockingPipedOutputStreamTest {
     @Test(groups = { "unit" })
     public void testRead() throws InterruptedException, IOException {
-        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(4, 3, 1, null);
+        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(4, 3, 1);
         Assert.assertEquals(stream.queue.size(), 0);
         try (InputStream in = stream.getInputStream()) {
             in.read();
@@ -81,7 +81,7 @@ public class BlockingPipedOutputStreamTest {
 
     @Test(groups = { "unit" })
     public void testReadBytes() throws InterruptedException, IOException {
-        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(4, 3, 1, null);
+        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(4, 3, 1);
         Assert.assertEquals(stream.queue.size(), 0);
         byte[] bytes = new byte[3];
         try (InputStream in = stream.getInputStream()) {
@@ -145,7 +145,7 @@ public class BlockingPipedOutputStreamTest {
 
     @Test(groups = { "unit" })
     public void testWrite() throws InterruptedException, IOException {
-        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(2, 3, 2, null);
+        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(2, 3, 2);
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
             out.write(5);
@@ -160,7 +160,7 @@ public class BlockingPipedOutputStreamTest {
             Assert.assertEquals(stream.queue.take().array(), new byte[] { (byte) 7, (byte) 0 });
         }
 
-        stream = new BlockingPipedOutputStream(1, 1, 2, null);
+        stream = new BlockingPipedOutputStream(1, 1, 2);
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
             out.write(5);
@@ -185,7 +185,7 @@ public class BlockingPipedOutputStreamTest {
 
     @Test(groups = { "unit" })
     public void testWriteBytes() throws InterruptedException, IOException {
-        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(2, 3, 2, null);
+        BlockingPipedOutputStream stream = new BlockingPipedOutputStream(2, 3, 2);
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
             out.write(new byte[] { (byte) 9, (byte) 10 });
@@ -215,8 +215,7 @@ public class BlockingPipedOutputStreamTest {
         ExecutorService executor = Executors.newFixedThreadPool(2);
         for (int bufferSize = -1; bufferSize < 10; bufferSize++) {
             for (int queueLength = -1; queueLength < 10; queueLength++) {
-                BlockingPipedOutputStream stream = new BlockingPipedOutputStream(bufferSize, queueLength, timeout,
-                        null);
+                BlockingPipedOutputStream stream = new BlockingPipedOutputStream(bufferSize, queueLength, timeout);
                 try (InputStream in = stream.getInputStream(); OutputStream out = stream) {
                     final int count = 10000;
                     final AtomicInteger p = new AtomicInteger(0);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/stream/DelegatedInputStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/stream/DelegatedInputStreamTest.java
@@ -30,7 +30,7 @@ public class DelegatedInputStreamTest {
 
     @Test(groups = { "unit" })
     public void testReadBytes() throws IOException {
-        try (DelegatedInputStream in = new DelegatedInputStream(null, w -> {
+        try (DelegatedInputStream in = new DelegatedInputStream(w -> {
             for (int i = 0; i < Byte.MAX_VALUE; i++) {
                 w.writeBytes(new byte[] { 1, 2, 3, 4, 5, 6 });
             }

--- a/clickhouse-data/src/test/java/com/clickhouse/data/stream/NonBlockingPipedOutputStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/stream/NonBlockingPipedOutputStreamTest.java
@@ -19,8 +19,8 @@ import org.testng.annotations.Test;
 public class NonBlockingPipedOutputStreamTest {
     @Test(groups = { "unit" })
     public void testRead() throws IOException {
-        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 3, 1, CapacityPolicy.fixedCapacity(3),
-                null);
+        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 3, 1,
+                CapacityPolicy.fixedCapacity(3));
         Assert.assertEquals(stream.queue.size(), 0);
         try (InputStream in = stream.getInputStream()) {
             in.read();
@@ -78,8 +78,8 @@ public class NonBlockingPipedOutputStreamTest {
 
     @Test(groups = { "unit" })
     public void testReadBytes() throws IOException {
-        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 3, 1, CapacityPolicy.fixedCapacity(3),
-                null);
+        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 3, 1,
+                CapacityPolicy.fixedCapacity(3));
         Assert.assertEquals(stream.queue.size(), 0);
         byte[] bytes = new byte[3];
         try (InputStream in = stream.getInputStream()) {
@@ -141,8 +141,8 @@ public class NonBlockingPipedOutputStreamTest {
 
     @Test(groups = { "unit" })
     public void testWrite() throws IOException {
-        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(2, 3, 2, CapacityPolicy.fixedCapacity(3),
-                null);
+        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(2, 3, 2,
+                CapacityPolicy.fixedCapacity(3));
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
             out.write(5);
@@ -157,7 +157,7 @@ public class NonBlockingPipedOutputStreamTest {
             Assert.assertEquals(stream.queue.poll(), new byte[] { (byte) 7 });
         }
 
-        stream = new NonBlockingPipedOutputStream(1, 1, 2, CapacityPolicy.fixedCapacity(1), null);
+        stream = new NonBlockingPipedOutputStream(1, 1, 2, CapacityPolicy.fixedCapacity(1));
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
             out.write(5);
@@ -182,8 +182,8 @@ public class NonBlockingPipedOutputStreamTest {
 
     @Test(groups = { "unit" })
     public void testWriteBytes() throws IOException {
-        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(2, 3, 2, CapacityPolicy.fixedCapacity(3),
-                null);
+        NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(2, 3, 2,
+                CapacityPolicy.fixedCapacity(3));
         Assert.assertEquals(stream.queue.size(), 0);
         try (OutputStream out = stream) {
             out.write(new byte[] { (byte) 9, (byte) 10 });
@@ -214,7 +214,7 @@ public class NonBlockingPipedOutputStreamTest {
         for (int bufferSize = -1; bufferSize < 10; bufferSize++) {
             for (int queueLength = -1; queueLength < 10; queueLength++) {
                 final NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(bufferSize, queueLength,
-                        timeout, CapacityPolicy.fixedCapacity(queueLength), null);
+                        timeout, CapacityPolicy.fixedCapacity(queueLength));
                 try (InputStream in = stream.getInputStream(); OutputStream out = stream) {
                     final int count = 10000;
                     final AtomicInteger p = new AtomicInteger(0);

--- a/clickhouse-grpc-client/pom.xml
+++ b/clickhouse-grpc-client/pom.xml
@@ -209,12 +209,6 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
                                     <artifact>org.tukaani:xz</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
@@ -303,12 +297,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>org.apache.commons:commons-compress</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>
@@ -404,12 +392,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>org.apache.commons:commons-compress</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
@@ -120,7 +120,7 @@ public class ClickHouseGrpcClient extends AbstractClient<ManagedChannel> {
 
         final int bufferSize = config.getWriteBufferSize();
         final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance() // NOSONAR
-                .createPipedOutputStream(bufferSize, 0, config.getSocketTimeout(), null);
+                .createPipedOutputStream(bufferSize, 0, config.getSocketTimeout());
         final ClickHouseInputStream compressedInput = stream.getInputStream();
 
         ClickHouseClient.submit(() -> {

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseStreamObserver.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseStreamObserver.java
@@ -63,7 +63,7 @@ public class ClickHouseStreamObserver implements StreamObserver<Result> {
                     ClickHouseDataConfig.DEFAULT_READ_COMPRESS_LEVEL, postCloseAction);
         } else {
             ClickHousePipedOutputStream pipedStream = ClickHouseDataStreamFactory.getInstance()
-                    .createPipedOutputStream(config, null);
+                    .createPipedOutputStream(config);
             this.stream = pipedStream;
             this.input = ClickHouseGrpcClient.getInput(config, pipedStream.getInputStream(), postCloseAction);
         }

--- a/clickhouse-http-client/pom.xml
+++ b/clickhouse-http-client/pom.xml
@@ -41,6 +41,12 @@
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
             <optional>true</optional>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.brotli</groupId>
@@ -151,12 +157,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>org.brotli:dec</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -209,9 +209,8 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
             String sql, ClickHouseInputStream data, List<ClickHouseExternalTable> tables, ClickHouseOutputStream output,
             Runnable postAction) throws IOException {
         try {
-            ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance().createPipedOutputStream(
-                    config,
-                    null);
+            ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
+                    .createPipedOutputStream(config);
             reqBuilder.POST(HttpRequest.BodyPublishers.ofInputStream(stream::getInputStream));
             // running in async is necessary to avoid deadlock of the piped stream
             CompletableFuture<HttpResponse<InputStream>> f = postRequest(reqBuilder.build());

--- a/clickhouse-http-client/src/main/java11/module-info.java
+++ b/clickhouse-http-client/src/main/java11/module-info.java
@@ -6,7 +6,5 @@ module com.clickhouse.client.http {
 
     requires java.net.http;
 
-    requires static com.google.gson;
-
     requires transitive com.clickhouse.client;
 }

--- a/clickhouse-http-client/src/main/java9/module-info.java
+++ b/clickhouse-http-client/src/main/java9/module-info.java
@@ -4,7 +4,5 @@ module com.clickhouse.client.http {
 
     provides com.clickhouse.client.ClickHouseClient with com.clickhouse.client.http.ClickHouseHttpClient;
 
-    requires static com.google.gson;
-
     requires transitive com.clickhouse.client;
 }

--- a/clickhouse-jdbc/pom.xml
+++ b/clickhouse-jdbc/pom.xml
@@ -54,6 +54,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.lz4</groupId>
@@ -218,12 +224,6 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>mozilla/**</exclude>
@@ -297,12 +297,6 @@
                                 </transformer>
                             </transformers>
                             <filters>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
                                 <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
@@ -387,12 +381,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>${project.parent.groupId}:clickhouse-http-client</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>
@@ -484,12 +472,6 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>google/**</exclude>
@@ -572,12 +554,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>com.google.code.gson:gson</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
@@ -80,7 +80,7 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
         counter = 0;
         // it's important to make sure the queue has unlimited length
         stream = ClickHouseDataStreamFactory.getInstance().createPipedOutputStream(config.getWriteBufferSize(), 0,
-                config.getSocketTimeout(), null);
+                config.getSocketTimeout());
     }
 
     protected void ensureParams() throws SQLException {
@@ -367,7 +367,7 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
 
         ClickHouseConfig config = getConfig();
         stream = ClickHouseDataStreamFactory.getInstance().createPipedOutputStream(config.getWriteBufferSize(), 0,
-                config.getSocketTimeout(), null);
+                config.getSocketTimeout());
         resetDataProcessor();
     }
 
@@ -447,7 +447,8 @@ public class InputBasedPreparedStatement extends AbstractPreparedStatement imple
             } else {
                 Calendar c = (Calendar) cal.clone();
                 c.setTime(x);
-                dt = c.toInstant().atZone(tz).withNano(x.getNanos()).withZoneSameInstant(timeZoneForTs).toLocalDateTime();
+                dt = c.toInstant().atZone(tz).withNano(x.getNanos()).withZoneSameInstant(timeZoneForTs)
+                        .toLocalDateTime();
             }
             values[idx].update(dt);
         } else {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/StreamBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/StreamBasedPreparedStatement.java
@@ -239,7 +239,7 @@ public class StreamBasedPreparedStatement extends AbstractPreparedStatement impl
         if (x instanceof ClickHouseWriter) {
             final ClickHouseWriter writer = (ClickHouseWriter) x;
             final ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance() // NOSONAR
-                    .createPipedOutputStream(getConfig(), null);
+                    .createPipedOutputStream(getConfig());
             value = stream.getInputStream();
 
             // always run in async mode or it will not work

--- a/clickhouse-jdbc/src/main/java9/module-info.java
+++ b/clickhouse-jdbc/src/main/java9/module-info.java
@@ -3,18 +3,12 @@
  */
 module com.clickhouse.jdbc {
     exports com.clickhouse.jdbc;
-    
+
     requires java.sql;
 
     requires transitive com.clickhouse.client;
-    requires transitive com.google.gson;
-    requires transitive org.lz4.java;
-
-    requires static java.logging;
-    // requires static com.github.benmanes.caffeine;
-    // requires static org.dnsjava;
-    // requires static org.slf4j;
-    requires static org.roaringbitmap;
+    // requires transitive com.google.gson;
+    // requires transitive org.lz4.java;
 
     uses com.clickhouse.client.ClickHouseClient;
     uses com.clickhouse.client.ClickHouseDnsResolver;

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -1069,7 +1069,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ClickHouseConfig config = stmt.getConfig();
             CompletableFuture<Integer> future;
             try (ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
-                    .createPipedOutputStream(config, null)) {
+                    .createPipedOutputStream(config)) {
                 ps.setObject(1, ClickHouseExternalTable.builder().name("raw_data")
                         .columns("s String").format(ClickHouseFormat.RowBinary)
                         .content(stream.getInputStream())

--- a/clickhouse-r2dbc/pom.xml
+++ b/clickhouse-r2dbc/pom.xml
@@ -287,12 +287,6 @@
                                     </excludes>
                                 </filter>
                                 <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>google/**</exclude>
@@ -388,12 +382,6 @@
                                 </filter>
                                 <filter>
                                     <artifact>org.reactivestreams:reactive-streams</artifact>
-                                    <excludes>
-                                        <exclude>**</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.slf4j:slf4j-api</artifact>
                                     <excludes>
                                         <exclude>**</exclude>
                                     </excludes>

--- a/clickhouse-r2dbc/src/main/java9/module-info.java
+++ b/clickhouse-r2dbc/src/main/java9/module-info.java
@@ -9,12 +9,6 @@ module com.clickhouse.r2dbc {
     requires transitive reactor.core;
     requires transitive org.lz4.java;
 
-    requires static java.logging;
-    // requires static com.github.benmanes.caffeine;
-    // requires static org.dnsjava;
-    // requires static org.slf4j;
-    requires static org.roaringbitmap;
-
     uses com.clickhouse.client.ClickHouseClient;
     uses com.clickhouse.client.ClickHouseDnsResolver;
     uses com.clickhouse.client.ClickHouseSslContextProvider;


### PR DESCRIPTION
* verify `testDumpFile` CI failure in gRPC client (2/3 tests failed)
* move thread pool to `ClickHouseDataStreamFactory` along for convenient methods for running blocking task and scheduling a task
* capture UncheckedIOException from postCloseAction and throw IOException in *Stream.close() method
* ClickHouseClient.dump & ClickHouseClient.load now support ClickHousePassThruStream